### PR TITLE
Multi regions support

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -20,7 +20,7 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="killbill-base-plugin" target="1.6" />
+      <module name="killbill-base-plugin" target="1.8" />
     </bytecodeTargetLevel>
   </component>
   <component name="JavacSettings">

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+1.2.0
+    jdk1.8+ only
+    Support for servlets backed by jooby
+    Support for plugin healthchecks
+    Support for multi-regions configuration
+
 1.1.2
     Update to killbill-oss-parent 0.140.24
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Kill Bill compatibility
 | Framework version | Kill Bill version |
 | ----------------: | ----------------: |
 | 0.3.y             | 0.16.z            |
-| 1.1.y             | 0.18.z            |
-| 1.2.y             | 0.19.z            |
+| 1.x.y             | 0.18.z            |
+| 2.x.y             | 0.19.z            |
 
 Usage
 -----

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.140.36</version>
+        <version>0.140.37</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>killbill-base-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>killbill-oss-parent</artifactId>
         <groupId>org.kill-bill.billing</groupId>
-        <version>0.140.24</version>
+        <version>0.140.36</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>killbill-base-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>killbill-base-plugin</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Kill Bill base OSGI plugin</name>
     <description>Kill Bill base OSGI plugin</description>
@@ -38,18 +38,31 @@
         <system>Github</system>
         <url>https://github.com/killbill/killbill-plugin-framework-java/issues</url>
     </issueManagement>
+    <properties>
+        <!-- More recent versions than the core (JDK1.8+) -->
+        <guava.version>21.0</guava.version>
+        <jackson.version>2.8.3</jackson.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -59,6 +72,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -81,6 +95,18 @@
         <dependency>
             <groupId>org.joda</groupId>
             <artifactId>joda-money</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jooby</groupId>
