### PR TITLE
Avoid InvalidResultException on multiple AuthorizationResponses

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/dao/payment/PluginPaymentDao.java
+++ b/src/main/java/org/killbill/billing/plugin/dao/payment/PluginPaymentDao.java
@@ -152,6 +152,7 @@ public abstract class PluginPaymentDao<RESP_R extends UpdatableRecord<RESP_R>, R
                                          .and(DSL.field(responsesTable.getName() + "." + TRANSACTION_TYPE).equal(TransactionType.AUTHORIZE.toString()))
                                          .and(DSL.field(responsesTable.getName() + "." + KB_TENANT_ID).equal(kbTenantId.toString()))
                                          .orderBy(DSL.field(responsesTable.getName() + "." + RECORD_ID).desc())
+                                         .limit(1)
                                          .fetchOne();
                            }
                        });


### PR DESCRIPTION
- In some cases a purchase has more than one AuthorizationResponses
- In those cases `.fetchOne()` throws an `InvalidResultException` for `Cursor returned more than one result`
- With a `.limit(1)` the `InvalidResultException` is avoided