### PR TITLE
reversed arguments for queryParams and headers at line 167 (issue #30)

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/util/http/HttpClient.java
+++ b/src/main/java/org/killbill/billing/plugin/util/http/HttpClient.java
@@ -164,7 +164,7 @@ public class HttpClient implements Closeable {
                                                                                            IOException,
                                                                                            TimeoutException,
                                                                                            URISyntaxException {
-        return doCall(verb, uri, body, headers, queryParams, String.class, ResponseFormat.TEXT);
+        return doCall(verb, uri, body, queryParams, headers, String.class, ResponseFormat.TEXT);
     }
 
     protected <T> T doCall(final String verb, final String uri, final String body, final Map<String, String> queryParams,


### PR DESCRIPTION
The call to doCall()  on line 167 in HttpClient passed the wrong args. Specifically queryParams and headers were reversed/interchanged in the call. This PR realigns them. 