+            <artifactId>jooby</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jooby</groupId>
+            <artifactId>jooby-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jooby</groupId>
+            <artifactId>jooby-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
@@ -167,4 +193,45 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>jdk18</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                            <showDeprecation>true</showDeprecation>
+                            <showWarnings>true</showWarnings>
+                            <fork>true</fork>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>jar</goal>
+                                    <goal>test-jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>jdk18</classifier>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skipIfEmpty>true</skipIfEmpty>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/org/killbill/billing/plugin/core/JoobyServlet.java
+++ b/src/main/java/org/killbill/billing/plugin/core/JoobyServlet.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2017 Groupon, Inc
+ * Copyright 2014-2017 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.core;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jooby.servlet.ServletServletRequest;
+import org.jooby.servlet.ServletServletResponse;
+import org.jooby.spi.HttpHandler;
+import org.killbill.billing.plugin.core.resources.jooby.PluginApp;
+
+import com.typesafe.config.Config;
+
+public class JoobyServlet extends PluginServlet {
+
+    private final PluginApp app;
+
+    private final HttpHandler dispatcher;
+    private final String tmpdir;
+
+    public JoobyServlet(final PluginApp app) {
+        this.app = app;
+        this.app.start();
+
+        dispatcher = app.require(HttpHandler.class);
+        tmpdir = app.require(Config.class).getString("application.tmpdir");
+    }
+
+    @Override
+    protected void service(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            dispatcher.handle(new ServletServletRequest(req, tmpdir),
+                              new ServletServletResponse(req, resp));
+        } catch (final Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        app.stop();
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/core/config/PluginEnvironmentConfig.java
+++ b/src/main/java/org/killbill/billing/plugin/core/config/PluginEnvironmentConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2017 Groupon, Inc
+ * Copyright 2014-2017 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.core.config;
+
+import java.util.Properties;
+
+public class PluginEnvironmentConfig {
+
+    public static final String KILL_BILL_NAMESPACE = "org.killbill.";
+
+    public static String getRegion(final Properties properties) {
+        // See KillbillServerConfig
+        return properties.getProperty(KILL_BILL_NAMESPACE + "server.region");
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/core/resources/PluginHealthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/core/resources/PluginHealthcheck.java
@@ -17,7 +17,7 @@
 
 package org.killbill.billing.plugin.core.resources;
 
-import java.util.Dictionary;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -37,7 +37,7 @@ public abstract class PluginHealthcheck {
     private static final String CACHE_CONTROL = "Cache-Control";
     private static final String DEFAULT_CACHE_CONTROL = "private, no-cache, no-store, no-transform, must-revalidate";
 
-    protected Result check(final Healthcheck healthcheck, @Nullable final Tenant tenant, @Nullable final Dictionary properties) {
+    protected Result check(final Healthcheck healthcheck, @Nullable final Tenant tenant, @Nullable final Map properties) {
         final HealthStatus healthStatus = healthcheck.getHealthStatus(tenant, properties);
         return buildHealthcheckResponse(healthStatus);
     }

--- a/src/main/java/org/killbill/billing/plugin/core/resources/PluginHealthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/core/resources/PluginHealthcheck.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2017 Groupon, Inc
+ * Copyright 2014-2017 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.core.resources;
+
+import java.util.Dictionary;
+
+import javax.annotation.Nullable;
+
+import org.jooby.MediaType;
+import org.jooby.Result;
+import org.jooby.Results;
+import org.jooby.Status;
+import org.killbill.billing.plugin.service.Healthcheck;
+import org.killbill.billing.plugin.service.Healthcheck.HealthStatus;
+import org.killbill.billing.tenant.api.Tenant;
+
+// Specified in the concrete class
+//@Singleton
+//@Path("/healthcheck")
+public abstract class PluginHealthcheck {
+
+    private static final String CACHE_CONTROL = "Cache-Control";
+    private static final String DEFAULT_CACHE_CONTROL = "private, no-cache, no-store, no-transform, must-revalidate";
+
+    protected Result check(final Healthcheck healthcheck, @Nullable final Tenant tenant, @Nullable final Dictionary properties) {
+        final HealthStatus healthStatus = healthcheck.getHealthStatus(tenant, properties);
+        return buildHealthcheckResponse(healthStatus);
+    }
+
+    protected Result buildHealthcheckResponse(final HealthStatus healthStatus) {
+        return Results.with(healthStatus.getDetails(), healthStatus.isHealthy() ? Status.OK : Status.SERVICE_UNAVAILABLE)
+                      .header(CACHE_CONTROL, DEFAULT_CACHE_CONTROL)
+                      .type(MediaType.json);
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/core/resources/jooby/PluginApp.java
+++ b/src/main/java/org/killbill/billing/plugin/core/resources/jooby/PluginApp.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2017 Groupon, Inc
+ * Copyright 2014-2017 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.core.resources.jooby;
+
+import javax.servlet.http.HttpServlet;
+
+import org.jooby.Jooby;
+import org.jooby.json.Jackson;
+import org.killbill.billing.plugin.core.JoobyServlet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class PluginApp extends Jooby {
+
+    public PluginApp(final ObjectMapper objectMapper,
+                     final Iterable<Object> services,
+                     final Iterable<Class> routeClasses) {
+        use(new Jackson(objectMapper));
+
+        for (final Object service : services) {
+            bind(service);
+        }
+
+        for (final Class<?> routeClass : routeClasses) {
+            use(routeClass);
+        }
+    }
+
+    // To be registered in your Activator
+    public static HttpServlet createServlet(final PluginApp pluginApp) {
+        return new JoobyServlet(pluginApp);
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/core/resources/jooby/PluginApp.java
+++ b/src/main/java/org/killbill/billing/plugin/core/resources/jooby/PluginApp.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class PluginApp extends Jooby {
 
+    public PluginApp() {}
+
     public PluginApp(final ObjectMapper objectMapper,
                      final Iterable<Object> services,
                      final Iterable<Class> routeClasses) {

--- a/src/main/java/org/killbill/billing/plugin/core/resources/jooby/PluginAppBuilder.java
+++ b/src/main/java/org/killbill/billing/plugin/core/resources/jooby/PluginAppBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014-2017 Groupon, Inc
+ * Copyright 2014-2017 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.core.resources.jooby;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.jooby.servlet.ServerInitializer;
+import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillClock;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillDataSource;
+import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
+import org.killbill.billing.plugin.core.resources.PluginHealthcheck;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+public class PluginAppBuilder {
+
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        DEFAULT_OBJECT_MAPPER.registerModule(new JodaModule());
+        DEFAULT_OBJECT_MAPPER.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    private final List<Object> services = new LinkedList<Object>();
+    private final List<Class> routeClasses = new LinkedList<Class>();
+
+    private ObjectMapper objectMapper;
+    private Config config;
+
+    public PluginAppBuilder(final String pluginName,
+                            final OSGIKillbillAPI killbillAPI,
+                            final OSGIKillbillLogService logService,
+                            final OSGIKillbillDataSource dataSource,
+                            final OSGIKillbillClock clock,
+                            final OSGIConfigPropertiesService configProperties) {
+        withConfig(ConfigFactory.empty()
+                                .withValue("application.path", ConfigValueFactory.fromAnyRef(String.format("/plugins/%s/", pluginName)))
+                                .withValue("server.module", ConfigValueFactory.fromAnyRef(ServerInitializer.ServletModule.class.getName())));
+
+        withService(killbillAPI);
+        withService(logService);
+        withService(dataSource);
+        withService(clock);
+        withService(configProperties);
+
+        withObjectMapper(DEFAULT_OBJECT_MAPPER);
+
+        withRouteClass(PluginHealthcheck.class);
+    }
+
+    public PluginAppBuilder withObjectMapper(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        return this;
+    }
+
+    public PluginAppBuilder withService(final Object service) {
+        services.add(service);
+        return this;
+    }
+
+    public PluginAppBuilder withRouteClass(final Class routeClass) {
+        routeClasses.add(routeClass);
+        return this;
+    }
+
+    public PluginAppBuilder withConfig(final Config config) {
+        this.config = config;
+        return this;
+    }
+
+    public PluginApp build() {
+        final PluginApp app = new PluginApp(objectMapper, services, routeClasses);
+        app.use(config);
+        return app;
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/service/Healthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/service/Healthcheck.java
@@ -27,7 +27,7 @@ import org.killbill.billing.tenant.api.Tenant;
 
 public interface Healthcheck {
 
-    public HealthStatus getHealthStatus(@Nullable final Tenant tenant, @Nullable final Dictionary properties);
+    public HealthStatus getHealthStatus(@Nullable final Tenant tenant, @Nullable final Map properties);
 
     public class HealthStatus {
 

--- a/src/main/java/org/killbill/billing/plugin/service/Healthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/service/Healthcheck.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2017 Groupon, Inc
+ * Copyright 2014-2017 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.service;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.killbill.billing.tenant.api.Tenant;
+
+public interface Healthcheck {
+
+    public HealthStatus getHealthStatus(@Nullable final Tenant tenant, @Nullable final Dictionary properties);
+
+    public class HealthStatus {
+
+        private final boolean healthy;
+        private final Map details;
+
+        public HealthStatus(final boolean healthy, final Map details) {
+            this.details = details;
+            this.healthy = healthy;
+        }
+
+        public static HealthStatus healthy() {
+            return new HealthStatus(true, Collections.EMPTY_MAP);
+        }
+
+        public static HealthStatus unHealthy(final String message) {
+            return new HealthStatus(false, Collections.singletonMap("message", message));
+        }
+
+        public boolean isHealthy() {
+            return healthy;
+        }
+
+        public Map getDetails() {
+            return details;
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/service/Healthcheck.java
+++ b/src/main/java/org/killbill/billing/plugin/service/Healthcheck.java
@@ -43,6 +43,10 @@ public interface Healthcheck {
             return new HealthStatus(true, Collections.EMPTY_MAP);
         }
 
+        public static HealthStatus healthy(final String message) {
+            return new HealthStatus(true, Collections.singletonMap("message", message));
+        }
+
         public static HealthStatus unHealthy(final String message) {
             return new HealthStatus(false, Collections.singletonMap("message", message));
         }


### PR DESCRIPTION
Support for multi-regions configuration (https://github.com/killbill/killbill-plugin-framework-java/issues/11).

Other changes that came up while integrating it with Adyen:
* Support for per-plugin healthcheck
* Support for servlets backed by [jooby](http://jooby.org/)
* The library is now JDK 1.8+ only now because of jooby. It's probably fine, as it is mostly used in the Adyen plugin today, which already requires 1.7+. If needed, we can continue maintaining the 1.1.x series.

/cc @andrenpaes for review.

**Do not merge yet**, as I'll have to release the base pom.xml first.