### PR TITLE
notification: make PluginTenantConfigurableConfigurationHandler#getConfigurable thread-safe

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/api/notification/PluginTenantConfigurableConfigurationHandler.java
+++ b/src/main/java/org/killbill/billing/plugin/api/notification/PluginTenantConfigurableConfigurationHandler.java
@@ -60,8 +60,13 @@ public abstract class PluginTenantConfigurableConfigurationHandler<C> extends Pl
     public C getConfigurable(@Nullable final UUID kbTenantId) {
         // Initial configuration
         if (kbTenantId != null && !configuredTenants.contains(kbTenantId)) {
-            configure(kbTenantId);
-            configuredTenants.add(kbTenantId);
+            // Make sure to initialize the value for the tenant once
+            synchronized (configuredTenants) {
+                if (!configuredTenants.contains(kbTenantId)) {
+                    configure(kbTenantId);
+                    configuredTenants.add(kbTenantId);
+                }
+            }
         }
         return pluginTenantConfigurable.get(kbTenantId);
     }


### PR DESCRIPTION
Under high load upon startup, getConfigurable was initializing the configuration for a tenant multiple times. While the underlying map perTenantConfigurable is thread-safe, createConfigurable was called by concurrent threads unnecessarily and the value re-initialized.

This could cause unexpected behaviors because when the old value is replaced, close() is called on the configuration object while some threads might already been using it (note that this could still happen when updating a configuration live, but this should be infrequent).

/cc @andrenpaes 