### PR TITLE
Remove ambiguous PluginPriorPaymentControlResult#CTOR

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="PROJECT_PROFILE" value="Project Default" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/src/main/java/org/killbill/billing/plugin/api/control/PluginPaymentControlPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/api/control/PluginPaymentControlPluginApi.java
@@ -38,7 +38,7 @@ public class PluginPaymentControlPluginApi extends PluginApi implements PaymentC
 
     @Override
     public PriorPaymentControlResult priorCall(final PaymentControlContext context, final Iterable<PluginProperty> properties) throws PaymentControlApiException {
-        return new PluginPriorPaymentControlResult(context);
+        return new PluginPriorPaymentControlResult(false);
     }
 
     @Override

--- a/src/main/java/org/killbill/billing/plugin/api/control/PluginPriorPaymentControlResult.java
+++ b/src/main/java/org/killbill/billing/plugin/api/control/PluginPriorPaymentControlResult.java
@@ -21,7 +21,6 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 import org.killbill.billing.catalog.api.Currency;
-import org.killbill.billing.control.plugin.api.PaymentControlContext;
 import org.killbill.billing.control.plugin.api.PriorPaymentControlResult;
 import org.killbill.billing.payment.api.PluginProperty;
 
@@ -34,16 +33,8 @@ public class PluginPriorPaymentControlResult implements PriorPaymentControlResul
     private final String adjustedPluginName;
     private final Iterable<PluginProperty> adjustedPluginProperties;
 
-    public PluginPriorPaymentControlResult(final PaymentControlContext context) {
-        this(false, context);
-    }
-
-    public PluginPriorPaymentControlResult(final boolean isAborted, final PaymentControlContext context) {
-        this(isAborted, context.getAmount(), context.getCurrency(), context.getPaymentMethodId(), null, null);
-    }
-
-    public PluginPriorPaymentControlResult(final Iterable<PluginProperty> adjustedPluginProperties, final PaymentControlContext context) {
-        this(false, context.getAmount(), context.getCurrency(), context.getPaymentMethodId(), null, adjustedPluginProperties);
+    public PluginPriorPaymentControlResult(final boolean isAborted) {
+        this(isAborted, null, null, null, null, null);
     }
 
     public PluginPriorPaymentControlResult(final boolean isAborted,


### PR DESCRIPTION
Our payment code was updated to be stricter and not allow passing a paymentMethodId when there is already one, so
it makes sense to not have default CTORs that do that. See https://github.com/killbill/killbill/commit/807e265f4c0cfece035883f355dd44053a35ca4a