### PR TITLE
add generated pojos

### DIFF
--- a/src/main/java/org/killbill/billing/account/api/boilerplate/AccountDataImp.java
+++ b/src/main/java/org/killbill/billing/account/api/boilerplate/AccountDataImp.java
@@ -1,0 +1,589 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.catalog.api.Currency;
+
+@JsonDeserialize( builder = AccountDataImp.Builder.class )
+public class AccountDataImp implements AccountData, Serializable {
+
+    private static final long serialVersionUID = 0x2C6389A98E22A198L;
+
+    protected String address1;
+    protected String address2;
+    protected Integer billCycleDayLocal;
+    protected String city;
+    protected String companyName;
+    protected String country;
+    protected Currency currency;
+    protected String email;
+    protected String externalKey;
+    protected Integer firstNameLength;
+    protected Boolean isMigrated;
+    protected Boolean isPaymentDelegatedToParent;
+    protected String locale;
+    protected String name;
+    protected String notes;
+    protected UUID parentAccountId;
+    protected UUID paymentMethodId;
+    protected String phone;
+    protected String postalCode;
+    protected DateTime referenceTime;
+    protected String stateOrProvince;
+    protected DateTimeZone timeZone;
+
+    public AccountDataImp(final AccountDataImp that) {
+        this.address1 = that.address1;
+        this.address2 = that.address2;
+        this.billCycleDayLocal = that.billCycleDayLocal;
+        this.city = that.city;
+        this.companyName = that.companyName;
+        this.country = that.country;
+        this.currency = that.currency;
+        this.email = that.email;
+        this.externalKey = that.externalKey;
+        this.firstNameLength = that.firstNameLength;
+        this.isMigrated = that.isMigrated;
+        this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent;
+        this.locale = that.locale;
+        this.name = that.name;
+        this.notes = that.notes;
+        this.parentAccountId = that.parentAccountId;
+        this.paymentMethodId = that.paymentMethodId;
+        this.phone = that.phone;
+        this.postalCode = that.postalCode;
+        this.referenceTime = that.referenceTime;
+        this.stateOrProvince = that.stateOrProvince;
+        this.timeZone = that.timeZone;
+    }
+    protected AccountDataImp(final AccountDataImp.Builder<?> builder) {
+        this.address1 = builder.address1;
+        this.address2 = builder.address2;
+        this.billCycleDayLocal = builder.billCycleDayLocal;
+        this.city = builder.city;
+        this.companyName = builder.companyName;
+        this.country = builder.country;
+        this.currency = builder.currency;
+        this.email = builder.email;
+        this.externalKey = builder.externalKey;
+        this.firstNameLength = builder.firstNameLength;
+        this.isMigrated = builder.isMigrated;
+        this.isPaymentDelegatedToParent = builder.isPaymentDelegatedToParent;
+        this.locale = builder.locale;
+        this.name = builder.name;
+        this.notes = builder.notes;
+        this.parentAccountId = builder.parentAccountId;
+        this.paymentMethodId = builder.paymentMethodId;
+        this.phone = builder.phone;
+        this.postalCode = builder.postalCode;
+        this.referenceTime = builder.referenceTime;
+        this.stateOrProvince = builder.stateOrProvince;
+        this.timeZone = builder.timeZone;
+    }
+    protected AccountDataImp() { }
+    @Override
+    public String getAddress1() {
+        return this.address1;
+    }
+    @Override
+    public String getAddress2() {
+        return this.address2;
+    }
+    @Override
+    public Integer getBillCycleDayLocal() {
+        return this.billCycleDayLocal;
+    }
+    @Override
+    public String getCity() {
+        return this.city;
+    }
+    @Override
+    public String getCompanyName() {
+        return this.companyName;
+    }
+    @Override
+    public String getCountry() {
+        return this.country;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public String getEmail() {
+        return this.email;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public Integer getFirstNameLength() {
+        return this.firstNameLength;
+    }
+    @Override
+    @JsonGetter("isMigrated")
+    public Boolean isMigrated() {
+        return this.isMigrated;
+    }
+    @Override
+    @JsonGetter("isPaymentDelegatedToParent")
+    public Boolean isPaymentDelegatedToParent() {
+        return this.isPaymentDelegatedToParent;
+    }
+    @Override
+    public String getLocale() {
+        return this.locale;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public String getNotes() {
+        return this.notes;
+    }
+    @Override
+    public UUID getParentAccountId() {
+        return this.parentAccountId;
+    }
+    @Override
+    public UUID getPaymentMethodId() {
+        return this.paymentMethodId;
+    }
+    @Override
+    public String getPhone() {
+        return this.phone;
+    }
+    @Override
+    public String getPostalCode() {
+        return this.postalCode;
+    }
+    @Override
+    public DateTime getReferenceTime() {
+        return this.referenceTime;
+    }
+    @Override
+    public String getStateOrProvince() {
+        return this.stateOrProvince;
+    }
+    @Override
+    public DateTimeZone getTimeZone() {
+        return this.timeZone;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AccountDataImp that = (AccountDataImp) o;
+        if( !Objects.equals(this.address1, that.address1) ) {
+            return false;
+        }
+        if( !Objects.equals(this.address2, that.address2) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billCycleDayLocal, that.billCycleDayLocal) ) {
+            return false;
+        }
+        if( !Objects.equals(this.city, that.city) ) {
+            return false;
+        }
+        if( !Objects.equals(this.companyName, that.companyName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.country, that.country) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.email, that.email) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.firstNameLength, that.firstNameLength) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isMigrated, that.isMigrated) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isPaymentDelegatedToParent, that.isPaymentDelegatedToParent) ) {
+            return false;
+        }
+        if( !Objects.equals(this.locale, that.locale) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.notes, that.notes) ) {
+            return false;
+        }
+        if( !Objects.equals(this.parentAccountId, that.parentAccountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentMethodId, that.paymentMethodId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phone, that.phone) ) {
+            return false;
+        }
+        if( !Objects.equals(this.postalCode, that.postalCode) ) {
+            return false;
+        }
+        if( ( this.referenceTime != null ) ? ( 0 != this.referenceTime.compareTo(that.referenceTime) ) : ( that.referenceTime != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.stateOrProvince, that.stateOrProvince) ) {
+            return false;
+        }
+        if( !Objects.equals(this.timeZone, that.timeZone) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.address1);
+        result = ( 31 * result ) + Objects.hashCode(this.address2);
+        result = ( 31 * result ) + Objects.hashCode(this.billCycleDayLocal);
+        result = ( 31 * result ) + Objects.hashCode(this.city);
+        result = ( 31 * result ) + Objects.hashCode(this.companyName);
+        result = ( 31 * result ) + Objects.hashCode(this.country);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.email);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.firstNameLength);
+        result = ( 31 * result ) + Objects.hashCode(this.isMigrated);
+        result = ( 31 * result ) + Objects.hashCode(this.isPaymentDelegatedToParent);
+        result = ( 31 * result ) + Objects.hashCode(this.locale);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.notes);
+        result = ( 31 * result ) + Objects.hashCode(this.parentAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentMethodId);
+        result = ( 31 * result ) + Objects.hashCode(this.phone);
+        result = ( 31 * result ) + Objects.hashCode(this.postalCode);
+        result = ( 31 * result ) + Objects.hashCode(this.referenceTime);
+        result = ( 31 * result ) + Objects.hashCode(this.stateOrProvince);
+        result = ( 31 * result ) + Objects.hashCode(this.timeZone);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("address1=");
+        if( this.address1 == null ) {
+            sb.append(this.address1);
+        }else{
+            sb.append("'").append(this.address1).append("'");
+        }
+        sb.append(", ");
+        sb.append("address2=");
+        if( this.address2 == null ) {
+            sb.append(this.address2);
+        }else{
+            sb.append("'").append(this.address2).append("'");
+        }
+        sb.append(", ");
+        sb.append("billCycleDayLocal=").append(this.billCycleDayLocal);
+        sb.append(", ");
+        sb.append("city=");
+        if( this.city == null ) {
+            sb.append(this.city);
+        }else{
+            sb.append("'").append(this.city).append("'");
+        }
+        sb.append(", ");
+        sb.append("companyName=");
+        if( this.companyName == null ) {
+            sb.append(this.companyName);
+        }else{
+            sb.append("'").append(this.companyName).append("'");
+        }
+        sb.append(", ");
+        sb.append("country=");
+        if( this.country == null ) {
+            sb.append(this.country);
+        }else{
+            sb.append("'").append(this.country).append("'");
+        }
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("email=");
+        if( this.email == null ) {
+            sb.append(this.email);
+        }else{
+            sb.append("'").append(this.email).append("'");
+        }
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("firstNameLength=").append(this.firstNameLength);
+        sb.append(", ");
+        sb.append("isMigrated=").append(this.isMigrated);
+        sb.append(", ");
+        sb.append("isPaymentDelegatedToParent=").append(this.isPaymentDelegatedToParent);
+        sb.append(", ");
+        sb.append("locale=");
+        if( this.locale == null ) {
+            sb.append(this.locale);
+        }else{
+            sb.append("'").append(this.locale).append("'");
+        }
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("notes=");
+        if( this.notes == null ) {
+            sb.append(this.notes);
+        }else{
+            sb.append("'").append(this.notes).append("'");
+        }
+        sb.append(", ");
+        sb.append("parentAccountId=").append(this.parentAccountId);
+        sb.append(", ");
+        sb.append("paymentMethodId=").append(this.paymentMethodId);
+        sb.append(", ");
+        sb.append("phone=");
+        if( this.phone == null ) {
+            sb.append(this.phone);
+        }else{
+            sb.append("'").append(this.phone).append("'");
+        }
+        sb.append(", ");
+        sb.append("postalCode=");
+        if( this.postalCode == null ) {
+            sb.append(this.postalCode);
+        }else{
+            sb.append("'").append(this.postalCode).append("'");
+        }
+        sb.append(", ");
+        sb.append("referenceTime=").append(this.referenceTime);
+        sb.append(", ");
+        sb.append("stateOrProvince=");
+        if( this.stateOrProvince == null ) {
+            sb.append(this.stateOrProvince);
+        }else{
+            sb.append("'").append(this.stateOrProvince).append("'");
+        }
+        sb.append(", ");
+        sb.append("timeZone=").append(this.timeZone);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AccountDataImp.Builder<T>> {
+
+        protected String address1;
+        protected String address2;
+        protected Integer billCycleDayLocal;
+        protected String city;
+        protected String companyName;
+        protected String country;
+        protected Currency currency;
+        protected String email;
+        protected String externalKey;
+        protected Integer firstNameLength;
+        protected Boolean isMigrated;
+        protected Boolean isPaymentDelegatedToParent;
+        protected String locale;
+        protected String name;
+        protected String notes;
+        protected UUID parentAccountId;
+        protected UUID paymentMethodId;
+        protected String phone;
+        protected String postalCode;
+        protected DateTime referenceTime;
+        protected String stateOrProvince;
+        protected DateTimeZone timeZone;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.address1 = that.address1;
+            this.address2 = that.address2;
+            this.billCycleDayLocal = that.billCycleDayLocal;
+            this.city = that.city;
+            this.companyName = that.companyName;
+            this.country = that.country;
+            this.currency = that.currency;
+            this.email = that.email;
+            this.externalKey = that.externalKey;
+            this.firstNameLength = that.firstNameLength;
+            this.isMigrated = that.isMigrated;
+            this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent;
+            this.locale = that.locale;
+            this.name = that.name;
+            this.notes = that.notes;
+            this.parentAccountId = that.parentAccountId;
+            this.paymentMethodId = that.paymentMethodId;
+            this.phone = that.phone;
+            this.postalCode = that.postalCode;
+            this.referenceTime = that.referenceTime;
+            this.stateOrProvince = that.stateOrProvince;
+            this.timeZone = that.timeZone;
+        }
+        public T withAddress1(final String address1) {
+            this.address1 = address1;
+            return (T) this;
+        }
+        public T withAddress2(final String address2) {
+            this.address2 = address2;
+            return (T) this;
+        }
+        public T withBillCycleDayLocal(final Integer billCycleDayLocal) {
+            this.billCycleDayLocal = billCycleDayLocal;
+            return (T) this;
+        }
+        public T withCity(final String city) {
+            this.city = city;
+            return (T) this;
+        }
+        public T withCompanyName(final String companyName) {
+            this.companyName = companyName;
+            return (T) this;
+        }
+        public T withCountry(final String country) {
+            this.country = country;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withEmail(final String email) {
+            this.email = email;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withFirstNameLength(final Integer firstNameLength) {
+            this.firstNameLength = firstNameLength;
+            return (T) this;
+        }
+        public T withIsMigrated(final Boolean isMigrated) {
+            this.isMigrated = isMigrated;
+            return (T) this;
+        }
+        public T withIsPaymentDelegatedToParent(final Boolean isPaymentDelegatedToParent) {
+            this.isPaymentDelegatedToParent = isPaymentDelegatedToParent;
+            return (T) this;
+        }
+        public T withLocale(final String locale) {
+            this.locale = locale;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withNotes(final String notes) {
+            this.notes = notes;
+            return (T) this;
+        }
+        public T withParentAccountId(final UUID parentAccountId) {
+            this.parentAccountId = parentAccountId;
+            return (T) this;
+        }
+        public T withPaymentMethodId(final UUID paymentMethodId) {
+            this.paymentMethodId = paymentMethodId;
+            return (T) this;
+        }
+        public T withPhone(final String phone) {
+            this.phone = phone;
+            return (T) this;
+        }
+        public T withPostalCode(final String postalCode) {
+            this.postalCode = postalCode;
+            return (T) this;
+        }
+        public T withReferenceTime(final DateTime referenceTime) {
+            this.referenceTime = referenceTime;
+            return (T) this;
+        }
+        public T withStateOrProvince(final String stateOrProvince) {
+            this.stateOrProvince = stateOrProvince;
+            return (T) this;
+        }
+        public T withTimeZone(final DateTimeZone timeZone) {
+            this.timeZone = timeZone;
+            return (T) this;
+        }
+        public T source(final AccountData that) {
+            this.address1 = that.getAddress1();
+            this.address2 = that.getAddress2();
+            this.billCycleDayLocal = that.getBillCycleDayLocal();
+            this.city = that.getCity();
+            this.companyName = that.getCompanyName();
+            this.country = that.getCountry();
+            this.currency = that.getCurrency();
+            this.email = that.getEmail();
+            this.externalKey = that.getExternalKey();
+            this.firstNameLength = that.getFirstNameLength();
+            this.isMigrated = that.isMigrated();
+            this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent();
+            this.locale = that.getLocale();
+            this.name = that.getName();
+            this.notes = that.getNotes();
+            this.parentAccountId = that.getParentAccountId();
+            this.paymentMethodId = that.getPaymentMethodId();
+            this.phone = that.getPhone();
+            this.postalCode = that.getPostalCode();
+            this.referenceTime = that.getReferenceTime();
+            this.stateOrProvince = that.getStateOrProvince();
+            this.timeZone = that.getTimeZone();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AccountDataImp build() {
+            return new AccountDataImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/account/api/boilerplate/AccountEmailImp.java
+++ b/src/main/java/org/killbill/billing/account/api/boilerplate/AccountEmailImp.java
@@ -1,0 +1,185 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.account.api.AccountEmail;
+
+@JsonDeserialize( builder = AccountEmailImp.Builder.class )
+public class AccountEmailImp implements AccountEmail, Serializable {
+
+    private static final long serialVersionUID = 0x89ADE56213E92CA8L;
+
+    protected UUID accountId;
+    protected DateTime createdDate;
+    protected String email;
+    protected UUID id;
+    protected DateTime updatedDate;
+
+    public AccountEmailImp(final AccountEmailImp that) {
+        this.accountId = that.accountId;
+        this.createdDate = that.createdDate;
+        this.email = that.email;
+        this.id = that.id;
+        this.updatedDate = that.updatedDate;
+    }
+    protected AccountEmailImp(final AccountEmailImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.createdDate = builder.createdDate;
+        this.email = builder.email;
+        this.id = builder.id;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected AccountEmailImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public String getEmail() {
+        return this.email;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AccountEmailImp that = (AccountEmailImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.email, that.email) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.email);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("email=");
+        if( this.email == null ) {
+            sb.append(this.email);
+        }else{
+            sb.append("'").append(this.email).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AccountEmailImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected DateTime createdDate;
+        protected String email;
+        protected UUID id;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.createdDate = that.createdDate;
+            this.email = that.email;
+            this.id = that.id;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withEmail(final String email) {
+            this.email = email;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final AccountEmail that) {
+            this.accountId = that.getAccountId();
+            this.createdDate = that.getCreatedDate();
+            this.email = that.getEmail();
+            this.id = that.getId();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AccountEmailImp build() {
+            return new AccountEmailImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/account/api/boilerplate/AccountImp.java
+++ b/src/main/java/org/killbill/billing/account/api/boilerplate/AccountImp.java
@@ -1,0 +1,678 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.account.api.MutableAccountData;
+import org.killbill.billing.catalog.api.Currency;
+
+@JsonDeserialize( builder = AccountImp.Builder.class )
+public class AccountImp implements Account, Serializable {
+
+    private static final long serialVersionUID = 0xC04BEEB88249E4BFL;
+
+    protected String address1;
+    protected String address2;
+    protected Integer billCycleDayLocal;
+    protected String city;
+    protected String companyName;
+    protected String country;
+    protected DateTime createdDate;
+    protected Currency currency;
+    protected String email;
+    protected String externalKey;
+    protected Integer firstNameLength;
+    protected DateTimeZone fixedOffsetTimeZone;
+    protected UUID id;
+    protected Boolean isMigrated;
+    protected Boolean isPaymentDelegatedToParent;
+    protected String locale;
+    protected String name;
+    protected String notes;
+    protected UUID parentAccountId;
+    protected UUID paymentMethodId;
+    protected String phone;
+    protected String postalCode;
+    protected DateTime referenceTime;
+    protected String stateOrProvince;
+    protected DateTimeZone timeZone;
+    protected DateTime updatedDate;
+
+    public AccountImp(final AccountImp that) {
+        this.address1 = that.address1;
+        this.address2 = that.address2;
+        this.billCycleDayLocal = that.billCycleDayLocal;
+        this.city = that.city;
+        this.companyName = that.companyName;
+        this.country = that.country;
+        this.createdDate = that.createdDate;
+        this.currency = that.currency;
+        this.email = that.email;
+        this.externalKey = that.externalKey;
+        this.firstNameLength = that.firstNameLength;
+        this.fixedOffsetTimeZone = that.fixedOffsetTimeZone;
+        this.id = that.id;
+        this.isMigrated = that.isMigrated;
+        this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent;
+        this.locale = that.locale;
+        this.name = that.name;
+        this.notes = that.notes;
+        this.parentAccountId = that.parentAccountId;
+        this.paymentMethodId = that.paymentMethodId;
+        this.phone = that.phone;
+        this.postalCode = that.postalCode;
+        this.referenceTime = that.referenceTime;
+        this.stateOrProvince = that.stateOrProvince;
+        this.timeZone = that.timeZone;
+        this.updatedDate = that.updatedDate;
+    }
+    protected AccountImp(final AccountImp.Builder<?> builder) {
+        this.address1 = builder.address1;
+        this.address2 = builder.address2;
+        this.billCycleDayLocal = builder.billCycleDayLocal;
+        this.city = builder.city;
+        this.companyName = builder.companyName;
+        this.country = builder.country;
+        this.createdDate = builder.createdDate;
+        this.currency = builder.currency;
+        this.email = builder.email;
+        this.externalKey = builder.externalKey;
+        this.firstNameLength = builder.firstNameLength;
+        this.fixedOffsetTimeZone = builder.fixedOffsetTimeZone;
+        this.id = builder.id;
+        this.isMigrated = builder.isMigrated;
+        this.isPaymentDelegatedToParent = builder.isPaymentDelegatedToParent;
+        this.locale = builder.locale;
+        this.name = builder.name;
+        this.notes = builder.notes;
+        this.parentAccountId = builder.parentAccountId;
+        this.paymentMethodId = builder.paymentMethodId;
+        this.phone = builder.phone;
+        this.postalCode = builder.postalCode;
+        this.referenceTime = builder.referenceTime;
+        this.stateOrProvince = builder.stateOrProvince;
+        this.timeZone = builder.timeZone;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected AccountImp() { }
+    @Override
+    public String getAddress1() {
+        return this.address1;
+    }
+    @Override
+    public String getAddress2() {
+        return this.address2;
+    }
+    @Override
+    public Integer getBillCycleDayLocal() {
+        return this.billCycleDayLocal;
+    }
+    @Override
+    public String getCity() {
+        return this.city;
+    }
+    @Override
+    public String getCompanyName() {
+        return this.companyName;
+    }
+    @Override
+    public String getCountry() {
+        return this.country;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public String getEmail() {
+        return this.email;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public Integer getFirstNameLength() {
+        return this.firstNameLength;
+    }
+    @Override
+    public DateTimeZone getFixedOffsetTimeZone() {
+        return this.fixedOffsetTimeZone;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    @JsonGetter("isMigrated")
+    public Boolean isMigrated() {
+        return this.isMigrated;
+    }
+    @Override
+    @JsonGetter("isPaymentDelegatedToParent")
+    public Boolean isPaymentDelegatedToParent() {
+        return this.isPaymentDelegatedToParent;
+    }
+    @Override
+    public String getLocale() {
+        return this.locale;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public String getNotes() {
+        return this.notes;
+    }
+    @Override
+    public UUID getParentAccountId() {
+        return this.parentAccountId;
+    }
+    @Override
+    public UUID getPaymentMethodId() {
+        return this.paymentMethodId;
+    }
+    @Override
+    public String getPhone() {
+        return this.phone;
+    }
+    @Override
+    public String getPostalCode() {
+        return this.postalCode;
+    }
+    @Override
+    public DateTime getReferenceTime() {
+        return this.referenceTime;
+    }
+    @Override
+    public String getStateOrProvince() {
+        return this.stateOrProvince;
+    }
+    @Override
+    public DateTimeZone getTimeZone() {
+        return this.timeZone;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public MutableAccountData toMutableAccountData() {
+        throw new UnsupportedOperationException("toMutableAccountData() must be implemented.");
+    }
+    @Override
+    public Account mergeWithDelegate(final Account delegate) {
+        throw new UnsupportedOperationException("mergeWithDelegate(org.killbill.billing.account.api.Account) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AccountImp that = (AccountImp) o;
+        if( !Objects.equals(this.address1, that.address1) ) {
+            return false;
+        }
+        if( !Objects.equals(this.address2, that.address2) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billCycleDayLocal, that.billCycleDayLocal) ) {
+            return false;
+        }
+        if( !Objects.equals(this.city, that.city) ) {
+            return false;
+        }
+        if( !Objects.equals(this.companyName, that.companyName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.country, that.country) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.email, that.email) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.firstNameLength, that.firstNameLength) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fixedOffsetTimeZone, that.fixedOffsetTimeZone) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isMigrated, that.isMigrated) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isPaymentDelegatedToParent, that.isPaymentDelegatedToParent) ) {
+            return false;
+        }
+        if( !Objects.equals(this.locale, that.locale) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.notes, that.notes) ) {
+            return false;
+        }
+        if( !Objects.equals(this.parentAccountId, that.parentAccountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentMethodId, that.paymentMethodId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phone, that.phone) ) {
+            return false;
+        }
+        if( !Objects.equals(this.postalCode, that.postalCode) ) {
+            return false;
+        }
+        if( ( this.referenceTime != null ) ? ( 0 != this.referenceTime.compareTo(that.referenceTime) ) : ( that.referenceTime != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.stateOrProvince, that.stateOrProvince) ) {
+            return false;
+        }
+        if( !Objects.equals(this.timeZone, that.timeZone) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.address1);
+        result = ( 31 * result ) + Objects.hashCode(this.address2);
+        result = ( 31 * result ) + Objects.hashCode(this.billCycleDayLocal);
+        result = ( 31 * result ) + Objects.hashCode(this.city);
+        result = ( 31 * result ) + Objects.hashCode(this.companyName);
+        result = ( 31 * result ) + Objects.hashCode(this.country);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.email);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.firstNameLength);
+        result = ( 31 * result ) + Objects.hashCode(this.fixedOffsetTimeZone);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.isMigrated);
+        result = ( 31 * result ) + Objects.hashCode(this.isPaymentDelegatedToParent);
+        result = ( 31 * result ) + Objects.hashCode(this.locale);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.notes);
+        result = ( 31 * result ) + Objects.hashCode(this.parentAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentMethodId);
+        result = ( 31 * result ) + Objects.hashCode(this.phone);
+        result = ( 31 * result ) + Objects.hashCode(this.postalCode);
+        result = ( 31 * result ) + Objects.hashCode(this.referenceTime);
+        result = ( 31 * result ) + Objects.hashCode(this.stateOrProvince);
+        result = ( 31 * result ) + Objects.hashCode(this.timeZone);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("address1=");
+        if( this.address1 == null ) {
+            sb.append(this.address1);
+        }else{
+            sb.append("'").append(this.address1).append("'");
+        }
+        sb.append(", ");
+        sb.append("address2=");
+        if( this.address2 == null ) {
+            sb.append(this.address2);
+        }else{
+            sb.append("'").append(this.address2).append("'");
+        }
+        sb.append(", ");
+        sb.append("billCycleDayLocal=").append(this.billCycleDayLocal);
+        sb.append(", ");
+        sb.append("city=");
+        if( this.city == null ) {
+            sb.append(this.city);
+        }else{
+            sb.append("'").append(this.city).append("'");
+        }
+        sb.append(", ");
+        sb.append("companyName=");
+        if( this.companyName == null ) {
+            sb.append(this.companyName);
+        }else{
+            sb.append("'").append(this.companyName).append("'");
+        }
+        sb.append(", ");
+        sb.append("country=");
+        if( this.country == null ) {
+            sb.append(this.country);
+        }else{
+            sb.append("'").append(this.country).append("'");
+        }
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("email=");
+        if( this.email == null ) {
+            sb.append(this.email);
+        }else{
+            sb.append("'").append(this.email).append("'");
+        }
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("firstNameLength=").append(this.firstNameLength);
+        sb.append(", ");
+        sb.append("fixedOffsetTimeZone=").append(this.fixedOffsetTimeZone);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("isMigrated=").append(this.isMigrated);
+        sb.append(", ");
+        sb.append("isPaymentDelegatedToParent=").append(this.isPaymentDelegatedToParent);
+        sb.append(", ");
+        sb.append("locale=");
+        if( this.locale == null ) {
+            sb.append(this.locale);
+        }else{
+            sb.append("'").append(this.locale).append("'");
+        }
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("notes=");
+        if( this.notes == null ) {
+            sb.append(this.notes);
+        }else{
+            sb.append("'").append(this.notes).append("'");
+        }
+        sb.append(", ");
+        sb.append("parentAccountId=").append(this.parentAccountId);
+        sb.append(", ");
+        sb.append("paymentMethodId=").append(this.paymentMethodId);
+        sb.append(", ");
+        sb.append("phone=");
+        if( this.phone == null ) {
+            sb.append(this.phone);
+        }else{
+            sb.append("'").append(this.phone).append("'");
+        }
+        sb.append(", ");
+        sb.append("postalCode=");
+        if( this.postalCode == null ) {
+            sb.append(this.postalCode);
+        }else{
+            sb.append("'").append(this.postalCode).append("'");
+        }
+        sb.append(", ");
+        sb.append("referenceTime=").append(this.referenceTime);
+        sb.append(", ");
+        sb.append("stateOrProvince=");
+        if( this.stateOrProvince == null ) {
+            sb.append(this.stateOrProvince);
+        }else{
+            sb.append("'").append(this.stateOrProvince).append("'");
+        }
+        sb.append(", ");
+        sb.append("timeZone=").append(this.timeZone);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AccountImp.Builder<T>> {
+
+        protected String address1;
+        protected String address2;
+        protected Integer billCycleDayLocal;
+        protected String city;
+        protected String companyName;
+        protected String country;
+        protected DateTime createdDate;
+        protected Currency currency;
+        protected String email;
+        protected String externalKey;
+        protected Integer firstNameLength;
+        protected DateTimeZone fixedOffsetTimeZone;
+        protected UUID id;
+        protected Boolean isMigrated;
+        protected Boolean isPaymentDelegatedToParent;
+        protected String locale;
+        protected String name;
+        protected String notes;
+        protected UUID parentAccountId;
+        protected UUID paymentMethodId;
+        protected String phone;
+        protected String postalCode;
+        protected DateTime referenceTime;
+        protected String stateOrProvince;
+        protected DateTimeZone timeZone;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.address1 = that.address1;
+            this.address2 = that.address2;
+            this.billCycleDayLocal = that.billCycleDayLocal;
+            this.city = that.city;
+            this.companyName = that.companyName;
+            this.country = that.country;
+            this.createdDate = that.createdDate;
+            this.currency = that.currency;
+            this.email = that.email;
+            this.externalKey = that.externalKey;
+            this.firstNameLength = that.firstNameLength;
+            this.fixedOffsetTimeZone = that.fixedOffsetTimeZone;
+            this.id = that.id;
+            this.isMigrated = that.isMigrated;
+            this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent;
+            this.locale = that.locale;
+            this.name = that.name;
+            this.notes = that.notes;
+            this.parentAccountId = that.parentAccountId;
+            this.paymentMethodId = that.paymentMethodId;
+            this.phone = that.phone;
+            this.postalCode = that.postalCode;
+            this.referenceTime = that.referenceTime;
+            this.stateOrProvince = that.stateOrProvince;
+            this.timeZone = that.timeZone;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAddress1(final String address1) {
+            this.address1 = address1;
+            return (T) this;
+        }
+        public T withAddress2(final String address2) {
+            this.address2 = address2;
+            return (T) this;
+        }
+        public T withBillCycleDayLocal(final Integer billCycleDayLocal) {
+            this.billCycleDayLocal = billCycleDayLocal;
+            return (T) this;
+        }
+        public T withCity(final String city) {
+            this.city = city;
+            return (T) this;
+        }
+        public T withCompanyName(final String companyName) {
+            this.companyName = companyName;
+            return (T) this;
+        }
+        public T withCountry(final String country) {
+            this.country = country;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withEmail(final String email) {
+            this.email = email;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withFirstNameLength(final Integer firstNameLength) {
+            this.firstNameLength = firstNameLength;
+            return (T) this;
+        }
+        public T withFixedOffsetTimeZone(final DateTimeZone fixedOffsetTimeZone) {
+            this.fixedOffsetTimeZone = fixedOffsetTimeZone;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withIsMigrated(final Boolean isMigrated) {
+            this.isMigrated = isMigrated;
+            return (T) this;
+        }
+        public T withIsPaymentDelegatedToParent(final Boolean isPaymentDelegatedToParent) {
+            this.isPaymentDelegatedToParent = isPaymentDelegatedToParent;
+            return (T) this;
+        }
+        public T withLocale(final String locale) {
+            this.locale = locale;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withNotes(final String notes) {
+            this.notes = notes;
+            return (T) this;
+        }
+        public T withParentAccountId(final UUID parentAccountId) {
+            this.parentAccountId = parentAccountId;
+            return (T) this;
+        }
+        public T withPaymentMethodId(final UUID paymentMethodId) {
+            this.paymentMethodId = paymentMethodId;
+            return (T) this;
+        }
+        public T withPhone(final String phone) {
+            this.phone = phone;
+            return (T) this;
+        }
+        public T withPostalCode(final String postalCode) {
+            this.postalCode = postalCode;
+            return (T) this;
+        }
+        public T withReferenceTime(final DateTime referenceTime) {
+            this.referenceTime = referenceTime;
+            return (T) this;
+        }
+        public T withStateOrProvince(final String stateOrProvince) {
+            this.stateOrProvince = stateOrProvince;
+            return (T) this;
+        }
+        public T withTimeZone(final DateTimeZone timeZone) {
+            this.timeZone = timeZone;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Account that) {
+            this.address1 = that.getAddress1();
+            this.address2 = that.getAddress2();
+            this.billCycleDayLocal = that.getBillCycleDayLocal();
+            this.city = that.getCity();
+            this.companyName = that.getCompanyName();
+            this.country = that.getCountry();
+            this.createdDate = that.getCreatedDate();
+            this.currency = that.getCurrency();
+            this.email = that.getEmail();
+            this.externalKey = that.getExternalKey();
+            this.firstNameLength = that.getFirstNameLength();
+            this.fixedOffsetTimeZone = that.getFixedOffsetTimeZone();
+            this.id = that.getId();
+            this.isMigrated = that.isMigrated();
+            this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent();
+            this.locale = that.getLocale();
+            this.name = that.getName();
+            this.notes = that.getNotes();
+            this.parentAccountId = that.getParentAccountId();
+            this.paymentMethodId = that.getPaymentMethodId();
+            this.phone = that.getPhone();
+            this.postalCode = that.getPostalCode();
+            this.referenceTime = that.getReferenceTime();
+            this.stateOrProvince = that.getStateOrProvince();
+            this.timeZone = that.getTimeZone();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AccountImp build() {
+            return new AccountImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/account/api/boilerplate/AccountUserApiImp.java
+++ b/src/main/java/org/killbill/billing/account/api/boilerplate/AccountUserApiImp.java
@@ -1,0 +1,150 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.account.api.AccountApiException;
+import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.account.api.AccountEmail;
+import org.killbill.billing.account.api.AccountUserApi;
+import org.killbill.billing.util.api.AuditLevel;
+import org.killbill.billing.util.audit.AuditLogWithHistory;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.entity.Pagination;
+
+@JsonDeserialize( builder = AccountUserApiImp.Builder.class )
+public class AccountUserApiImp implements AccountUserApi, Serializable {
+
+    private static final long serialVersionUID = 0xC633864CD6FD2567L;
+
+
+    public AccountUserApiImp(final AccountUserApiImp that) {
+    }
+    protected AccountUserApiImp(final AccountUserApiImp.Builder<?> builder) {
+    }
+    protected AccountUserApiImp() { }
+    @Override
+    public Account getAccountById(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccountById(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void updateAccount(final UUID accountId, final AccountData accountData, final CallContext context) {
+        throw new UnsupportedOperationException("updateAccount(java.util.UUID, org.killbill.billing.account.api.AccountData, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<Account> getChildrenAccounts(final UUID parentAccountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getChildrenAccounts(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AccountEmail> getEmails(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getEmails(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getEmailAuditLogsWithHistoryForId(final UUID accountEmailId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getEmailAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void addEmail(final UUID accountId, final AccountEmail email, final CallContext context) {
+        throw new UnsupportedOperationException("addEmail(java.util.UUID, org.killbill.billing.account.api.AccountEmail, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void updateAccount(final String key, final AccountData accountData, final CallContext context) {
+        throw new UnsupportedOperationException("updateAccount(java.lang.String, org.killbill.billing.account.api.AccountData, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public UUID getIdFromKey(final String externalKey, final TenantContext context) {
+        throw new UnsupportedOperationException("getIdFromKey(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Account getAccountByKey(final String key, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccountByKey(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getAuditLogsWithHistoryForId(final UUID accountId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void removeEmail(final UUID accountId, final AccountEmail email, final CallContext context) {
+        throw new UnsupportedOperationException("removeEmail(java.util.UUID, org.killbill.billing.account.api.AccountEmail, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Account> searchAccounts(final String searchKey, final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("searchAccounts(java.lang.String, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Account> getAccounts(final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccounts(java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void updateAccount(final Account account, final CallContext context) {
+        throw new UnsupportedOperationException("updateAccount(org.killbill.billing.account.api.Account, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Account createAccount(final AccountData data, final CallContext context) {
+        throw new UnsupportedOperationException("createAccount(org.killbill.billing.account.api.AccountData, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AccountUserApiImp that = (AccountUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AccountUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final AccountUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AccountUserApiImp build() {
+            return new AccountUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/account/api/boilerplate/ImmutableAccountDataImp.java
+++ b/src/main/java/org/killbill/billing/account/api/boilerplate/ImmutableAccountDataImp.java
@@ -1,0 +1,207 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.killbill.billing.account.api.ImmutableAccountData;
+import org.killbill.billing.catalog.api.Currency;
+
+@JsonDeserialize( builder = ImmutableAccountDataImp.Builder.class )
+public class ImmutableAccountDataImp implements ImmutableAccountData, Serializable {
+
+    private static final long serialVersionUID = 0x2FDAB7550B03310EL;
+
+    protected Currency currency;
+    protected String externalKey;
+    protected DateTimeZone fixedOffsetTimeZone;
+    protected UUID id;
+    protected DateTime referenceTime;
+    protected DateTimeZone timeZone;
+
+    public ImmutableAccountDataImp(final ImmutableAccountDataImp that) {
+        this.currency = that.currency;
+        this.externalKey = that.externalKey;
+        this.fixedOffsetTimeZone = that.fixedOffsetTimeZone;
+        this.id = that.id;
+        this.referenceTime = that.referenceTime;
+        this.timeZone = that.timeZone;
+    }
+    protected ImmutableAccountDataImp(final ImmutableAccountDataImp.Builder<?> builder) {
+        this.currency = builder.currency;
+        this.externalKey = builder.externalKey;
+        this.fixedOffsetTimeZone = builder.fixedOffsetTimeZone;
+        this.id = builder.id;
+        this.referenceTime = builder.referenceTime;
+        this.timeZone = builder.timeZone;
+    }
+    protected ImmutableAccountDataImp() { }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public DateTimeZone getFixedOffsetTimeZone() {
+        return this.fixedOffsetTimeZone;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public DateTime getReferenceTime() {
+        return this.referenceTime;
+    }
+    @Override
+    public DateTimeZone getTimeZone() {
+        return this.timeZone;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final ImmutableAccountDataImp that = (ImmutableAccountDataImp) o;
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fixedOffsetTimeZone, that.fixedOffsetTimeZone) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( ( this.referenceTime != null ) ? ( 0 != this.referenceTime.compareTo(that.referenceTime) ) : ( that.referenceTime != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.timeZone, that.timeZone) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.fixedOffsetTimeZone);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.referenceTime);
+        result = ( 31 * result ) + Objects.hashCode(this.timeZone);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("fixedOffsetTimeZone=").append(this.fixedOffsetTimeZone);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("referenceTime=").append(this.referenceTime);
+        sb.append(", ");
+        sb.append("timeZone=").append(this.timeZone);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends ImmutableAccountDataImp.Builder<T>> {
+
+        protected Currency currency;
+        protected String externalKey;
+        protected DateTimeZone fixedOffsetTimeZone;
+        protected UUID id;
+        protected DateTime referenceTime;
+        protected DateTimeZone timeZone;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.currency = that.currency;
+            this.externalKey = that.externalKey;
+            this.fixedOffsetTimeZone = that.fixedOffsetTimeZone;
+            this.id = that.id;
+            this.referenceTime = that.referenceTime;
+            this.timeZone = that.timeZone;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withFixedOffsetTimeZone(final DateTimeZone fixedOffsetTimeZone) {
+            this.fixedOffsetTimeZone = fixedOffsetTimeZone;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withReferenceTime(final DateTime referenceTime) {
+            this.referenceTime = referenceTime;
+            return (T) this;
+        }
+        public T withTimeZone(final DateTimeZone timeZone) {
+            this.timeZone = timeZone;
+            return (T) this;
+        }
+        public T source(final ImmutableAccountData that) {
+            this.currency = that.getCurrency();
+            this.externalKey = that.getExternalKey();
+            this.fixedOffsetTimeZone = that.getFixedOffsetTimeZone();
+            this.id = that.getId();
+            this.referenceTime = that.getReferenceTime();
+            this.timeZone = that.getTimeZone();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public ImmutableAccountDataImp build() {
+            return new ImmutableAccountDataImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/account/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/account/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.account.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/account/api/boilerplate/MutableAccountDataImp.java
+++ b/src/main/java/org/killbill/billing/account/api/boilerplate/MutableAccountDataImp.java
@@ -1,0 +1,677 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.killbill.billing.account.api.MutableAccountData;
+import org.killbill.billing.catalog.api.Currency;
+
+@JsonDeserialize( builder = MutableAccountDataImp.Builder.class )
+public class MutableAccountDataImp implements MutableAccountData, Serializable {
+
+    private static final long serialVersionUID = 0xD26E53FB34A75489L;
+
+    protected String address1;
+    protected String address2;
+    protected Integer billCycleDayLocal;
+    protected String city;
+    protected String companyName;
+    protected String country;
+    protected Currency currency;
+    protected String email;
+    protected String externalKey;
+    protected Integer firstNameLength;
+    protected Boolean isMigrated;
+    protected Boolean isPaymentDelegatedToParent;
+    protected String locale;
+    protected String name;
+    protected String notes;
+    protected UUID parentAccountId;
+    protected UUID paymentMethodId;
+    protected String phone;
+    protected String postalCode;
+    protected DateTime referenceTime;
+    protected String stateOrProvince;
+    protected DateTimeZone timeZone;
+
+    public MutableAccountDataImp(final MutableAccountDataImp that) {
+        this.address1 = that.address1;
+        this.address2 = that.address2;
+        this.billCycleDayLocal = that.billCycleDayLocal;
+        this.city = that.city;
+        this.companyName = that.companyName;
+        this.country = that.country;
+        this.currency = that.currency;
+        this.email = that.email;
+        this.externalKey = that.externalKey;
+        this.firstNameLength = that.firstNameLength;
+        this.isMigrated = that.isMigrated;
+        this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent;
+        this.locale = that.locale;
+        this.name = that.name;
+        this.notes = that.notes;
+        this.parentAccountId = that.parentAccountId;
+        this.paymentMethodId = that.paymentMethodId;
+        this.phone = that.phone;
+        this.postalCode = that.postalCode;
+        this.referenceTime = that.referenceTime;
+        this.stateOrProvince = that.stateOrProvince;
+        this.timeZone = that.timeZone;
+    }
+    protected MutableAccountDataImp(final MutableAccountDataImp.Builder<?> builder) {
+        this.address1 = builder.address1;
+        this.address2 = builder.address2;
+        this.billCycleDayLocal = builder.billCycleDayLocal;
+        this.city = builder.city;
+        this.companyName = builder.companyName;
+        this.country = builder.country;
+        this.currency = builder.currency;
+        this.email = builder.email;
+        this.externalKey = builder.externalKey;
+        this.firstNameLength = builder.firstNameLength;
+        this.isMigrated = builder.isMigrated;
+        this.isPaymentDelegatedToParent = builder.isPaymentDelegatedToParent;
+        this.locale = builder.locale;
+        this.name = builder.name;
+        this.notes = builder.notes;
+        this.parentAccountId = builder.parentAccountId;
+        this.paymentMethodId = builder.paymentMethodId;
+        this.phone = builder.phone;
+        this.postalCode = builder.postalCode;
+        this.referenceTime = builder.referenceTime;
+        this.stateOrProvince = builder.stateOrProvince;
+        this.timeZone = builder.timeZone;
+    }
+    protected MutableAccountDataImp() { }
+    @Override
+    public String getAddress1() {
+        return this.address1;
+    }
+    @Override
+    public void setAddress1(final String address1) {
+        this.address1 = address1;
+    }
+    @Override
+    public String getAddress2() {
+        return this.address2;
+    }
+    @Override
+    public void setAddress2(final String address2) {
+        this.address2 = address2;
+    }
+    @Override
+    public Integer getBillCycleDayLocal() {
+        return this.billCycleDayLocal;
+    }
+    @Override
+    public void setBillCycleDayLocal(final int billCycleDayLocal) {
+        this.billCycleDayLocal = billCycleDayLocal;
+    }
+    @Override
+    public String getCity() {
+        return this.city;
+    }
+    @Override
+    public void setCity(final String city) {
+        this.city = city;
+    }
+    @Override
+    public String getCompanyName() {
+        return this.companyName;
+    }
+    @Override
+    public void setCompanyName(final String companyName) {
+        this.companyName = companyName;
+    }
+    @Override
+    public String getCountry() {
+        return this.country;
+    }
+    @Override
+    public void setCountry(final String country) {
+        this.country = country;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public void setCurrency(final Currency currency) {
+        this.currency = currency;
+    }
+    @Override
+    public String getEmail() {
+        return this.email;
+    }
+    @Override
+    public void setEmail(final String email) {
+        this.email = email;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public void setExternalKey(final String externalKey) {
+        this.externalKey = externalKey;
+    }
+    @Override
+    public Integer getFirstNameLength() {
+        return this.firstNameLength;
+    }
+    @Override
+    public void setFirstNameLength(final int firstNameLength) {
+        this.firstNameLength = firstNameLength;
+    }
+    @Override
+    @JsonGetter("isMigrated")
+    public Boolean isMigrated() {
+        return this.isMigrated;
+    }
+    @Override
+    public void setIsMigrated(final boolean isMigrated) {
+        this.isMigrated = isMigrated;
+    }
+    @Override
+    @JsonGetter("isPaymentDelegatedToParent")
+    public Boolean isPaymentDelegatedToParent() {
+        return this.isPaymentDelegatedToParent;
+    }
+    @Override
+    public void setIsPaymentDelegatedToParent(final boolean isPaymentDelegatedToParent) {
+        this.isPaymentDelegatedToParent = isPaymentDelegatedToParent;
+    }
+    @Override
+    public String getLocale() {
+        return this.locale;
+    }
+    @Override
+    public void setLocale(final String locale) {
+        this.locale = locale;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public void setName(final String name) {
+        this.name = name;
+    }
+    @Override
+    public String getNotes() {
+        return this.notes;
+    }
+    @Override
+    public void setNotes(final String notes) {
+        this.notes = notes;
+    }
+    @Override
+    public UUID getParentAccountId() {
+        return this.parentAccountId;
+    }
+    @Override
+    public void setParentAccountId(final UUID parentAccountId) {
+        this.parentAccountId = parentAccountId;
+    }
+    @Override
+    public UUID getPaymentMethodId() {
+        return this.paymentMethodId;
+    }
+    @Override
+    public void setPaymentMethodId(final UUID paymentMethodId) {
+        this.paymentMethodId = paymentMethodId;
+    }
+    @Override
+    public String getPhone() {
+        return this.phone;
+    }
+    @Override
+    public void setPhone(final String phone) {
+        this.phone = phone;
+    }
+    @Override
+    public String getPostalCode() {
+        return this.postalCode;
+    }
+    @Override
+    public void setPostalCode(final String postalCode) {
+        this.postalCode = postalCode;
+    }
+    @Override
+    public DateTime getReferenceTime() {
+        return this.referenceTime;
+    }
+    @Override
+    public void setReferenceTime(final DateTime referenceTime) {
+        this.referenceTime = referenceTime;
+    }
+    @Override
+    public String getStateOrProvince() {
+        return this.stateOrProvince;
+    }
+    @Override
+    public void setStateOrProvince(final String stateOrProvince) {
+        this.stateOrProvince = stateOrProvince;
+    }
+    @Override
+    public DateTimeZone getTimeZone() {
+        return this.timeZone;
+    }
+    @Override
+    public void setTimeZone(final DateTimeZone timeZone) {
+        this.timeZone = timeZone;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final MutableAccountDataImp that = (MutableAccountDataImp) o;
+        if( !Objects.equals(this.address1, that.address1) ) {
+            return false;
+        }
+        if( !Objects.equals(this.address2, that.address2) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billCycleDayLocal, that.billCycleDayLocal) ) {
+            return false;
+        }
+        if( !Objects.equals(this.city, that.city) ) {
+            return false;
+        }
+        if( !Objects.equals(this.companyName, that.companyName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.country, that.country) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.email, that.email) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.firstNameLength, that.firstNameLength) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isMigrated, that.isMigrated) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isPaymentDelegatedToParent, that.isPaymentDelegatedToParent) ) {
+            return false;
+        }
+        if( !Objects.equals(this.locale, that.locale) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.notes, that.notes) ) {
+            return false;
+        }
+        if( !Objects.equals(this.parentAccountId, that.parentAccountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentMethodId, that.paymentMethodId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phone, that.phone) ) {
+            return false;
+        }
+        if( !Objects.equals(this.postalCode, that.postalCode) ) {
+            return false;
+        }
+        if( ( this.referenceTime != null ) ? ( 0 != this.referenceTime.compareTo(that.referenceTime) ) : ( that.referenceTime != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.stateOrProvince, that.stateOrProvince) ) {
+            return false;
+        }
+        if( !Objects.equals(this.timeZone, that.timeZone) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.address1);
+        result = ( 31 * result ) + Objects.hashCode(this.address2);
+        result = ( 31 * result ) + Objects.hashCode(this.billCycleDayLocal);
+        result = ( 31 * result ) + Objects.hashCode(this.city);
+        result = ( 31 * result ) + Objects.hashCode(this.companyName);
+        result = ( 31 * result ) + Objects.hashCode(this.country);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.email);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.firstNameLength);
+        result = ( 31 * result ) + Objects.hashCode(this.isMigrated);
+        result = ( 31 * result ) + Objects.hashCode(this.isPaymentDelegatedToParent);
+        result = ( 31 * result ) + Objects.hashCode(this.locale);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.notes);
+        result = ( 31 * result ) + Objects.hashCode(this.parentAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentMethodId);
+        result = ( 31 * result ) + Objects.hashCode(this.phone);
+        result = ( 31 * result ) + Objects.hashCode(this.postalCode);
+        result = ( 31 * result ) + Objects.hashCode(this.referenceTime);
+        result = ( 31 * result ) + Objects.hashCode(this.stateOrProvince);
+        result = ( 31 * result ) + Objects.hashCode(this.timeZone);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("address1=");
+        if( this.address1 == null ) {
+            sb.append(this.address1);
+        }else{
+            sb.append("'").append(this.address1).append("'");
+        }
+        sb.append(", ");
+        sb.append("address2=");
+        if( this.address2 == null ) {
+            sb.append(this.address2);
+        }else{
+            sb.append("'").append(this.address2).append("'");
+        }
+        sb.append(", ");
+        sb.append("billCycleDayLocal=").append(this.billCycleDayLocal);
+        sb.append(", ");
+        sb.append("city=");
+        if( this.city == null ) {
+            sb.append(this.city);
+        }else{
+            sb.append("'").append(this.city).append("'");
+        }
+        sb.append(", ");
+        sb.append("companyName=");
+        if( this.companyName == null ) {
+            sb.append(this.companyName);
+        }else{
+            sb.append("'").append(this.companyName).append("'");
+        }
+        sb.append(", ");
+        sb.append("country=");
+        if( this.country == null ) {
+            sb.append(this.country);
+        }else{
+            sb.append("'").append(this.country).append("'");
+        }
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("email=");
+        if( this.email == null ) {
+            sb.append(this.email);
+        }else{
+            sb.append("'").append(this.email).append("'");
+        }
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("firstNameLength=").append(this.firstNameLength);
+        sb.append(", ");
+        sb.append("isMigrated=").append(this.isMigrated);
+        sb.append(", ");
+        sb.append("isPaymentDelegatedToParent=").append(this.isPaymentDelegatedToParent);
+        sb.append(", ");
+        sb.append("locale=");
+        if( this.locale == null ) {
+            sb.append(this.locale);
+        }else{
+            sb.append("'").append(this.locale).append("'");
+        }
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("notes=");
+        if( this.notes == null ) {
+            sb.append(this.notes);
+        }else{
+            sb.append("'").append(this.notes).append("'");
+        }
+        sb.append(", ");
+        sb.append("parentAccountId=").append(this.parentAccountId);
+        sb.append(", ");
+        sb.append("paymentMethodId=").append(this.paymentMethodId);
+        sb.append(", ");
+        sb.append("phone=");
+        if( this.phone == null ) {
+            sb.append(this.phone);
+        }else{
+            sb.append("'").append(this.phone).append("'");
+        }
+        sb.append(", ");
+        sb.append("postalCode=");
+        if( this.postalCode == null ) {
+            sb.append(this.postalCode);
+        }else{
+            sb.append("'").append(this.postalCode).append("'");
+        }
+        sb.append(", ");
+        sb.append("referenceTime=").append(this.referenceTime);
+        sb.append(", ");
+        sb.append("stateOrProvince=");
+        if( this.stateOrProvince == null ) {
+            sb.append(this.stateOrProvince);
+        }else{
+            sb.append("'").append(this.stateOrProvince).append("'");
+        }
+        sb.append(", ");
+        sb.append("timeZone=").append(this.timeZone);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends MutableAccountDataImp.Builder<T>> {
+
+        protected String address1;
+        protected String address2;
+        protected Integer billCycleDayLocal;
+        protected String city;
+        protected String companyName;
+        protected String country;
+        protected Currency currency;
+        protected String email;
+        protected String externalKey;
+        protected Integer firstNameLength;
+        protected Boolean isMigrated;
+        protected Boolean isPaymentDelegatedToParent;
+        protected String locale;
+        protected String name;
+        protected String notes;
+        protected UUID parentAccountId;
+        protected UUID paymentMethodId;
+        protected String phone;
+        protected String postalCode;
+        protected DateTime referenceTime;
+        protected String stateOrProvince;
+        protected DateTimeZone timeZone;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.address1 = that.address1;
+            this.address2 = that.address2;
+            this.billCycleDayLocal = that.billCycleDayLocal;
+            this.city = that.city;
+            this.companyName = that.companyName;
+            this.country = that.country;
+            this.currency = that.currency;
+            this.email = that.email;
+            this.externalKey = that.externalKey;
+            this.firstNameLength = that.firstNameLength;
+            this.isMigrated = that.isMigrated;
+            this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent;
+            this.locale = that.locale;
+            this.name = that.name;
+            this.notes = that.notes;
+            this.parentAccountId = that.parentAccountId;
+            this.paymentMethodId = that.paymentMethodId;
+            this.phone = that.phone;
+            this.postalCode = that.postalCode;
+            this.referenceTime = that.referenceTime;
+            this.stateOrProvince = that.stateOrProvince;
+            this.timeZone = that.timeZone;
+        }
+        public T withAddress1(final String address1) {
+            this.address1 = address1;
+            return (T) this;
+        }
+        public T withAddress2(final String address2) {
+            this.address2 = address2;
+            return (T) this;
+        }
+        public T withBillCycleDayLocal(final Integer billCycleDayLocal) {
+            this.billCycleDayLocal = billCycleDayLocal;
+            return (T) this;
+        }
+        public T withCity(final String city) {
+            this.city = city;
+            return (T) this;
+        }
+        public T withCompanyName(final String companyName) {
+            this.companyName = companyName;
+            return (T) this;
+        }
+        public T withCountry(final String country) {
+            this.country = country;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withEmail(final String email) {
+            this.email = email;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withFirstNameLength(final Integer firstNameLength) {
+            this.firstNameLength = firstNameLength;
+            return (T) this;
+        }
+        public T withIsMigrated(final Boolean isMigrated) {
+            this.isMigrated = isMigrated;
+            return (T) this;
+        }
+        public T withIsPaymentDelegatedToParent(final Boolean isPaymentDelegatedToParent) {
+            this.isPaymentDelegatedToParent = isPaymentDelegatedToParent;
+            return (T) this;
+        }
+        public T withLocale(final String locale) {
+            this.locale = locale;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withNotes(final String notes) {
+            this.notes = notes;
+            return (T) this;
+        }
+        public T withParentAccountId(final UUID parentAccountId) {
+            this.parentAccountId = parentAccountId;
+            return (T) this;
+        }
+        public T withPaymentMethodId(final UUID paymentMethodId) {
+            this.paymentMethodId = paymentMethodId;
+            return (T) this;
+        }
+        public T withPhone(final String phone) {
+            this.phone = phone;
+            return (T) this;
+        }
+        public T withPostalCode(final String postalCode) {
+            this.postalCode = postalCode;
+            return (T) this;
+        }
+        public T withReferenceTime(final DateTime referenceTime) {
+            this.referenceTime = referenceTime;
+            return (T) this;
+        }
+        public T withStateOrProvince(final String stateOrProvince) {
+            this.stateOrProvince = stateOrProvince;
+            return (T) this;
+        }
+        public T withTimeZone(final DateTimeZone timeZone) {
+            this.timeZone = timeZone;
+            return (T) this;
+        }
+        public T source(final MutableAccountData that) {
+            this.address1 = that.getAddress1();
+            this.address2 = that.getAddress2();
+            this.billCycleDayLocal = that.getBillCycleDayLocal();
+            this.city = that.getCity();
+            this.companyName = that.getCompanyName();
+            this.country = that.getCountry();
+            this.currency = that.getCurrency();
+            this.email = that.getEmail();
+            this.externalKey = that.getExternalKey();
+            this.firstNameLength = that.getFirstNameLength();
+            this.isMigrated = that.isMigrated();
+            this.isPaymentDelegatedToParent = that.isPaymentDelegatedToParent();
+            this.locale = that.getLocale();
+            this.name = that.getName();
+            this.notes = that.getNotes();
+            this.parentAccountId = that.getParentAccountId();
+            this.paymentMethodId = that.getPaymentMethodId();
+            this.phone = that.getPhone();
+            this.postalCode = that.getPostalCode();
+            this.referenceTime = that.getReferenceTime();
+            this.stateOrProvince = that.getStateOrProvince();
+            this.timeZone = that.getTimeZone();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public MutableAccountDataImp build() {
+            return new MutableAccountDataImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/account/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/account/api/boilerplate/Resolver.java
@@ -1,0 +1,37 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.account.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.account.api.AccountEmail;
+import org.killbill.billing.account.api.AccountUserApi;
+import org.killbill.billing.account.api.ImmutableAccountData;
+import org.killbill.billing.account.api.MutableAccountData;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(AccountData.class, AccountDataImp.class);
+        this.addMapping(AccountEmail.class, AccountEmailImp.class);
+        this.addMapping(Account.class, AccountImp.class);
+        this.addMapping(AccountUserApi.class, AccountUserApiImp.class);
+        this.addMapping(ImmutableAccountData.class, ImmutableAccountDataImp.class);
+        this.addMapping(MutableAccountData.class, MutableAccountDataImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/boilerplate/KillbillApiImp.java
+++ b/src/main/java/org/killbill/billing/boilerplate/KillbillApiImp.java
@@ -1,0 +1,79 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.KillbillApi;
+
+@JsonDeserialize( builder = KillbillApiImp.Builder.class )
+public class KillbillApiImp implements KillbillApi, Serializable {
+
+    private static final long serialVersionUID = 0x20A7341610C22B78L;
+
+
+    public KillbillApiImp(final KillbillApiImp that) {
+    }
+    protected KillbillApiImp(final KillbillApiImp.Builder<?> builder) {
+    }
+    protected KillbillApiImp() { }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final KillbillApiImp that = (KillbillApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends KillbillApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final KillbillApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public KillbillApiImp build() {
+            return new KillbillApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/boilerplate/Resolver.java
@@ -1,0 +1,27 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.KillbillApi;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(KillbillApi.class, KillbillApiImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/BlockImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/BlockImp.java
@@ -1,0 +1,182 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Block;
+import org.killbill.billing.catalog.api.BlockType;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.InternationalPrice;
+import org.killbill.billing.catalog.api.Unit;
+
+@JsonDeserialize( builder = BlockImp.Builder.class )
+public class BlockImp implements Block, Serializable {
+
+    private static final long serialVersionUID = 0xDA423D317BA66755L;
+
+    protected Double minTopUpCredit;
+    protected InternationalPrice price;
+    protected Double size;
+    protected BlockType type;
+    protected Unit unit;
+
+    public BlockImp(final BlockImp that) {
+        this.minTopUpCredit = that.minTopUpCredit;
+        this.price = that.price;
+        this.size = that.size;
+        this.type = that.type;
+        this.unit = that.unit;
+    }
+    protected BlockImp(final BlockImp.Builder<?> builder) {
+        this.minTopUpCredit = builder.minTopUpCredit;
+        this.price = builder.price;
+        this.size = builder.size;
+        this.type = builder.type;
+        this.unit = builder.unit;
+    }
+    protected BlockImp() { }
+    @Override
+    public Double getMinTopUpCredit() {
+        return this.minTopUpCredit;
+    }
+    @Override
+    public InternationalPrice getPrice() {
+        return this.price;
+    }
+    @Override
+    public Double getSize() {
+        return this.size;
+    }
+    @Override
+    public BlockType getType() {
+        return this.type;
+    }
+    @Override
+    public Unit getUnit() {
+        return this.unit;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final BlockImp that = (BlockImp) o;
+        if( !Objects.equals(this.minTopUpCredit, that.minTopUpCredit) ) {
+            return false;
+        }
+        if( !Objects.equals(this.price, that.price) ) {
+            return false;
+        }
+        if( !Objects.equals(this.size, that.size) ) {
+            return false;
+        }
+        if( !Objects.equals(this.type, that.type) ) {
+            return false;
+        }
+        if( !Objects.equals(this.unit, that.unit) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.minTopUpCredit);
+        result = ( 31 * result ) + Objects.hashCode(this.price);
+        result = ( 31 * result ) + Objects.hashCode(this.size);
+        result = ( 31 * result ) + Objects.hashCode(this.type);
+        result = ( 31 * result ) + Objects.hashCode(this.unit);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("minTopUpCredit=").append(this.minTopUpCredit);
+        sb.append(", ");
+        sb.append("price=").append(this.price);
+        sb.append(", ");
+        sb.append("size=").append(this.size);
+        sb.append(", ");
+        sb.append("type=").append(this.type);
+        sb.append(", ");
+        sb.append("unit=").append(this.unit);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends BlockImp.Builder<T>> {
+
+        protected Double minTopUpCredit;
+        protected InternationalPrice price;
+        protected Double size;
+        protected BlockType type;
+        protected Unit unit;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.minTopUpCredit = that.minTopUpCredit;
+            this.price = that.price;
+            this.size = that.size;
+            this.type = that.type;
+            this.unit = that.unit;
+        }
+        public T withMinTopUpCredit(final Double minTopUpCredit) {
+            this.minTopUpCredit = minTopUpCredit;
+            return (T) this;
+        }
+        public T withPrice(final InternationalPrice price) {
+            this.price = price;
+            return (T) this;
+        }
+        public T withSize(final Double size) {
+            this.size = size;
+            return (T) this;
+        }
+        public T withType(final BlockType type) {
+            this.type = type;
+            return (T) this;
+        }
+        public T withUnit(final Unit unit) {
+            this.unit = unit;
+            return (T) this;
+        }
+        public T source(final Block that) throws CatalogApiException {
+            this.minTopUpCredit = that.getMinTopUpCredit();
+            this.price = that.getPrice();
+            this.size = that.getSize();
+            this.type = that.getType();
+            this.unit = that.getUnit();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public BlockImp build() {
+            return new BlockImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/BlockPriceOverrideImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/BlockPriceOverrideImp.java
@@ -1,0 +1,165 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BlockPriceOverride;
+import org.killbill.billing.catalog.api.Currency;
+
+@JsonDeserialize( builder = BlockPriceOverrideImp.Builder.class )
+public class BlockPriceOverrideImp implements BlockPriceOverride, Serializable {
+
+    private static final long serialVersionUID = 0x3D35C7641AB97F04L;
+
+    protected Currency currency;
+    protected BigDecimal price;
+    protected Double size;
+    protected String unitName;
+
+    public BlockPriceOverrideImp(final BlockPriceOverrideImp that) {
+        this.currency = that.currency;
+        this.price = that.price;
+        this.size = that.size;
+        this.unitName = that.unitName;
+    }
+    protected BlockPriceOverrideImp(final BlockPriceOverrideImp.Builder<?> builder) {
+        this.currency = builder.currency;
+        this.price = builder.price;
+        this.size = builder.size;
+        this.unitName = builder.unitName;
+    }
+    protected BlockPriceOverrideImp() { }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public BigDecimal getPrice() {
+        return this.price;
+    }
+    @Override
+    public Double getSize() {
+        return this.size;
+    }
+    @Override
+    public String getUnitName() {
+        return this.unitName;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final BlockPriceOverrideImp that = (BlockPriceOverrideImp) o;
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( ( this.price != null ) ? ( 0 != this.price.compareTo(that.price) ) : ( that.price != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.size, that.size) ) {
+            return false;
+        }
+        if( !Objects.equals(this.unitName, that.unitName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.price);
+        result = ( 31 * result ) + Objects.hashCode(this.size);
+        result = ( 31 * result ) + Objects.hashCode(this.unitName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("price=").append(this.price);
+        sb.append(", ");
+        sb.append("size=").append(this.size);
+        sb.append(", ");
+        sb.append("unitName=");
+        if( this.unitName == null ) {
+            sb.append(this.unitName);
+        }else{
+            sb.append("'").append(this.unitName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends BlockPriceOverrideImp.Builder<T>> {
+
+        protected Currency currency;
+        protected BigDecimal price;
+        protected Double size;
+        protected String unitName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.currency = that.currency;
+            this.price = that.price;
+            this.size = that.size;
+            this.unitName = that.unitName;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withPrice(final BigDecimal price) {
+            this.price = price;
+            return (T) this;
+        }
+        public T withSize(final Double size) {
+            this.size = size;
+            return (T) this;
+        }
+        public T withUnitName(final String unitName) {
+            this.unitName = unitName;
+            return (T) this;
+        }
+        public T source(final BlockPriceOverride that) {
+            this.currency = that.getCurrency();
+            this.price = that.getPrice();
+            this.size = that.getSize();
+            this.unitName = that.getUnitName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public BlockPriceOverrideImp build() {
+            return new BlockPriceOverrideImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/CatalogEntityImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/CatalogEntityImp.java
@@ -1,0 +1,128 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.CatalogEntity;
+
+@JsonDeserialize( builder = CatalogEntityImp.Builder.class )
+public class CatalogEntityImp implements CatalogEntity, Serializable {
+
+    private static final long serialVersionUID = 0x1EAEAFBDB03087E2L;
+
+    protected String name;
+    protected String prettyName;
+
+    public CatalogEntityImp(final CatalogEntityImp that) {
+        this.name = that.name;
+        this.prettyName = that.prettyName;
+    }
+    protected CatalogEntityImp(final CatalogEntityImp.Builder<?> builder) {
+        this.name = builder.name;
+        this.prettyName = builder.prettyName;
+    }
+    protected CatalogEntityImp() { }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public String getPrettyName() {
+        return this.prettyName;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CatalogEntityImp that = (CatalogEntityImp) o;
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyName, that.prettyName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyName=");
+        if( this.prettyName == null ) {
+            sb.append(this.prettyName);
+        }else{
+            sb.append("'").append(this.prettyName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CatalogEntityImp.Builder<T>> {
+
+        protected String name;
+        protected String prettyName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.name = that.name;
+            this.prettyName = that.prettyName;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withPrettyName(final String prettyName) {
+            this.prettyName = prettyName;
+            return (T) this;
+        }
+        public T source(final CatalogEntity that) {
+            this.name = that.getName();
+            this.prettyName = that.getPrettyName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CatalogEntityImp build() {
+            return new CatalogEntityImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/CatalogUserApiImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/CatalogUserApiImp.java
@@ -1,0 +1,110 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.CatalogUserApi;
+import org.killbill.billing.catalog.api.SimplePlanDescriptor;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = CatalogUserApiImp.Builder.class )
+public class CatalogUserApiImp implements CatalogUserApi, Serializable {
+
+    private static final long serialVersionUID = 0x3067F07C17AFFCFAL;
+
+
+    public CatalogUserApiImp(final CatalogUserApiImp that) {
+    }
+    protected CatalogUserApiImp(final CatalogUserApiImp.Builder<?> builder) {
+    }
+    protected CatalogUserApiImp() { }
+    @Override
+    public void addSimplePlan(final SimplePlanDescriptor planDescriptor, final DateTime requestedDate, final CallContext context) {
+        throw new UnsupportedOperationException("addSimplePlan(org.killbill.billing.catalog.api.SimplePlanDescriptor, org.joda.time.DateTime, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public VersionedCatalog getCatalog(final String catalogName, final TenantContext context) {
+        throw new UnsupportedOperationException("getCatalog(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public StaticCatalog getCurrentCatalog(final String catalogName, final TenantContext context) {
+        throw new UnsupportedOperationException("getCurrentCatalog(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void createDefaultEmptyCatalog(final DateTime effectiveDate, final CallContext callContext) {
+        throw new UnsupportedOperationException("createDefaultEmptyCatalog(org.joda.time.DateTime, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void deleteCatalog(final CallContext callContext) {
+        throw new UnsupportedOperationException("deleteCatalog(org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void uploadCatalog(final String catalogXML, final CallContext context) {
+        throw new UnsupportedOperationException("uploadCatalog(java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CatalogUserApiImp that = (CatalogUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CatalogUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final CatalogUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CatalogUserApiImp build() {
+            return new CatalogUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/DurationImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/DurationImp.java
@@ -1,0 +1,135 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.Period;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.Duration;
+import org.killbill.billing.catalog.api.TimeUnit;
+
+@JsonDeserialize( builder = DurationImp.Builder.class )
+public class DurationImp implements Duration, Serializable {
+
+    private static final long serialVersionUID = 0x960B032F06518C3EL;
+
+    protected int number;
+    protected TimeUnit unit;
+
+    public DurationImp(final DurationImp that) {
+        this.number = that.number;
+        this.unit = that.unit;
+    }
+    protected DurationImp(final DurationImp.Builder<?> builder) {
+        this.number = builder.number;
+        this.unit = builder.unit;
+    }
+    protected DurationImp() { }
+    @Override
+    public int getNumber() {
+        return this.number;
+    }
+    @Override
+    public TimeUnit getUnit() {
+        return this.unit;
+    }
+    @Override
+    public LocalDate addToLocalDate(final LocalDate localDate) {
+        throw new UnsupportedOperationException("addToLocalDate(org.joda.time.LocalDate) must be implemented.");
+    }
+    @Override
+    public Period toJodaPeriod() {
+        throw new UnsupportedOperationException("toJodaPeriod() must be implemented.");
+    }
+    @Override
+    public DateTime addToDateTime(final DateTime dateTime) {
+        throw new UnsupportedOperationException("addToDateTime(org.joda.time.DateTime) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final DurationImp that = (DurationImp) o;
+        if( this.number != that.number ) {
+            return false;
+        }
+        if( !Objects.equals(this.unit, that.unit) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.number);
+        result = ( 31 * result ) + Objects.hashCode(this.unit);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("number=").append(this.number);
+        sb.append(", ");
+        sb.append("unit=").append(this.unit);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends DurationImp.Builder<T>> {
+
+        protected int number;
+        protected TimeUnit unit;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.number = that.number;
+            this.unit = that.unit;
+        }
+        public T withNumber(final int number) {
+            this.number = number;
+            return (T) this;
+        }
+        public T withUnit(final TimeUnit unit) {
+            this.unit = unit;
+            return (T) this;
+        }
+        public T source(final Duration that) {
+            this.number = that.getNumber();
+            this.unit = that.getUnit();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public DurationImp build() {
+            return new DurationImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/FixedImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/FixedImp.java
@@ -1,0 +1,120 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Fixed;
+import org.killbill.billing.catalog.api.FixedType;
+import org.killbill.billing.catalog.api.InternationalPrice;
+
+@JsonDeserialize( builder = FixedImp.Builder.class )
+public class FixedImp implements Fixed, Serializable {
+
+    private static final long serialVersionUID = 0xE56482B05D5C48E9L;
+
+    protected InternationalPrice price;
+    protected FixedType type;
+
+    public FixedImp(final FixedImp that) {
+        this.price = that.price;
+        this.type = that.type;
+    }
+    protected FixedImp(final FixedImp.Builder<?> builder) {
+        this.price = builder.price;
+        this.type = builder.type;
+    }
+    protected FixedImp() { }
+    @Override
+    public InternationalPrice getPrice() {
+        return this.price;
+    }
+    @Override
+    public FixedType getType() {
+        return this.type;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final FixedImp that = (FixedImp) o;
+        if( !Objects.equals(this.price, that.price) ) {
+            return false;
+        }
+        if( !Objects.equals(this.type, that.type) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.price);
+        result = ( 31 * result ) + Objects.hashCode(this.type);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("price=").append(this.price);
+        sb.append(", ");
+        sb.append("type=").append(this.type);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends FixedImp.Builder<T>> {
+
+        protected InternationalPrice price;
+        protected FixedType type;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.price = that.price;
+            this.type = that.type;
+        }
+        public T withPrice(final InternationalPrice price) {
+            this.price = price;
+            return (T) this;
+        }
+        public T withType(final FixedType type) {
+            this.type = type;
+            return (T) this;
+        }
+        public T source(final Fixed that) {
+            this.price = that.getPrice();
+            this.type = that.getType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public FixedImp build() {
+            return new FixedImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/InternationalPriceImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/InternationalPriceImp.java
@@ -1,0 +1,127 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.catalog.api.InternationalPrice;
+import org.killbill.billing.catalog.api.Price;
+
+@JsonDeserialize( builder = InternationalPriceImp.Builder.class )
+public class InternationalPriceImp implements InternationalPrice, Serializable {
+
+    private static final long serialVersionUID = 0xF5CA9ADDE8F2DC3BL;
+
+    protected boolean isZero;
+    protected Price[] prices;
+
+    public InternationalPriceImp(final InternationalPriceImp that) {
+        this.isZero = that.isZero;
+        this.prices = that.prices;
+    }
+    protected InternationalPriceImp(final InternationalPriceImp.Builder<?> builder) {
+        this.isZero = builder.isZero;
+        this.prices = builder.prices;
+    }
+    protected InternationalPriceImp() { }
+    @Override
+    @JsonGetter("isZero")
+    public boolean isZero() {
+        return this.isZero;
+    }
+    @Override
+    public Price[] getPrices() {
+        return this.prices;
+    }
+    @Override
+    public BigDecimal getPrice(final Currency currency) {
+        throw new UnsupportedOperationException("getPrice(org.killbill.billing.catalog.api.Currency) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InternationalPriceImp that = (InternationalPriceImp) o;
+        if( this.isZero != that.isZero ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.prices, that.prices) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.isZero);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.prices);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("isZero=").append(this.isZero);
+        sb.append(", ");
+        sb.append("prices=").append(Arrays.toString(this.prices));
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InternationalPriceImp.Builder<T>> {
+
+        protected boolean isZero;
+        protected Price[] prices;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.isZero = that.isZero;
+            this.prices = that.prices;
+        }
+        public T withIsZero(final boolean isZero) {
+            this.isZero = isZero;
+            return (T) this;
+        }
+        public T withPrices(final Price[] prices) {
+            this.prices = prices;
+            return (T) this;
+        }
+        public T source(final InternationalPrice that) {
+            this.isZero = that.isZero();
+            this.prices = that.getPrices();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InternationalPriceImp build() {
+            return new InternationalPriceImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/LimitImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/LimitImp.java
@@ -1,0 +1,143 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Limit;
+import org.killbill.billing.catalog.api.Unit;
+
+@JsonDeserialize( builder = LimitImp.Builder.class )
+public class LimitImp implements Limit, Serializable {
+
+    private static final long serialVersionUID = 0xEDC0423E78E935EL;
+
+    protected Double max;
+    protected Double min;
+    protected Unit unit;
+
+    public LimitImp(final LimitImp that) {
+        this.max = that.max;
+        this.min = that.min;
+        this.unit = that.unit;
+    }
+    protected LimitImp(final LimitImp.Builder<?> builder) {
+        this.max = builder.max;
+        this.min = builder.min;
+        this.unit = builder.unit;
+    }
+    protected LimitImp() { }
+    @Override
+    public Double getMax() {
+        return this.max;
+    }
+    @Override
+    public Double getMin() {
+        return this.min;
+    }
+    @Override
+    public Unit getUnit() {
+        return this.unit;
+    }
+    @Override
+    public boolean compliesWith(final double value) {
+        throw new UnsupportedOperationException("compliesWith(double) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final LimitImp that = (LimitImp) o;
+        if( !Objects.equals(this.max, that.max) ) {
+            return false;
+        }
+        if( !Objects.equals(this.min, that.min) ) {
+            return false;
+        }
+        if( !Objects.equals(this.unit, that.unit) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.max);
+        result = ( 31 * result ) + Objects.hashCode(this.min);
+        result = ( 31 * result ) + Objects.hashCode(this.unit);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("max=").append(this.max);
+        sb.append(", ");
+        sb.append("min=").append(this.min);
+        sb.append(", ");
+        sb.append("unit=").append(this.unit);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends LimitImp.Builder<T>> {
+
+        protected Double max;
+        protected Double min;
+        protected Unit unit;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.max = that.max;
+            this.min = that.min;
+            this.unit = that.unit;
+        }
+        public T withMax(final Double max) {
+            this.max = max;
+            return (T) this;
+        }
+        public T withMin(final Double min) {
+            this.min = min;
+            return (T) this;
+        }
+        public T withUnit(final Unit unit) {
+            this.unit = unit;
+            return (T) this;
+        }
+        public T source(final Limit that) {
+            this.max = that.getMax();
+            this.min = that.getMin();
+            this.unit = that.getUnit();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public LimitImp build() {
+            return new LimitImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/ListingImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/ListingImp.java
@@ -1,0 +1,120 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Listing;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PriceList;
+
+@JsonDeserialize( builder = ListingImp.Builder.class )
+public class ListingImp implements Listing, Serializable {
+
+    private static final long serialVersionUID = 0x2C0F0703EA4BBDB7L;
+
+    protected Plan plan;
+    protected PriceList priceList;
+
+    public ListingImp(final ListingImp that) {
+        this.plan = that.plan;
+        this.priceList = that.priceList;
+    }
+    protected ListingImp(final ListingImp.Builder<?> builder) {
+        this.plan = builder.plan;
+        this.priceList = builder.priceList;
+    }
+    protected ListingImp() { }
+    @Override
+    public Plan getPlan() {
+        return this.plan;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final ListingImp that = (ListingImp) o;
+        if( !Objects.equals(this.plan, that.plan) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.plan);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("plan=").append(this.plan);
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends ListingImp.Builder<T>> {
+
+        protected Plan plan;
+        protected PriceList priceList;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.plan = that.plan;
+            this.priceList = that.priceList;
+        }
+        public T withPlan(final Plan plan) {
+            this.plan = plan;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T source(final Listing that) {
+            this.plan = that.getPlan();
+            this.priceList = that.getPriceList();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public ListingImp build() {
+            return new ListingImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/MigrationPlanImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/MigrationPlanImp.java
@@ -1,0 +1,367 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Objects;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.BillingMode;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.MigrationPlan;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.StaticCatalog;
+
+@JsonDeserialize( builder = MigrationPlanImp.Builder.class )
+public class MigrationPlanImp implements MigrationPlan, Serializable {
+
+    private static final long serialVersionUID = 0xA54A95C4B62D73FCL;
+
+    protected PlanPhase[] allPhases;
+    protected StaticCatalog catalog;
+    protected Date effectiveDateForExistingSubscriptions;
+    protected PlanPhase finalPhase;
+    protected Iterator<PlanPhase> initialPhaseIterator;
+    protected PlanPhase[] initialPhases;
+    protected String name;
+    protected int plansAllowedInBundle;
+    protected String prettyName;
+    protected PriceList priceList;
+    protected Product product;
+    protected BillingMode recurringBillingMode;
+    protected BillingPeriod recurringBillingPeriod;
+
+    public MigrationPlanImp(final MigrationPlanImp that) {
+        this.allPhases = that.allPhases;
+        this.catalog = that.catalog;
+        this.effectiveDateForExistingSubscriptions = that.effectiveDateForExistingSubscriptions;
+        this.finalPhase = that.finalPhase;
+        this.initialPhaseIterator = that.initialPhaseIterator;
+        this.initialPhases = that.initialPhases;
+        this.name = that.name;
+        this.plansAllowedInBundle = that.plansAllowedInBundle;
+        this.prettyName = that.prettyName;
+        this.priceList = that.priceList;
+        this.product = that.product;
+        this.recurringBillingMode = that.recurringBillingMode;
+        this.recurringBillingPeriod = that.recurringBillingPeriod;
+    }
+    protected MigrationPlanImp(final MigrationPlanImp.Builder<?> builder) {
+        this.allPhases = builder.allPhases;
+        this.catalog = builder.catalog;
+        this.effectiveDateForExistingSubscriptions = builder.effectiveDateForExistingSubscriptions;
+        this.finalPhase = builder.finalPhase;
+        this.initialPhaseIterator = builder.initialPhaseIterator;
+        this.initialPhases = builder.initialPhases;
+        this.name = builder.name;
+        this.plansAllowedInBundle = builder.plansAllowedInBundle;
+        this.prettyName = builder.prettyName;
+        this.priceList = builder.priceList;
+        this.product = builder.product;
+        this.recurringBillingMode = builder.recurringBillingMode;
+        this.recurringBillingPeriod = builder.recurringBillingPeriod;
+    }
+    protected MigrationPlanImp() { }
+    @Override
+    public PlanPhase[] getAllPhases() {
+        return this.allPhases;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public Date getEffectiveDateForExistingSubscriptions() {
+        return this.effectiveDateForExistingSubscriptions;
+    }
+    @Override
+    public PlanPhase getFinalPhase() {
+        return this.finalPhase;
+    }
+    @Override
+    public Iterator<PlanPhase> getInitialPhaseIterator() {
+        return this.initialPhaseIterator;
+    }
+    @Override
+    public PlanPhase[] getInitialPhases() {
+        return this.initialPhases;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public int getPlansAllowedInBundle() {
+        return this.plansAllowedInBundle;
+    }
+    @Override
+    public String getPrettyName() {
+        return this.prettyName;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public Product getProduct() {
+        return this.product;
+    }
+    @Override
+    public BillingMode getRecurringBillingMode() {
+        return this.recurringBillingMode;
+    }
+    @Override
+    public BillingPeriod getRecurringBillingPeriod() {
+        return this.recurringBillingPeriod;
+    }
+    @Override
+    public DateTime dateOfFirstRecurringNonZeroCharge(final DateTime subscriptionStartDate, final PhaseType intialPhaseType) {
+        throw new UnsupportedOperationException("dateOfFirstRecurringNonZeroCharge(org.joda.time.DateTime, org.killbill.billing.catalog.api.PhaseType) must be implemented.");
+    }
+    @Override
+    public PlanPhase findPhase(final String name) {
+        throw new UnsupportedOperationException("findPhase(java.lang.String) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final MigrationPlanImp that = (MigrationPlanImp) o;
+        if( !Arrays.deepEquals(this.allPhases, that.allPhases) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.effectiveDateForExistingSubscriptions, that.effectiveDateForExistingSubscriptions) ) {
+            return false;
+        }
+        if( !Objects.equals(this.finalPhase, that.finalPhase) ) {
+            return false;
+        }
+        if( !Objects.equals(this.initialPhaseIterator, that.initialPhaseIterator) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.initialPhases, that.initialPhases) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( this.plansAllowedInBundle != that.plansAllowedInBundle ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyName, that.prettyName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.product, that.product) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recurringBillingMode, that.recurringBillingMode) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recurringBillingPeriod, that.recurringBillingPeriod) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Arrays.deepHashCode(this.allPhases);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDateForExistingSubscriptions);
+        result = ( 31 * result ) + Objects.hashCode(this.finalPhase);
+        result = ( 31 * result ) + Objects.hashCode(this.initialPhaseIterator);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.initialPhases);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.plansAllowedInBundle);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyName);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.product);
+        result = ( 31 * result ) + Objects.hashCode(this.recurringBillingMode);
+        result = ( 31 * result ) + Objects.hashCode(this.recurringBillingPeriod);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("allPhases=").append(Arrays.toString(this.allPhases));
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("effectiveDateForExistingSubscriptions=").append(this.effectiveDateForExistingSubscriptions);
+        sb.append(", ");
+        sb.append("finalPhase=").append(this.finalPhase);
+        sb.append(", ");
+        sb.append("initialPhaseIterator=").append(this.initialPhaseIterator);
+        sb.append(", ");
+        sb.append("initialPhases=").append(Arrays.toString(this.initialPhases));
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("plansAllowedInBundle=").append(this.plansAllowedInBundle);
+        sb.append(", ");
+        sb.append("prettyName=");
+        if( this.prettyName == null ) {
+            sb.append(this.prettyName);
+        }else{
+            sb.append("'").append(this.prettyName).append("'");
+        }
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append(", ");
+        sb.append("product=").append(this.product);
+        sb.append(", ");
+        sb.append("recurringBillingMode=").append(this.recurringBillingMode);
+        sb.append(", ");
+        sb.append("recurringBillingPeriod=").append(this.recurringBillingPeriod);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends MigrationPlanImp.Builder<T>> {
+
+        protected PlanPhase[] allPhases;
+        protected StaticCatalog catalog;
+        protected Date effectiveDateForExistingSubscriptions;
+        protected PlanPhase finalPhase;
+        protected Iterator<PlanPhase> initialPhaseIterator;
+        protected PlanPhase[] initialPhases;
+        protected String name;
+        protected int plansAllowedInBundle;
+        protected String prettyName;
+        protected PriceList priceList;
+        protected Product product;
+        protected BillingMode recurringBillingMode;
+        protected BillingPeriod recurringBillingPeriod;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.allPhases = that.allPhases;
+            this.catalog = that.catalog;
+            this.effectiveDateForExistingSubscriptions = that.effectiveDateForExistingSubscriptions;
+            this.finalPhase = that.finalPhase;
+            this.initialPhaseIterator = that.initialPhaseIterator;
+            this.initialPhases = that.initialPhases;
+            this.name = that.name;
+            this.plansAllowedInBundle = that.plansAllowedInBundle;
+            this.prettyName = that.prettyName;
+            this.priceList = that.priceList;
+            this.product = that.product;
+            this.recurringBillingMode = that.recurringBillingMode;
+            this.recurringBillingPeriod = that.recurringBillingPeriod;
+        }
+        public T withAllPhases(final PlanPhase[] allPhases) {
+            this.allPhases = allPhases;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withEffectiveDateForExistingSubscriptions(final Date effectiveDateForExistingSubscriptions) {
+            this.effectiveDateForExistingSubscriptions = effectiveDateForExistingSubscriptions;
+            return (T) this;
+        }
+        public T withFinalPhase(final PlanPhase finalPhase) {
+            this.finalPhase = finalPhase;
+            return (T) this;
+        }
+        public T withInitialPhaseIterator(final Iterator<PlanPhase> initialPhaseIterator) {
+            this.initialPhaseIterator = initialPhaseIterator;
+            return (T) this;
+        }
+        public T withInitialPhases(final PlanPhase[] initialPhases) {
+            this.initialPhases = initialPhases;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withPlansAllowedInBundle(final int plansAllowedInBundle) {
+            this.plansAllowedInBundle = plansAllowedInBundle;
+            return (T) this;
+        }
+        public T withPrettyName(final String prettyName) {
+            this.prettyName = prettyName;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProduct(final Product product) {
+            this.product = product;
+            return (T) this;
+        }
+        public T withRecurringBillingMode(final BillingMode recurringBillingMode) {
+            this.recurringBillingMode = recurringBillingMode;
+            return (T) this;
+        }
+        public T withRecurringBillingPeriod(final BillingPeriod recurringBillingPeriod) {
+            this.recurringBillingPeriod = recurringBillingPeriod;
+            return (T) this;
+        }
+        public T source(final MigrationPlan that) {
+            this.allPhases = that.getAllPhases();
+            this.catalog = that.getCatalog();
+            this.effectiveDateForExistingSubscriptions = that.getEffectiveDateForExistingSubscriptions();
+            this.finalPhase = that.getFinalPhase();
+            this.initialPhaseIterator = that.getInitialPhaseIterator();
+            this.initialPhases = that.getInitialPhases();
+            this.name = that.getName();
+            this.plansAllowedInBundle = that.getPlansAllowedInBundle();
+            this.prettyName = that.getPrettyName();
+            this.priceList = that.getPriceList();
+            this.product = that.getProduct();
+            this.recurringBillingMode = that.getRecurringBillingMode();
+            this.recurringBillingPeriod = that.getRecurringBillingPeriod();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public MigrationPlanImp build() {
+            return new MigrationPlanImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.catalog.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/MutableStaticCatalogImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/MutableStaticCatalogImp.java
@@ -1,0 +1,318 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.catalog.api.Listing;
+import org.killbill.billing.catalog.api.MutableStaticCatalog;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverridesWithCallContext;
+import org.killbill.billing.catalog.api.PlanSpecifier;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.PriceListSet;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.Unit;
+import org.killbill.billing.catalog.api.rules.PlanRules;
+
+@JsonDeserialize( builder = MutableStaticCatalogImp.Builder.class )
+public class MutableStaticCatalogImp implements MutableStaticCatalog, Serializable {
+
+    private static final long serialVersionUID = 0x12A4C42B079AD147L;
+
+    protected List<Listing> availableBasePlanListings;
+    protected String catalogName;
+    protected Date effectiveDate;
+    protected PlanRules planRules;
+    protected Collection<Plan> plans;
+    protected PriceListSet priceLists;
+    protected Collection<Product> products;
+    protected Currency[] supportedCurrencies;
+    protected Unit[] units;
+
+    public MutableStaticCatalogImp(final MutableStaticCatalogImp that) {
+        this.availableBasePlanListings = that.availableBasePlanListings;
+        this.catalogName = that.catalogName;
+        this.effectiveDate = that.effectiveDate;
+        this.planRules = that.planRules;
+        this.plans = that.plans;
+        this.priceLists = that.priceLists;
+        this.products = that.products;
+        this.supportedCurrencies = that.supportedCurrencies;
+        this.units = that.units;
+    }
+    protected MutableStaticCatalogImp(final MutableStaticCatalogImp.Builder<?> builder) {
+        this.availableBasePlanListings = builder.availableBasePlanListings;
+        this.catalogName = builder.catalogName;
+        this.effectiveDate = builder.effectiveDate;
+        this.planRules = builder.planRules;
+        this.plans = builder.plans;
+        this.priceLists = builder.priceLists;
+        this.products = builder.products;
+        this.supportedCurrencies = builder.supportedCurrencies;
+        this.units = builder.units;
+    }
+    protected MutableStaticCatalogImp() { }
+    @Override
+    public List<Listing> getAvailableBasePlanListings() {
+        return this.availableBasePlanListings;
+    }
+    @Override
+    public String getCatalogName() {
+        return this.catalogName;
+    }
+    @Override
+    public Date getEffectiveDate() {
+        return this.effectiveDate;
+    }
+    @Override
+    public PlanRules getPlanRules() {
+        return this.planRules;
+    }
+    @Override
+    public Collection<Plan> getPlans() {
+        return this.plans;
+    }
+    @Override
+    public PriceListSet getPriceLists() {
+        return this.priceLists;
+    }
+    @Override
+    public Collection<Product> getProducts() {
+        return this.products;
+    }
+    @Override
+    public Currency[] getSupportedCurrencies() {
+        return this.supportedCurrencies;
+    }
+    @Override
+    public Unit[] getUnits() {
+        return this.units;
+    }
+    @Override
+    public Plan findPlan(final String name) {
+        throw new UnsupportedOperationException("findPlan(java.lang.String) must be implemented.");
+    }
+    @Override
+    public Plan createOrFindPlan(final PlanSpecifier spec, final PlanPhasePriceOverridesWithCallContext overrides) {
+        throw new UnsupportedOperationException("createOrFindPlan(org.killbill.billing.catalog.api.PlanSpecifier, org.killbill.billing.catalog.api.PlanPhasePriceOverridesWithCallContext) must be implemented.");
+    }
+    @Override
+    public void addProduct(final Product product) {
+        throw new UnsupportedOperationException("addProduct(org.killbill.billing.catalog.api.Product) must be implemented.");
+    }
+    @Override
+    public List<Listing> getAvailableAddOnListings(final String baseProductName, final String priceListName) {
+        throw new UnsupportedOperationException("getAvailableAddOnListings(java.lang.String, java.lang.String) must be implemented.");
+    }
+    @Override
+    public void addPlan(final Plan plan) {
+        throw new UnsupportedOperationException("addPlan(org.killbill.billing.catalog.api.Plan) must be implemented.");
+    }
+    @Override
+    public Product findProduct(final String name) {
+        throw new UnsupportedOperationException("findProduct(java.lang.String) must be implemented.");
+    }
+    @Override
+    public PlanPhase findPhase(final String name) {
+        throw new UnsupportedOperationException("findPhase(java.lang.String) must be implemented.");
+    }
+    @Override
+    public void addCurrency(final Currency currency) {
+        throw new UnsupportedOperationException("addCurrency(org.killbill.billing.catalog.api.Currency) must be implemented.");
+    }
+    @Override
+    public PriceList findPriceList(final String name) {
+        throw new UnsupportedOperationException("findPriceList(java.lang.String) must be implemented.");
+    }
+    @Override
+    public void addPriceList(final PriceList priceList) {
+        throw new UnsupportedOperationException("addPriceList(org.killbill.billing.catalog.api.PriceList) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final MutableStaticCatalogImp that = (MutableStaticCatalogImp) o;
+        if( !Objects.equals(this.availableBasePlanListings, that.availableBasePlanListings) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalogName, that.catalogName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.effectiveDate, that.effectiveDate) ) {
+            return false;
+        }
+        if( !Objects.equals(this.planRules, that.planRules) ) {
+            return false;
+        }
+        if( !Objects.equals(this.plans, that.plans) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceLists, that.priceLists) ) {
+            return false;
+        }
+        if( !Objects.equals(this.products, that.products) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.supportedCurrencies, that.supportedCurrencies) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.units, that.units) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.availableBasePlanListings);
+        result = ( 31 * result ) + Objects.hashCode(this.catalogName);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.planRules);
+        result = ( 31 * result ) + Objects.hashCode(this.plans);
+        result = ( 31 * result ) + Objects.hashCode(this.priceLists);
+        result = ( 31 * result ) + Objects.hashCode(this.products);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.supportedCurrencies);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.units);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("availableBasePlanListings=").append(this.availableBasePlanListings);
+        sb.append(", ");
+        sb.append("catalogName=");
+        if( this.catalogName == null ) {
+            sb.append(this.catalogName);
+        }else{
+            sb.append("'").append(this.catalogName).append("'");
+        }
+        sb.append(", ");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("planRules=").append(this.planRules);
+        sb.append(", ");
+        sb.append("plans=").append(this.plans);
+        sb.append(", ");
+        sb.append("priceLists=").append(this.priceLists);
+        sb.append(", ");
+        sb.append("products=").append(this.products);
+        sb.append(", ");
+        sb.append("supportedCurrencies=").append(Arrays.toString(this.supportedCurrencies));
+        sb.append(", ");
+        sb.append("units=").append(Arrays.toString(this.units));
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends MutableStaticCatalogImp.Builder<T>> {
+
+        protected List<Listing> availableBasePlanListings;
+        protected String catalogName;
+        protected Date effectiveDate;
+        protected PlanRules planRules;
+        protected Collection<Plan> plans;
+        protected PriceListSet priceLists;
+        protected Collection<Product> products;
+        protected Currency[] supportedCurrencies;
+        protected Unit[] units;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.availableBasePlanListings = that.availableBasePlanListings;
+            this.catalogName = that.catalogName;
+            this.effectiveDate = that.effectiveDate;
+            this.planRules = that.planRules;
+            this.plans = that.plans;
+            this.priceLists = that.priceLists;
+            this.products = that.products;
+            this.supportedCurrencies = that.supportedCurrencies;
+            this.units = that.units;
+        }
+        public T withAvailableBasePlanListings(final List<Listing> availableBasePlanListings) {
+            this.availableBasePlanListings = availableBasePlanListings;
+            return (T) this;
+        }
+        public T withCatalogName(final String catalogName) {
+            this.catalogName = catalogName;
+            return (T) this;
+        }
+        public T withEffectiveDate(final Date effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+        public T withPlanRules(final PlanRules planRules) {
+            this.planRules = planRules;
+            return (T) this;
+        }
+        public T withPlans(final Collection<Plan> plans) {
+            this.plans = plans;
+            return (T) this;
+        }
+        public T withPriceLists(final PriceListSet priceLists) {
+            this.priceLists = priceLists;
+            return (T) this;
+        }
+        public T withProducts(final Collection<Product> products) {
+            this.products = products;
+            return (T) this;
+        }
+        public T withSupportedCurrencies(final Currency[] supportedCurrencies) {
+            this.supportedCurrencies = supportedCurrencies;
+            return (T) this;
+        }
+        public T withUnits(final Unit[] units) {
+            this.units = units;
+            return (T) this;
+        }
+        public T source(final MutableStaticCatalog that) throws CatalogApiException {
+            this.availableBasePlanListings = that.getAvailableBasePlanListings();
+            this.catalogName = that.getCatalogName();
+            this.effectiveDate = that.getEffectiveDate();
+            this.planRules = that.getPlanRules();
+            this.plans = that.getPlans();
+            this.priceLists = that.getPriceLists();
+            this.products = that.getProducts();
+            this.supportedCurrencies = that.getSupportedCurrencies();
+            this.units = that.getUnits();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public MutableStaticCatalogImp build() {
+            return new MutableStaticCatalogImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/PlanImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/PlanImp.java
@@ -1,0 +1,367 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Objects;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.BillingMode;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.StaticCatalog;
+
+@JsonDeserialize( builder = PlanImp.Builder.class )
+public class PlanImp implements Plan, Serializable {
+
+    private static final long serialVersionUID = 0xF3EE496703EAF392L;
+
+    protected PlanPhase[] allPhases;
+    protected StaticCatalog catalog;
+    protected Date effectiveDateForExistingSubscriptions;
+    protected PlanPhase finalPhase;
+    protected Iterator<PlanPhase> initialPhaseIterator;
+    protected PlanPhase[] initialPhases;
+    protected String name;
+    protected int plansAllowedInBundle;
+    protected String prettyName;
+    protected PriceList priceList;
+    protected Product product;
+    protected BillingMode recurringBillingMode;
+    protected BillingPeriod recurringBillingPeriod;
+
+    public PlanImp(final PlanImp that) {
+        this.allPhases = that.allPhases;
+        this.catalog = that.catalog;
+        this.effectiveDateForExistingSubscriptions = that.effectiveDateForExistingSubscriptions;
+        this.finalPhase = that.finalPhase;
+        this.initialPhaseIterator = that.initialPhaseIterator;
+        this.initialPhases = that.initialPhases;
+        this.name = that.name;
+        this.plansAllowedInBundle = that.plansAllowedInBundle;
+        this.prettyName = that.prettyName;
+        this.priceList = that.priceList;
+        this.product = that.product;
+        this.recurringBillingMode = that.recurringBillingMode;
+        this.recurringBillingPeriod = that.recurringBillingPeriod;
+    }
+    protected PlanImp(final PlanImp.Builder<?> builder) {
+        this.allPhases = builder.allPhases;
+        this.catalog = builder.catalog;
+        this.effectiveDateForExistingSubscriptions = builder.effectiveDateForExistingSubscriptions;
+        this.finalPhase = builder.finalPhase;
+        this.initialPhaseIterator = builder.initialPhaseIterator;
+        this.initialPhases = builder.initialPhases;
+        this.name = builder.name;
+        this.plansAllowedInBundle = builder.plansAllowedInBundle;
+        this.prettyName = builder.prettyName;
+        this.priceList = builder.priceList;
+        this.product = builder.product;
+        this.recurringBillingMode = builder.recurringBillingMode;
+        this.recurringBillingPeriod = builder.recurringBillingPeriod;
+    }
+    protected PlanImp() { }
+    @Override
+    public PlanPhase[] getAllPhases() {
+        return this.allPhases;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public Date getEffectiveDateForExistingSubscriptions() {
+        return this.effectiveDateForExistingSubscriptions;
+    }
+    @Override
+    public PlanPhase getFinalPhase() {
+        return this.finalPhase;
+    }
+    @Override
+    public Iterator<PlanPhase> getInitialPhaseIterator() {
+        return this.initialPhaseIterator;
+    }
+    @Override
+    public PlanPhase[] getInitialPhases() {
+        return this.initialPhases;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public int getPlansAllowedInBundle() {
+        return this.plansAllowedInBundle;
+    }
+    @Override
+    public String getPrettyName() {
+        return this.prettyName;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public Product getProduct() {
+        return this.product;
+    }
+    @Override
+    public BillingMode getRecurringBillingMode() {
+        return this.recurringBillingMode;
+    }
+    @Override
+    public BillingPeriod getRecurringBillingPeriod() {
+        return this.recurringBillingPeriod;
+    }
+    @Override
+    public DateTime dateOfFirstRecurringNonZeroCharge(final DateTime subscriptionStartDate, final PhaseType intialPhaseType) {
+        throw new UnsupportedOperationException("dateOfFirstRecurringNonZeroCharge(org.joda.time.DateTime, org.killbill.billing.catalog.api.PhaseType) must be implemented.");
+    }
+    @Override
+    public PlanPhase findPhase(final String name) {
+        throw new UnsupportedOperationException("findPhase(java.lang.String) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PlanImp that = (PlanImp) o;
+        if( !Arrays.deepEquals(this.allPhases, that.allPhases) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.effectiveDateForExistingSubscriptions, that.effectiveDateForExistingSubscriptions) ) {
+            return false;
+        }
+        if( !Objects.equals(this.finalPhase, that.finalPhase) ) {
+            return false;
+        }
+        if( !Objects.equals(this.initialPhaseIterator, that.initialPhaseIterator) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.initialPhases, that.initialPhases) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( this.plansAllowedInBundle != that.plansAllowedInBundle ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyName, that.prettyName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.product, that.product) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recurringBillingMode, that.recurringBillingMode) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recurringBillingPeriod, that.recurringBillingPeriod) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Arrays.deepHashCode(this.allPhases);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDateForExistingSubscriptions);
+        result = ( 31 * result ) + Objects.hashCode(this.finalPhase);
+        result = ( 31 * result ) + Objects.hashCode(this.initialPhaseIterator);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.initialPhases);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.plansAllowedInBundle);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyName);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.product);
+        result = ( 31 * result ) + Objects.hashCode(this.recurringBillingMode);
+        result = ( 31 * result ) + Objects.hashCode(this.recurringBillingPeriod);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("allPhases=").append(Arrays.toString(this.allPhases));
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("effectiveDateForExistingSubscriptions=").append(this.effectiveDateForExistingSubscriptions);
+        sb.append(", ");
+        sb.append("finalPhase=").append(this.finalPhase);
+        sb.append(", ");
+        sb.append("initialPhaseIterator=").append(this.initialPhaseIterator);
+        sb.append(", ");
+        sb.append("initialPhases=").append(Arrays.toString(this.initialPhases));
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("plansAllowedInBundle=").append(this.plansAllowedInBundle);
+        sb.append(", ");
+        sb.append("prettyName=");
+        if( this.prettyName == null ) {
+            sb.append(this.prettyName);
+        }else{
+            sb.append("'").append(this.prettyName).append("'");
+        }
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append(", ");
+        sb.append("product=").append(this.product);
+        sb.append(", ");
+        sb.append("recurringBillingMode=").append(this.recurringBillingMode);
+        sb.append(", ");
+        sb.append("recurringBillingPeriod=").append(this.recurringBillingPeriod);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PlanImp.Builder<T>> {
+
+        protected PlanPhase[] allPhases;
+        protected StaticCatalog catalog;
+        protected Date effectiveDateForExistingSubscriptions;
+        protected PlanPhase finalPhase;
+        protected Iterator<PlanPhase> initialPhaseIterator;
+        protected PlanPhase[] initialPhases;
+        protected String name;
+        protected int plansAllowedInBundle;
+        protected String prettyName;
+        protected PriceList priceList;
+        protected Product product;
+        protected BillingMode recurringBillingMode;
+        protected BillingPeriod recurringBillingPeriod;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.allPhases = that.allPhases;
+            this.catalog = that.catalog;
+            this.effectiveDateForExistingSubscriptions = that.effectiveDateForExistingSubscriptions;
+            this.finalPhase = that.finalPhase;
+            this.initialPhaseIterator = that.initialPhaseIterator;
+            this.initialPhases = that.initialPhases;
+            this.name = that.name;
+            this.plansAllowedInBundle = that.plansAllowedInBundle;
+            this.prettyName = that.prettyName;
+            this.priceList = that.priceList;
+            this.product = that.product;
+            this.recurringBillingMode = that.recurringBillingMode;
+            this.recurringBillingPeriod = that.recurringBillingPeriod;
+        }
+        public T withAllPhases(final PlanPhase[] allPhases) {
+            this.allPhases = allPhases;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withEffectiveDateForExistingSubscriptions(final Date effectiveDateForExistingSubscriptions) {
+            this.effectiveDateForExistingSubscriptions = effectiveDateForExistingSubscriptions;
+            return (T) this;
+        }
+        public T withFinalPhase(final PlanPhase finalPhase) {
+            this.finalPhase = finalPhase;
+            return (T) this;
+        }
+        public T withInitialPhaseIterator(final Iterator<PlanPhase> initialPhaseIterator) {
+            this.initialPhaseIterator = initialPhaseIterator;
+            return (T) this;
+        }
+        public T withInitialPhases(final PlanPhase[] initialPhases) {
+            this.initialPhases = initialPhases;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withPlansAllowedInBundle(final int plansAllowedInBundle) {
+            this.plansAllowedInBundle = plansAllowedInBundle;
+            return (T) this;
+        }
+        public T withPrettyName(final String prettyName) {
+            this.prettyName = prettyName;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProduct(final Product product) {
+            this.product = product;
+            return (T) this;
+        }
+        public T withRecurringBillingMode(final BillingMode recurringBillingMode) {
+            this.recurringBillingMode = recurringBillingMode;
+            return (T) this;
+        }
+        public T withRecurringBillingPeriod(final BillingPeriod recurringBillingPeriod) {
+            this.recurringBillingPeriod = recurringBillingPeriod;
+            return (T) this;
+        }
+        public T source(final Plan that) {
+            this.allPhases = that.getAllPhases();
+            this.catalog = that.getCatalog();
+            this.effectiveDateForExistingSubscriptions = that.getEffectiveDateForExistingSubscriptions();
+            this.finalPhase = that.getFinalPhase();
+            this.initialPhaseIterator = that.getInitialPhaseIterator();
+            this.initialPhases = that.getInitialPhases();
+            this.name = that.getName();
+            this.plansAllowedInBundle = that.getPlansAllowedInBundle();
+            this.prettyName = that.getPrettyName();
+            this.priceList = that.getPriceList();
+            this.product = that.getProduct();
+            this.recurringBillingMode = that.getRecurringBillingMode();
+            this.recurringBillingPeriod = that.getRecurringBillingPeriod();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PlanImp build() {
+            return new PlanImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/PlanPhaseImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/PlanPhaseImp.java
@@ -1,0 +1,258 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Duration;
+import org.killbill.billing.catalog.api.Fixed;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.Recurring;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.Usage;
+
+@JsonDeserialize( builder = PlanPhaseImp.Builder.class )
+public class PlanPhaseImp implements PlanPhase, Serializable {
+
+    private static final long serialVersionUID = 0xAF49E600C9BB037DL;
+
+    protected StaticCatalog catalog;
+    protected Duration duration;
+    protected Fixed fixed;
+    protected String name;
+    protected PhaseType phaseType;
+    protected String prettyName;
+    protected Recurring recurring;
+    protected Usage[] usages;
+
+    public PlanPhaseImp(final PlanPhaseImp that) {
+        this.catalog = that.catalog;
+        this.duration = that.duration;
+        this.fixed = that.fixed;
+        this.name = that.name;
+        this.phaseType = that.phaseType;
+        this.prettyName = that.prettyName;
+        this.recurring = that.recurring;
+        this.usages = that.usages;
+    }
+    protected PlanPhaseImp(final PlanPhaseImp.Builder<?> builder) {
+        this.catalog = builder.catalog;
+        this.duration = builder.duration;
+        this.fixed = builder.fixed;
+        this.name = builder.name;
+        this.phaseType = builder.phaseType;
+        this.prettyName = builder.prettyName;
+        this.recurring = builder.recurring;
+        this.usages = builder.usages;
+    }
+    protected PlanPhaseImp() { }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public Duration getDuration() {
+        return this.duration;
+    }
+    @Override
+    public Fixed getFixed() {
+        return this.fixed;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public PhaseType getPhaseType() {
+        return this.phaseType;
+    }
+    @Override
+    public String getPrettyName() {
+        return this.prettyName;
+    }
+    @Override
+    public Recurring getRecurring() {
+        return this.recurring;
+    }
+    @Override
+    public Usage[] getUsages() {
+        return this.usages;
+    }
+    @Override
+    public boolean compliesWithLimits(final String unit, final double value) {
+        throw new UnsupportedOperationException("compliesWithLimits(java.lang.String, double) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PlanPhaseImp that = (PlanPhaseImp) o;
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.duration, that.duration) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fixed, that.fixed) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseType, that.phaseType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyName, that.prettyName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recurring, that.recurring) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.usages, that.usages) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.duration);
+        result = ( 31 * result ) + Objects.hashCode(this.fixed);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseType);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyName);
+        result = ( 31 * result ) + Objects.hashCode(this.recurring);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.usages);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("duration=").append(this.duration);
+        sb.append(", ");
+        sb.append("fixed=").append(this.fixed);
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("phaseType=").append(this.phaseType);
+        sb.append(", ");
+        sb.append("prettyName=");
+        if( this.prettyName == null ) {
+            sb.append(this.prettyName);
+        }else{
+            sb.append("'").append(this.prettyName).append("'");
+        }
+        sb.append(", ");
+        sb.append("recurring=").append(this.recurring);
+        sb.append(", ");
+        sb.append("usages=").append(Arrays.toString(this.usages));
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PlanPhaseImp.Builder<T>> {
+
+        protected StaticCatalog catalog;
+        protected Duration duration;
+        protected Fixed fixed;
+        protected String name;
+        protected PhaseType phaseType;
+        protected String prettyName;
+        protected Recurring recurring;
+        protected Usage[] usages;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.catalog = that.catalog;
+            this.duration = that.duration;
+            this.fixed = that.fixed;
+            this.name = that.name;
+            this.phaseType = that.phaseType;
+            this.prettyName = that.prettyName;
+            this.recurring = that.recurring;
+            this.usages = that.usages;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withDuration(final Duration duration) {
+            this.duration = duration;
+            return (T) this;
+        }
+        public T withFixed(final Fixed fixed) {
+            this.fixed = fixed;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withPhaseType(final PhaseType phaseType) {
+            this.phaseType = phaseType;
+            return (T) this;
+        }
+        public T withPrettyName(final String prettyName) {
+            this.prettyName = prettyName;
+            return (T) this;
+        }
+        public T withRecurring(final Recurring recurring) {
+            this.recurring = recurring;
+            return (T) this;
+        }
+        public T withUsages(final Usage[] usages) {
+            this.usages = usages;
+            return (T) this;
+        }
+        public T source(final PlanPhase that) {
+            this.catalog = that.getCatalog();
+            this.duration = that.getDuration();
+            this.fixed = that.getFixed();
+            this.name = that.getName();
+            this.phaseType = that.getPhaseType();
+            this.prettyName = that.getPrettyName();
+            this.recurring = that.getRecurring();
+            this.usages = that.getUsages();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PlanPhaseImp build() {
+            return new PlanPhaseImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/PlanPhasePriceOverrideImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/PlanPhasePriceOverrideImp.java
@@ -1,0 +1,208 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.catalog.api.UsagePriceOverride;
+
+@JsonDeserialize( builder = PlanPhasePriceOverrideImp.Builder.class )
+public class PlanPhasePriceOverrideImp implements PlanPhasePriceOverride, Serializable {
+
+    private static final long serialVersionUID = 0x7AAF7FEE20AC0469L;
+
+    protected Currency currency;
+    protected BigDecimal fixedPrice;
+    protected String phaseName;
+    protected PlanPhaseSpecifier planPhaseSpecifier;
+    protected BigDecimal recurringPrice;
+    protected List<UsagePriceOverride> usagePriceOverrides;
+
+    public PlanPhasePriceOverrideImp(final PlanPhasePriceOverrideImp that) {
+        this.currency = that.currency;
+        this.fixedPrice = that.fixedPrice;
+        this.phaseName = that.phaseName;
+        this.planPhaseSpecifier = that.planPhaseSpecifier;
+        this.recurringPrice = that.recurringPrice;
+        this.usagePriceOverrides = that.usagePriceOverrides;
+    }
+    protected PlanPhasePriceOverrideImp(final PlanPhasePriceOverrideImp.Builder<?> builder) {
+        this.currency = builder.currency;
+        this.fixedPrice = builder.fixedPrice;
+        this.phaseName = builder.phaseName;
+        this.planPhaseSpecifier = builder.planPhaseSpecifier;
+        this.recurringPrice = builder.recurringPrice;
+        this.usagePriceOverrides = builder.usagePriceOverrides;
+    }
+    protected PlanPhasePriceOverrideImp() { }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public BigDecimal getFixedPrice() {
+        return this.fixedPrice;
+    }
+    @Override
+    public String getPhaseName() {
+        return this.phaseName;
+    }
+    @Override
+    public PlanPhaseSpecifier getPlanPhaseSpecifier() {
+        return this.planPhaseSpecifier;
+    }
+    @Override
+    public BigDecimal getRecurringPrice() {
+        return this.recurringPrice;
+    }
+    @Override
+    public List<UsagePriceOverride> getUsagePriceOverrides() {
+        return this.usagePriceOverrides;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PlanPhasePriceOverrideImp that = (PlanPhasePriceOverrideImp) o;
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( ( this.fixedPrice != null ) ? ( 0 != this.fixedPrice.compareTo(that.fixedPrice) ) : ( that.fixedPrice != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseName, that.phaseName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.planPhaseSpecifier, that.planPhaseSpecifier) ) {
+            return false;
+        }
+        if( ( this.recurringPrice != null ) ? ( 0 != this.recurringPrice.compareTo(that.recurringPrice) ) : ( that.recurringPrice != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.usagePriceOverrides, that.usagePriceOverrides) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.fixedPrice);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseName);
+        result = ( 31 * result ) + Objects.hashCode(this.planPhaseSpecifier);
+        result = ( 31 * result ) + Objects.hashCode(this.recurringPrice);
+        result = ( 31 * result ) + Objects.hashCode(this.usagePriceOverrides);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("fixedPrice=").append(this.fixedPrice);
+        sb.append(", ");
+        sb.append("phaseName=");
+        if( this.phaseName == null ) {
+            sb.append(this.phaseName);
+        }else{
+            sb.append("'").append(this.phaseName).append("'");
+        }
+        sb.append(", ");
+        sb.append("planPhaseSpecifier=").append(this.planPhaseSpecifier);
+        sb.append(", ");
+        sb.append("recurringPrice=").append(this.recurringPrice);
+        sb.append(", ");
+        sb.append("usagePriceOverrides=").append(this.usagePriceOverrides);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PlanPhasePriceOverrideImp.Builder<T>> {
+
+        protected Currency currency;
+        protected BigDecimal fixedPrice;
+        protected String phaseName;
+        protected PlanPhaseSpecifier planPhaseSpecifier;
+        protected BigDecimal recurringPrice;
+        protected List<UsagePriceOverride> usagePriceOverrides;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.currency = that.currency;
+            this.fixedPrice = that.fixedPrice;
+            this.phaseName = that.phaseName;
+            this.planPhaseSpecifier = that.planPhaseSpecifier;
+            this.recurringPrice = that.recurringPrice;
+            this.usagePriceOverrides = that.usagePriceOverrides;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withFixedPrice(final BigDecimal fixedPrice) {
+            this.fixedPrice = fixedPrice;
+            return (T) this;
+        }
+        public T withPhaseName(final String phaseName) {
+            this.phaseName = phaseName;
+            return (T) this;
+        }
+        public T withPlanPhaseSpecifier(final PlanPhaseSpecifier planPhaseSpecifier) {
+            this.planPhaseSpecifier = planPhaseSpecifier;
+            return (T) this;
+        }
+        public T withRecurringPrice(final BigDecimal recurringPrice) {
+            this.recurringPrice = recurringPrice;
+            return (T) this;
+        }
+        public T withUsagePriceOverrides(final List<UsagePriceOverride> usagePriceOverrides) {
+            this.usagePriceOverrides = usagePriceOverrides;
+            return (T) this;
+        }
+        public T source(final PlanPhasePriceOverride that) {
+            this.currency = that.getCurrency();
+            this.fixedPrice = that.getFixedPrice();
+            this.phaseName = that.getPhaseName();
+            this.planPhaseSpecifier = that.getPlanPhaseSpecifier();
+            this.recurringPrice = that.getRecurringPrice();
+            this.usagePriceOverrides = that.getUsagePriceOverrides();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PlanPhasePriceOverrideImp build() {
+            return new PlanPhasePriceOverrideImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/PlanPhasePriceOverridesWithCallContextImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/PlanPhasePriceOverridesWithCallContextImp.java
@@ -1,0 +1,121 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverridesWithCallContext;
+import org.killbill.billing.util.callcontext.CallContext;
+
+@JsonDeserialize( builder = PlanPhasePriceOverridesWithCallContextImp.Builder.class )
+public class PlanPhasePriceOverridesWithCallContextImp implements PlanPhasePriceOverridesWithCallContext, Serializable {
+
+    private static final long serialVersionUID = 0xFEAD7869462749EDL;
+
+    protected CallContext callContext;
+    protected List<PlanPhasePriceOverride> overrides;
+
+    public PlanPhasePriceOverridesWithCallContextImp(final PlanPhasePriceOverridesWithCallContextImp that) {
+        this.callContext = that.callContext;
+        this.overrides = that.overrides;
+    }
+    protected PlanPhasePriceOverridesWithCallContextImp(final PlanPhasePriceOverridesWithCallContextImp.Builder<?> builder) {
+        this.callContext = builder.callContext;
+        this.overrides = builder.overrides;
+    }
+    protected PlanPhasePriceOverridesWithCallContextImp() { }
+    @Override
+    public CallContext getCallContext() {
+        return this.callContext;
+    }
+    @Override
+    public List<PlanPhasePriceOverride> getOverrides() {
+        return this.overrides;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PlanPhasePriceOverridesWithCallContextImp that = (PlanPhasePriceOverridesWithCallContextImp) o;
+        if( !Objects.equals(this.callContext, that.callContext) ) {
+            return false;
+        }
+        if( !Objects.equals(this.overrides, that.overrides) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.callContext);
+        result = ( 31 * result ) + Objects.hashCode(this.overrides);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("callContext=").append(this.callContext);
+        sb.append(", ");
+        sb.append("overrides=").append(this.overrides);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PlanPhasePriceOverridesWithCallContextImp.Builder<T>> {
+
+        protected CallContext callContext;
+        protected List<PlanPhasePriceOverride> overrides;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.callContext = that.callContext;
+            this.overrides = that.overrides;
+        }
+        public T withCallContext(final CallContext callContext) {
+            this.callContext = callContext;
+            return (T) this;
+        }
+        public T withOverrides(final List<PlanPhasePriceOverride> overrides) {
+            this.overrides = overrides;
+            return (T) this;
+        }
+        public T source(final PlanPhasePriceOverridesWithCallContext that) {
+            this.callContext = that.getCallContext();
+            this.overrides = that.getOverrides();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PlanPhasePriceOverridesWithCallContextImp build() {
+            return new PlanPhasePriceOverridesWithCallContextImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/PriceImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/PriceImp.java
@@ -1,0 +1,121 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.catalog.api.CurrencyValueNull;
+import org.killbill.billing.catalog.api.Price;
+
+@JsonDeserialize( builder = PriceImp.Builder.class )
+public class PriceImp implements Price, Serializable {
+
+    private static final long serialVersionUID = 0xD2B8DE0232F22E0EL;
+
+    protected Currency currency;
+    protected BigDecimal value;
+
+    public PriceImp(final PriceImp that) {
+        this.currency = that.currency;
+        this.value = that.value;
+    }
+    protected PriceImp(final PriceImp.Builder<?> builder) {
+        this.currency = builder.currency;
+        this.value = builder.value;
+    }
+    protected PriceImp() { }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public BigDecimal getValue() {
+        return this.value;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PriceImp that = (PriceImp) o;
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( ( this.value != null ) ? ( 0 != this.value.compareTo(that.value) ) : ( that.value != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.value);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("value=").append(this.value);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PriceImp.Builder<T>> {
+
+        protected Currency currency;
+        protected BigDecimal value;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.currency = that.currency;
+            this.value = that.value;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withValue(final BigDecimal value) {
+            this.value = value;
+            return (T) this;
+        }
+        public T source(final Price that) throws CurrencyValueNull {
+            this.currency = that.getCurrency();
+            this.value = that.getValue();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PriceImp build() {
+            return new PriceImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/PriceListImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/PriceListImp.java
@@ -1,0 +1,177 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.StaticCatalog;
+
+@JsonDeserialize( builder = PriceListImp.Builder.class )
+public class PriceListImp implements PriceList, Serializable {
+
+    private static final long serialVersionUID = 0x5D1F2B634C3D86DCL;
+
+    protected StaticCatalog catalog;
+    protected String name;
+    protected Collection<Plan> plans;
+    protected String prettyName;
+
+    public PriceListImp(final PriceListImp that) {
+        this.catalog = that.catalog;
+        this.name = that.name;
+        this.plans = that.plans;
+        this.prettyName = that.prettyName;
+    }
+    protected PriceListImp(final PriceListImp.Builder<?> builder) {
+        this.catalog = builder.catalog;
+        this.name = builder.name;
+        this.plans = builder.plans;
+        this.prettyName = builder.prettyName;
+    }
+    protected PriceListImp() { }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public Collection<Plan> getPlans() {
+        return this.plans;
+    }
+    @Override
+    public String getPrettyName() {
+        return this.prettyName;
+    }
+    @Override
+    public Collection<Plan> findPlans(final Product product, final BillingPeriod period) {
+        throw new UnsupportedOperationException("findPlans(org.killbill.billing.catalog.api.Product, org.killbill.billing.catalog.api.BillingPeriod) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PriceListImp that = (PriceListImp) o;
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.plans, that.plans) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyName, that.prettyName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.plans);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("plans=").append(this.plans);
+        sb.append(", ");
+        sb.append("prettyName=");
+        if( this.prettyName == null ) {
+            sb.append(this.prettyName);
+        }else{
+            sb.append("'").append(this.prettyName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PriceListImp.Builder<T>> {
+
+        protected StaticCatalog catalog;
+        protected String name;
+        protected Collection<Plan> plans;
+        protected String prettyName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.catalog = that.catalog;
+            this.name = that.name;
+            this.plans = that.plans;
+            this.prettyName = that.prettyName;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withPlans(final Collection<Plan> plans) {
+            this.plans = plans;
+            return (T) this;
+        }
+        public T withPrettyName(final String prettyName) {
+            this.prettyName = prettyName;
+            return (T) this;
+        }
+        public T source(final PriceList that) {
+            this.catalog = that.getCatalog();
+            this.name = that.getName();
+            this.plans = that.getPlans();
+            this.prettyName = that.getPrettyName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PriceListImp build() {
+            return new PriceListImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/PriceListSetImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/PriceListSetImp.java
@@ -1,0 +1,121 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.PriceListSet;
+import org.killbill.billing.catalog.api.StaticCatalog;
+
+@JsonDeserialize( builder = PriceListSetImp.Builder.class )
+public class PriceListSetImp implements PriceListSet, Serializable {
+
+    private static final long serialVersionUID = 0x7F145FE5CA67CC48L;
+
+    protected List<PriceList> allPriceLists;
+    protected StaticCatalog catalog;
+
+    public PriceListSetImp(final PriceListSetImp that) {
+        this.allPriceLists = that.allPriceLists;
+        this.catalog = that.catalog;
+    }
+    protected PriceListSetImp(final PriceListSetImp.Builder<?> builder) {
+        this.allPriceLists = builder.allPriceLists;
+        this.catalog = builder.catalog;
+    }
+    protected PriceListSetImp() { }
+    @Override
+    public List<PriceList> getAllPriceLists() {
+        return this.allPriceLists;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PriceListSetImp that = (PriceListSetImp) o;
+        if( !Objects.equals(this.allPriceLists, that.allPriceLists) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.allPriceLists);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("allPriceLists=").append(this.allPriceLists);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PriceListSetImp.Builder<T>> {
+
+        protected List<PriceList> allPriceLists;
+        protected StaticCatalog catalog;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.allPriceLists = that.allPriceLists;
+            this.catalog = that.catalog;
+        }
+        public T withAllPriceLists(final List<PriceList> allPriceLists) {
+            this.allPriceLists = allPriceLists;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T source(final PriceListSet that) {
+            this.allPriceLists = that.getAllPriceLists();
+            this.catalog = that.getCatalog();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PriceListSetImp build() {
+            return new PriceListSetImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/ProductImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/ProductImp.java
@@ -1,0 +1,261 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Limit;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+
+@JsonDeserialize( builder = ProductImp.Builder.class )
+public class ProductImp implements Product, Serializable {
+
+    private static final long serialVersionUID = 0x25986204CF11F2C6L;
+
+    protected Collection<Product> available;
+    protected StaticCatalog catalog;
+    protected String catalogName;
+    protected ProductCategory category;
+    protected Collection<Product> included;
+    protected Limit[] limits;
+    protected String name;
+    protected String prettyName;
+
+    public ProductImp(final ProductImp that) {
+        this.available = that.available;
+        this.catalog = that.catalog;
+        this.catalogName = that.catalogName;
+        this.category = that.category;
+        this.included = that.included;
+        this.limits = that.limits;
+        this.name = that.name;
+        this.prettyName = that.prettyName;
+    }
+    protected ProductImp(final ProductImp.Builder<?> builder) {
+        this.available = builder.available;
+        this.catalog = builder.catalog;
+        this.catalogName = builder.catalogName;
+        this.category = builder.category;
+        this.included = builder.included;
+        this.limits = builder.limits;
+        this.name = builder.name;
+        this.prettyName = builder.prettyName;
+    }
+    protected ProductImp() { }
+    @Override
+    public Collection<Product> getAvailable() {
+        return this.available;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public String getCatalogName() {
+        return this.catalogName;
+    }
+    @Override
+    public ProductCategory getCategory() {
+        return this.category;
+    }
+    @Override
+    public Collection<Product> getIncluded() {
+        return this.included;
+    }
+    @Override
+    public Limit[] getLimits() {
+        return this.limits;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public String getPrettyName() {
+        return this.prettyName;
+    }
+    @Override
+    public boolean compliesWithLimits(final String unit, final double value) {
+        throw new UnsupportedOperationException("compliesWithLimits(java.lang.String, double) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final ProductImp that = (ProductImp) o;
+        if( !Objects.equals(this.available, that.available) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalogName, that.catalogName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.category, that.category) ) {
+            return false;
+        }
+        if( !Objects.equals(this.included, that.included) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.limits, that.limits) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyName, that.prettyName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.available);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.catalogName);
+        result = ( 31 * result ) + Objects.hashCode(this.category);
+        result = ( 31 * result ) + Objects.hashCode(this.included);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.limits);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("available=").append(this.available);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("catalogName=");
+        if( this.catalogName == null ) {
+            sb.append(this.catalogName);
+        }else{
+            sb.append("'").append(this.catalogName).append("'");
+        }
+        sb.append(", ");
+        sb.append("category=").append(this.category);
+        sb.append(", ");
+        sb.append("included=").append(this.included);
+        sb.append(", ");
+        sb.append("limits=").append(Arrays.toString(this.limits));
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyName=");
+        if( this.prettyName == null ) {
+            sb.append(this.prettyName);
+        }else{
+            sb.append("'").append(this.prettyName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends ProductImp.Builder<T>> {
+
+        protected Collection<Product> available;
+        protected StaticCatalog catalog;
+        protected String catalogName;
+        protected ProductCategory category;
+        protected Collection<Product> included;
+        protected Limit[] limits;
+        protected String name;
+        protected String prettyName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.available = that.available;
+            this.catalog = that.catalog;
+            this.catalogName = that.catalogName;
+            this.category = that.category;
+            this.included = that.included;
+            this.limits = that.limits;
+            this.name = that.name;
+            this.prettyName = that.prettyName;
+        }
+        public T withAvailable(final Collection<Product> available) {
+            this.available = available;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withCatalogName(final String catalogName) {
+            this.catalogName = catalogName;
+            return (T) this;
+        }
+        public T withCategory(final ProductCategory category) {
+            this.category = category;
+            return (T) this;
+        }
+        public T withIncluded(final Collection<Product> included) {
+            this.included = included;
+            return (T) this;
+        }
+        public T withLimits(final Limit[] limits) {
+            this.limits = limits;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withPrettyName(final String prettyName) {
+            this.prettyName = prettyName;
+            return (T) this;
+        }
+        public T source(final Product that) {
+            this.available = that.getAvailable();
+            this.catalog = that.getCatalog();
+            this.catalogName = that.getCatalogName();
+            this.category = that.getCategory();
+            this.included = that.getIncluded();
+            this.limits = that.getLimits();
+            this.name = that.getName();
+            this.prettyName = that.getPrettyName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public ProductImp build() {
+            return new ProductImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/RecurringImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/RecurringImp.java
@@ -1,0 +1,120 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.InternationalPrice;
+import org.killbill.billing.catalog.api.Recurring;
+
+@JsonDeserialize( builder = RecurringImp.Builder.class )
+public class RecurringImp implements Recurring, Serializable {
+
+    private static final long serialVersionUID = 0x43536F908E82DDF9L;
+
+    protected BillingPeriod billingPeriod;
+    protected InternationalPrice recurringPrice;
+
+    public RecurringImp(final RecurringImp that) {
+        this.billingPeriod = that.billingPeriod;
+        this.recurringPrice = that.recurringPrice;
+    }
+    protected RecurringImp(final RecurringImp.Builder<?> builder) {
+        this.billingPeriod = builder.billingPeriod;
+        this.recurringPrice = builder.recurringPrice;
+    }
+    protected RecurringImp() { }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public InternationalPrice getRecurringPrice() {
+        return this.recurringPrice;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final RecurringImp that = (RecurringImp) o;
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recurringPrice, that.recurringPrice) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.recurringPrice);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("recurringPrice=").append(this.recurringPrice);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends RecurringImp.Builder<T>> {
+
+        protected BillingPeriod billingPeriod;
+        protected InternationalPrice recurringPrice;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingPeriod = that.billingPeriod;
+            this.recurringPrice = that.recurringPrice;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withRecurringPrice(final InternationalPrice recurringPrice) {
+            this.recurringPrice = recurringPrice;
+            return (T) this;
+        }
+        public T source(final Recurring that) {
+            this.billingPeriod = that.getBillingPeriod();
+            this.recurringPrice = that.getRecurringPrice();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public RecurringImp build() {
+            return new RecurringImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/Resolver.java
@@ -1,0 +1,85 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.catalog.api.Block;
+import org.killbill.billing.catalog.api.BlockPriceOverride;
+import org.killbill.billing.catalog.api.CatalogEntity;
+import org.killbill.billing.catalog.api.CatalogUserApi;
+import org.killbill.billing.catalog.api.Duration;
+import org.killbill.billing.catalog.api.Fixed;
+import org.killbill.billing.catalog.api.InternationalPrice;
+import org.killbill.billing.catalog.api.Limit;
+import org.killbill.billing.catalog.api.Listing;
+import org.killbill.billing.catalog.api.MigrationPlan;
+import org.killbill.billing.catalog.api.MutableStaticCatalog;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverridesWithCallContext;
+import org.killbill.billing.catalog.api.Price;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.PriceListSet;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.Recurring;
+import org.killbill.billing.catalog.api.SimplePlanDescriptor;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.Tier;
+import org.killbill.billing.catalog.api.TierPriceOverride;
+import org.killbill.billing.catalog.api.TieredBlock;
+import org.killbill.billing.catalog.api.TieredBlockPriceOverride;
+import org.killbill.billing.catalog.api.Unit;
+import org.killbill.billing.catalog.api.Usage;
+import org.killbill.billing.catalog.api.UsagePriceOverride;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(Block.class, BlockImp.class);
+        this.addMapping(BlockPriceOverride.class, BlockPriceOverrideImp.class);
+        this.addMapping(CatalogEntity.class, CatalogEntityImp.class);
+        this.addMapping(CatalogUserApi.class, CatalogUserApiImp.class);
+        this.addMapping(Duration.class, DurationImp.class);
+        this.addMapping(Fixed.class, FixedImp.class);
+        this.addMapping(InternationalPrice.class, InternationalPriceImp.class);
+        this.addMapping(Limit.class, LimitImp.class);
+        this.addMapping(Listing.class, ListingImp.class);
+        this.addMapping(MigrationPlan.class, MigrationPlanImp.class);
+        this.addMapping(MutableStaticCatalog.class, MutableStaticCatalogImp.class);
+        this.addMapping(Plan.class, PlanImp.class);
+        this.addMapping(PlanPhase.class, PlanPhaseImp.class);
+        this.addMapping(PlanPhasePriceOverride.class, PlanPhasePriceOverrideImp.class);
+        this.addMapping(PlanPhasePriceOverridesWithCallContext.class, PlanPhasePriceOverridesWithCallContextImp.class);
+        this.addMapping(Price.class, PriceImp.class);
+        this.addMapping(PriceList.class, PriceListImp.class);
+        this.addMapping(PriceListSet.class, PriceListSetImp.class);
+        this.addMapping(Product.class, ProductImp.class);
+        this.addMapping(Recurring.class, RecurringImp.class);
+        this.addMapping(SimplePlanDescriptor.class, SimplePlanDescriptorImp.class);
+        this.addMapping(StaticCatalog.class, StaticCatalogImp.class);
+        this.addMapping(Tier.class, TierImp.class);
+        this.addMapping(TierPriceOverride.class, TierPriceOverrideImp.class);
+        this.addMapping(TieredBlock.class, TieredBlockImp.class);
+        this.addMapping(TieredBlockPriceOverride.class, TieredBlockPriceOverrideImp.class);
+        this.addMapping(Unit.class, UnitImp.class);
+        this.addMapping(Usage.class, UsageImp.class);
+        this.addMapping(UsagePriceOverride.class, UsagePriceOverrideImp.class);
+        this.addMapping(VersionedCatalog.class, VersionedCatalogImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/SimplePlanDescriptorImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/SimplePlanDescriptorImp.java
@@ -1,0 +1,274 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.SimplePlanDescriptor;
+import org.killbill.billing.catalog.api.TimeUnit;
+
+@JsonDeserialize( builder = SimplePlanDescriptorImp.Builder.class )
+public class SimplePlanDescriptorImp implements SimplePlanDescriptor, Serializable {
+
+    private static final long serialVersionUID = 0x87AD39BFF808A74BL;
+
+    protected BigDecimal amount;
+    protected List<String> availableBaseProducts;
+    protected BillingPeriod billingPeriod;
+    protected Currency currency;
+    protected String planId;
+    protected ProductCategory productCategory;
+    protected String productName;
+    protected Integer trialLength;
+    protected TimeUnit trialTimeUnit;
+
+    public SimplePlanDescriptorImp(final SimplePlanDescriptorImp that) {
+        this.amount = that.amount;
+        this.availableBaseProducts = that.availableBaseProducts;
+        this.billingPeriod = that.billingPeriod;
+        this.currency = that.currency;
+        this.planId = that.planId;
+        this.productCategory = that.productCategory;
+        this.productName = that.productName;
+        this.trialLength = that.trialLength;
+        this.trialTimeUnit = that.trialTimeUnit;
+    }
+    protected SimplePlanDescriptorImp(final SimplePlanDescriptorImp.Builder<?> builder) {
+        this.amount = builder.amount;
+        this.availableBaseProducts = builder.availableBaseProducts;
+        this.billingPeriod = builder.billingPeriod;
+        this.currency = builder.currency;
+        this.planId = builder.planId;
+        this.productCategory = builder.productCategory;
+        this.productName = builder.productName;
+        this.trialLength = builder.trialLength;
+        this.trialTimeUnit = builder.trialTimeUnit;
+    }
+    protected SimplePlanDescriptorImp() { }
+    @Override
+    public BigDecimal getAmount() {
+        return this.amount;
+    }
+    @Override
+    public List<String> getAvailableBaseProducts() {
+        return this.availableBaseProducts;
+    }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public String getPlanId() {
+        return this.planId;
+    }
+    @Override
+    public ProductCategory getProductCategory() {
+        return this.productCategory;
+    }
+    @Override
+    public String getProductName() {
+        return this.productName;
+    }
+    @Override
+    public Integer getTrialLength() {
+        return this.trialLength;
+    }
+    @Override
+    public TimeUnit getTrialTimeUnit() {
+        return this.trialTimeUnit;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final SimplePlanDescriptorImp that = (SimplePlanDescriptorImp) o;
+        if( ( this.amount != null ) ? ( 0 != this.amount.compareTo(that.amount) ) : ( that.amount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.availableBaseProducts, that.availableBaseProducts) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.planId, that.planId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productCategory, that.productCategory) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productName, that.productName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.trialLength, that.trialLength) ) {
+            return false;
+        }
+        if( !Objects.equals(this.trialTimeUnit, that.trialTimeUnit) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.availableBaseProducts);
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.planId);
+        result = ( 31 * result ) + Objects.hashCode(this.productCategory);
+        result = ( 31 * result ) + Objects.hashCode(this.productName);
+        result = ( 31 * result ) + Objects.hashCode(this.trialLength);
+        result = ( 31 * result ) + Objects.hashCode(this.trialTimeUnit);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("availableBaseProducts=").append(this.availableBaseProducts);
+        sb.append(", ");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("planId=");
+        if( this.planId == null ) {
+            sb.append(this.planId);
+        }else{
+            sb.append("'").append(this.planId).append("'");
+        }
+        sb.append(", ");
+        sb.append("productCategory=").append(this.productCategory);
+        sb.append(", ");
+        sb.append("productName=");
+        if( this.productName == null ) {
+            sb.append(this.productName);
+        }else{
+            sb.append("'").append(this.productName).append("'");
+        }
+        sb.append(", ");
+        sb.append("trialLength=").append(this.trialLength);
+        sb.append(", ");
+        sb.append("trialTimeUnit=").append(this.trialTimeUnit);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends SimplePlanDescriptorImp.Builder<T>> {
+
+        protected BigDecimal amount;
+        protected List<String> availableBaseProducts;
+        protected BillingPeriod billingPeriod;
+        protected Currency currency;
+        protected String planId;
+        protected ProductCategory productCategory;
+        protected String productName;
+        protected Integer trialLength;
+        protected TimeUnit trialTimeUnit;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.amount = that.amount;
+            this.availableBaseProducts = that.availableBaseProducts;
+            this.billingPeriod = that.billingPeriod;
+            this.currency = that.currency;
+            this.planId = that.planId;
+            this.productCategory = that.productCategory;
+            this.productName = that.productName;
+            this.trialLength = that.trialLength;
+            this.trialTimeUnit = that.trialTimeUnit;
+        }
+        public T withAmount(final BigDecimal amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withAvailableBaseProducts(final List<String> availableBaseProducts) {
+            this.availableBaseProducts = availableBaseProducts;
+            return (T) this;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withPlanId(final String planId) {
+            this.planId = planId;
+            return (T) this;
+        }
+        public T withProductCategory(final ProductCategory productCategory) {
+            this.productCategory = productCategory;
+            return (T) this;
+        }
+        public T withProductName(final String productName) {
+            this.productName = productName;
+            return (T) this;
+        }
+        public T withTrialLength(final Integer trialLength) {
+            this.trialLength = trialLength;
+            return (T) this;
+        }
+        public T withTrialTimeUnit(final TimeUnit trialTimeUnit) {
+            this.trialTimeUnit = trialTimeUnit;
+            return (T) this;
+        }
+        public T source(final SimplePlanDescriptor that) {
+            this.amount = that.getAmount();
+            this.availableBaseProducts = that.getAvailableBaseProducts();
+            this.billingPeriod = that.getBillingPeriod();
+            this.currency = that.getCurrency();
+            this.planId = that.getPlanId();
+            this.productCategory = that.getProductCategory();
+            this.productName = that.getProductName();
+            this.trialLength = that.getTrialLength();
+            this.trialTimeUnit = that.getTrialTimeUnit();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public SimplePlanDescriptorImp build() {
+            return new SimplePlanDescriptorImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/StaticCatalogImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/StaticCatalogImp.java
@@ -1,0 +1,302 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.catalog.api.Listing;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverridesWithCallContext;
+import org.killbill.billing.catalog.api.PlanSpecifier;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.PriceListSet;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.Unit;
+import org.killbill.billing.catalog.api.rules.PlanRules;
+
+@JsonDeserialize( builder = StaticCatalogImp.Builder.class )
+public class StaticCatalogImp implements StaticCatalog, Serializable {
+
+    private static final long serialVersionUID = 0xE722A02C87A2AC87L;
+
+    protected List<Listing> availableBasePlanListings;
+    protected String catalogName;
+    protected Date effectiveDate;
+    protected PlanRules planRules;
+    protected Collection<Plan> plans;
+    protected PriceListSet priceLists;
+    protected Collection<Product> products;
+    protected Currency[] supportedCurrencies;
+    protected Unit[] units;
+
+    public StaticCatalogImp(final StaticCatalogImp that) {
+        this.availableBasePlanListings = that.availableBasePlanListings;
+        this.catalogName = that.catalogName;
+        this.effectiveDate = that.effectiveDate;
+        this.planRules = that.planRules;
+        this.plans = that.plans;
+        this.priceLists = that.priceLists;
+        this.products = that.products;
+        this.supportedCurrencies = that.supportedCurrencies;
+        this.units = that.units;
+    }
+    protected StaticCatalogImp(final StaticCatalogImp.Builder<?> builder) {
+        this.availableBasePlanListings = builder.availableBasePlanListings;
+        this.catalogName = builder.catalogName;
+        this.effectiveDate = builder.effectiveDate;
+        this.planRules = builder.planRules;
+        this.plans = builder.plans;
+        this.priceLists = builder.priceLists;
+        this.products = builder.products;
+        this.supportedCurrencies = builder.supportedCurrencies;
+        this.units = builder.units;
+    }
+    protected StaticCatalogImp() { }
+    @Override
+    public List<Listing> getAvailableBasePlanListings() {
+        return this.availableBasePlanListings;
+    }
+    @Override
+    public String getCatalogName() {
+        return this.catalogName;
+    }
+    @Override
+    public Date getEffectiveDate() {
+        return this.effectiveDate;
+    }
+    @Override
+    public PlanRules getPlanRules() {
+        return this.planRules;
+    }
+    @Override
+    public Collection<Plan> getPlans() {
+        return this.plans;
+    }
+    @Override
+    public PriceListSet getPriceLists() {
+        return this.priceLists;
+    }
+    @Override
+    public Collection<Product> getProducts() {
+        return this.products;
+    }
+    @Override
+    public Currency[] getSupportedCurrencies() {
+        return this.supportedCurrencies;
+    }
+    @Override
+    public Unit[] getUnits() {
+        return this.units;
+    }
+    @Override
+    public Plan createOrFindPlan(final PlanSpecifier spec, final PlanPhasePriceOverridesWithCallContext overrides) {
+        throw new UnsupportedOperationException("createOrFindPlan(org.killbill.billing.catalog.api.PlanSpecifier, org.killbill.billing.catalog.api.PlanPhasePriceOverridesWithCallContext) must be implemented.");
+    }
+    @Override
+    public Plan findPlan(final String name) {
+        throw new UnsupportedOperationException("findPlan(java.lang.String) must be implemented.");
+    }
+    @Override
+    public List<Listing> getAvailableAddOnListings(final String baseProductName, final String priceListName) {
+        throw new UnsupportedOperationException("getAvailableAddOnListings(java.lang.String, java.lang.String) must be implemented.");
+    }
+    @Override
+    public Product findProduct(final String name) {
+        throw new UnsupportedOperationException("findProduct(java.lang.String) must be implemented.");
+    }
+    @Override
+    public PlanPhase findPhase(final String name) {
+        throw new UnsupportedOperationException("findPhase(java.lang.String) must be implemented.");
+    }
+    @Override
+    public PriceList findPriceList(final String name) {
+        throw new UnsupportedOperationException("findPriceList(java.lang.String) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final StaticCatalogImp that = (StaticCatalogImp) o;
+        if( !Objects.equals(this.availableBasePlanListings, that.availableBasePlanListings) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalogName, that.catalogName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.effectiveDate, that.effectiveDate) ) {
+            return false;
+        }
+        if( !Objects.equals(this.planRules, that.planRules) ) {
+            return false;
+        }
+        if( !Objects.equals(this.plans, that.plans) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceLists, that.priceLists) ) {
+            return false;
+        }
+        if( !Objects.equals(this.products, that.products) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.supportedCurrencies, that.supportedCurrencies) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.units, that.units) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.availableBasePlanListings);
+        result = ( 31 * result ) + Objects.hashCode(this.catalogName);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.planRules);
+        result = ( 31 * result ) + Objects.hashCode(this.plans);
+        result = ( 31 * result ) + Objects.hashCode(this.priceLists);
+        result = ( 31 * result ) + Objects.hashCode(this.products);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.supportedCurrencies);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.units);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("availableBasePlanListings=").append(this.availableBasePlanListings);
+        sb.append(", ");
+        sb.append("catalogName=");
+        if( this.catalogName == null ) {
+            sb.append(this.catalogName);
+        }else{
+            sb.append("'").append(this.catalogName).append("'");
+        }
+        sb.append(", ");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("planRules=").append(this.planRules);
+        sb.append(", ");
+        sb.append("plans=").append(this.plans);
+        sb.append(", ");
+        sb.append("priceLists=").append(this.priceLists);
+        sb.append(", ");
+        sb.append("products=").append(this.products);
+        sb.append(", ");
+        sb.append("supportedCurrencies=").append(Arrays.toString(this.supportedCurrencies));
+        sb.append(", ");
+        sb.append("units=").append(Arrays.toString(this.units));
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends StaticCatalogImp.Builder<T>> {
+
+        protected List<Listing> availableBasePlanListings;
+        protected String catalogName;
+        protected Date effectiveDate;
+        protected PlanRules planRules;
+        protected Collection<Plan> plans;
+        protected PriceListSet priceLists;
+        protected Collection<Product> products;
+        protected Currency[] supportedCurrencies;
+        protected Unit[] units;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.availableBasePlanListings = that.availableBasePlanListings;
+            this.catalogName = that.catalogName;
+            this.effectiveDate = that.effectiveDate;
+            this.planRules = that.planRules;
+            this.plans = that.plans;
+            this.priceLists = that.priceLists;
+            this.products = that.products;
+            this.supportedCurrencies = that.supportedCurrencies;
+            this.units = that.units;
+        }
+        public T withAvailableBasePlanListings(final List<Listing> availableBasePlanListings) {
+            this.availableBasePlanListings = availableBasePlanListings;
+            return (T) this;
+        }
+        public T withCatalogName(final String catalogName) {
+            this.catalogName = catalogName;
+            return (T) this;
+        }
+        public T withEffectiveDate(final Date effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+        public T withPlanRules(final PlanRules planRules) {
+            this.planRules = planRules;
+            return (T) this;
+        }
+        public T withPlans(final Collection<Plan> plans) {
+            this.plans = plans;
+            return (T) this;
+        }
+        public T withPriceLists(final PriceListSet priceLists) {
+            this.priceLists = priceLists;
+            return (T) this;
+        }
+        public T withProducts(final Collection<Product> products) {
+            this.products = products;
+            return (T) this;
+        }
+        public T withSupportedCurrencies(final Currency[] supportedCurrencies) {
+            this.supportedCurrencies = supportedCurrencies;
+            return (T) this;
+        }
+        public T withUnits(final Unit[] units) {
+            this.units = units;
+            return (T) this;
+        }
+        public T source(final StaticCatalog that) throws CatalogApiException {
+            this.availableBasePlanListings = that.getAvailableBasePlanListings();
+            this.catalogName = that.getCatalogName();
+            this.effectiveDate = that.getEffectiveDate();
+            this.planRules = that.getPlanRules();
+            this.plans = that.getPlans();
+            this.priceLists = that.getPriceLists();
+            this.products = that.getProducts();
+            this.supportedCurrencies = that.getSupportedCurrencies();
+            this.units = that.getUnits();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public StaticCatalogImp build() {
+            return new StaticCatalogImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/TierImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/TierImp.java
@@ -1,0 +1,161 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.InternationalPrice;
+import org.killbill.billing.catalog.api.Limit;
+import org.killbill.billing.catalog.api.Tier;
+import org.killbill.billing.catalog.api.TieredBlock;
+
+@JsonDeserialize( builder = TierImp.Builder.class )
+public class TierImp implements Tier, Serializable {
+
+    private static final long serialVersionUID = 0x920E4CDB395343AEL;
+
+    protected InternationalPrice fixedPrice;
+    protected Limit[] limits;
+    protected InternationalPrice recurringPrice;
+    protected TieredBlock[] tieredBlocks;
+
+    public TierImp(final TierImp that) {
+        this.fixedPrice = that.fixedPrice;
+        this.limits = that.limits;
+        this.recurringPrice = that.recurringPrice;
+        this.tieredBlocks = that.tieredBlocks;
+    }
+    protected TierImp(final TierImp.Builder<?> builder) {
+        this.fixedPrice = builder.fixedPrice;
+        this.limits = builder.limits;
+        this.recurringPrice = builder.recurringPrice;
+        this.tieredBlocks = builder.tieredBlocks;
+    }
+    protected TierImp() { }
+    @Override
+    public InternationalPrice getFixedPrice() {
+        return this.fixedPrice;
+    }
+    @Override
+    public Limit[] getLimits() {
+        return this.limits;
+    }
+    @Override
+    public InternationalPrice getRecurringPrice() {
+        return this.recurringPrice;
+    }
+    @Override
+    public TieredBlock[] getTieredBlocks() {
+        return this.tieredBlocks;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TierImp that = (TierImp) o;
+        if( !Objects.equals(this.fixedPrice, that.fixedPrice) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.limits, that.limits) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recurringPrice, that.recurringPrice) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.tieredBlocks, that.tieredBlocks) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.fixedPrice);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.limits);
+        result = ( 31 * result ) + Objects.hashCode(this.recurringPrice);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.tieredBlocks);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("fixedPrice=").append(this.fixedPrice);
+        sb.append(", ");
+        sb.append("limits=").append(Arrays.toString(this.limits));
+        sb.append(", ");
+        sb.append("recurringPrice=").append(this.recurringPrice);
+        sb.append(", ");
+        sb.append("tieredBlocks=").append(Arrays.toString(this.tieredBlocks));
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TierImp.Builder<T>> {
+
+        protected InternationalPrice fixedPrice;
+        protected Limit[] limits;
+        protected InternationalPrice recurringPrice;
+        protected TieredBlock[] tieredBlocks;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.fixedPrice = that.fixedPrice;
+            this.limits = that.limits;
+            this.recurringPrice = that.recurringPrice;
+            this.tieredBlocks = that.tieredBlocks;
+        }
+        public T withFixedPrice(final InternationalPrice fixedPrice) {
+            this.fixedPrice = fixedPrice;
+            return (T) this;
+        }
+        public T withLimits(final Limit[] limits) {
+            this.limits = limits;
+            return (T) this;
+        }
+        public T withRecurringPrice(final InternationalPrice recurringPrice) {
+            this.recurringPrice = recurringPrice;
+            return (T) this;
+        }
+        public T withTieredBlocks(final TieredBlock[] tieredBlocks) {
+            this.tieredBlocks = tieredBlocks;
+            return (T) this;
+        }
+        public T source(final Tier that) {
+            this.fixedPrice = that.getFixedPrice();
+            this.limits = that.getLimits();
+            this.recurringPrice = that.getRecurringPrice();
+            this.tieredBlocks = that.getTieredBlocks();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TierImp build() {
+            return new TierImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/TierPriceOverrideImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/TierPriceOverrideImp.java
@@ -1,0 +1,100 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.TierPriceOverride;
+import org.killbill.billing.catalog.api.TieredBlockPriceOverride;
+
+@JsonDeserialize( builder = TierPriceOverrideImp.Builder.class )
+public class TierPriceOverrideImp implements TierPriceOverride, Serializable {
+
+    private static final long serialVersionUID = 0x500AF08EB554052AL;
+
+    protected List<TieredBlockPriceOverride> tieredBlockPriceOverrides;
+
+    public TierPriceOverrideImp(final TierPriceOverrideImp that) {
+        this.tieredBlockPriceOverrides = that.tieredBlockPriceOverrides;
+    }
+    protected TierPriceOverrideImp(final TierPriceOverrideImp.Builder<?> builder) {
+        this.tieredBlockPriceOverrides = builder.tieredBlockPriceOverrides;
+    }
+    protected TierPriceOverrideImp() { }
+    @Override
+    public List<TieredBlockPriceOverride> getTieredBlockPriceOverrides() {
+        return this.tieredBlockPriceOverrides;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TierPriceOverrideImp that = (TierPriceOverrideImp) o;
+        if( !Objects.equals(this.tieredBlockPriceOverrides, that.tieredBlockPriceOverrides) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.tieredBlockPriceOverrides);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("tieredBlockPriceOverrides=").append(this.tieredBlockPriceOverrides);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TierPriceOverrideImp.Builder<T>> {
+
+        protected List<TieredBlockPriceOverride> tieredBlockPriceOverrides;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.tieredBlockPriceOverrides = that.tieredBlockPriceOverrides;
+        }
+        public T withTieredBlockPriceOverrides(final List<TieredBlockPriceOverride> tieredBlockPriceOverrides) {
+            this.tieredBlockPriceOverrides = tieredBlockPriceOverrides;
+            return (T) this;
+        }
+        public T source(final TierPriceOverride that) {
+            this.tieredBlockPriceOverrides = that.getTieredBlockPriceOverrides();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TierPriceOverrideImp build() {
+            return new TierPriceOverrideImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/TieredBlockImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/TieredBlockImp.java
@@ -1,0 +1,202 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BlockType;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.InternationalPrice;
+import org.killbill.billing.catalog.api.TieredBlock;
+import org.killbill.billing.catalog.api.Unit;
+
+@JsonDeserialize( builder = TieredBlockImp.Builder.class )
+public class TieredBlockImp implements TieredBlock, Serializable {
+
+    private static final long serialVersionUID = 0xD94B1A0BE079B80L;
+
+    protected Double max;
+    protected Double minTopUpCredit;
+    protected InternationalPrice price;
+    protected Double size;
+    protected BlockType type;
+    protected Unit unit;
+
+    public TieredBlockImp(final TieredBlockImp that) {
+        this.max = that.max;
+        this.minTopUpCredit = that.minTopUpCredit;
+        this.price = that.price;
+        this.size = that.size;
+        this.type = that.type;
+        this.unit = that.unit;
+    }
+    protected TieredBlockImp(final TieredBlockImp.Builder<?> builder) {
+        this.max = builder.max;
+        this.minTopUpCredit = builder.minTopUpCredit;
+        this.price = builder.price;
+        this.size = builder.size;
+        this.type = builder.type;
+        this.unit = builder.unit;
+    }
+    protected TieredBlockImp() { }
+    @Override
+    public Double getMax() {
+        return this.max;
+    }
+    @Override
+    public Double getMinTopUpCredit() {
+        return this.minTopUpCredit;
+    }
+    @Override
+    public InternationalPrice getPrice() {
+        return this.price;
+    }
+    @Override
+    public Double getSize() {
+        return this.size;
+    }
+    @Override
+    public BlockType getType() {
+        return this.type;
+    }
+    @Override
+    public Unit getUnit() {
+        return this.unit;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TieredBlockImp that = (TieredBlockImp) o;
+        if( !Objects.equals(this.max, that.max) ) {
+            return false;
+        }
+        if( !Objects.equals(this.minTopUpCredit, that.minTopUpCredit) ) {
+            return false;
+        }
+        if( !Objects.equals(this.price, that.price) ) {
+            return false;
+        }
+        if( !Objects.equals(this.size, that.size) ) {
+            return false;
+        }
+        if( !Objects.equals(this.type, that.type) ) {
+            return false;
+        }
+        if( !Objects.equals(this.unit, that.unit) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.max);
+        result = ( 31 * result ) + Objects.hashCode(this.minTopUpCredit);
+        result = ( 31 * result ) + Objects.hashCode(this.price);
+        result = ( 31 * result ) + Objects.hashCode(this.size);
+        result = ( 31 * result ) + Objects.hashCode(this.type);
+        result = ( 31 * result ) + Objects.hashCode(this.unit);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("max=").append(this.max);
+        sb.append(", ");
+        sb.append("minTopUpCredit=").append(this.minTopUpCredit);
+        sb.append(", ");
+        sb.append("price=").append(this.price);
+        sb.append(", ");
+        sb.append("size=").append(this.size);
+        sb.append(", ");
+        sb.append("type=").append(this.type);
+        sb.append(", ");
+        sb.append("unit=").append(this.unit);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TieredBlockImp.Builder<T>> {
+
+        protected Double max;
+        protected Double minTopUpCredit;
+        protected InternationalPrice price;
+        protected Double size;
+        protected BlockType type;
+        protected Unit unit;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.max = that.max;
+            this.minTopUpCredit = that.minTopUpCredit;
+            this.price = that.price;
+            this.size = that.size;
+            this.type = that.type;
+            this.unit = that.unit;
+        }
+        public T withMax(final Double max) {
+            this.max = max;
+            return (T) this;
+        }
+        public T withMinTopUpCredit(final Double minTopUpCredit) {
+            this.minTopUpCredit = minTopUpCredit;
+            return (T) this;
+        }
+        public T withPrice(final InternationalPrice price) {
+            this.price = price;
+            return (T) this;
+        }
+        public T withSize(final Double size) {
+            this.size = size;
+            return (T) this;
+        }
+        public T withType(final BlockType type) {
+            this.type = type;
+            return (T) this;
+        }
+        public T withUnit(final Unit unit) {
+            this.unit = unit;
+            return (T) this;
+        }
+        public T source(final TieredBlock that) throws CatalogApiException {
+            this.max = that.getMax();
+            this.minTopUpCredit = that.getMinTopUpCredit();
+            this.price = that.getPrice();
+            this.size = that.getSize();
+            this.type = that.getType();
+            this.unit = that.getUnit();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TieredBlockImp build() {
+            return new TieredBlockImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/TieredBlockPriceOverrideImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/TieredBlockPriceOverrideImp.java
@@ -1,0 +1,185 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.catalog.api.TieredBlockPriceOverride;
+
+@JsonDeserialize( builder = TieredBlockPriceOverrideImp.Builder.class )
+public class TieredBlockPriceOverrideImp implements TieredBlockPriceOverride, Serializable {
+
+    private static final long serialVersionUID = 0x98BDDDE54E98099EL;
+
+    protected Currency currency;
+    protected Double max;
+    protected BigDecimal price;
+    protected Double size;
+    protected String unitName;
+
+    public TieredBlockPriceOverrideImp(final TieredBlockPriceOverrideImp that) {
+        this.currency = that.currency;
+        this.max = that.max;
+        this.price = that.price;
+        this.size = that.size;
+        this.unitName = that.unitName;
+    }
+    protected TieredBlockPriceOverrideImp(final TieredBlockPriceOverrideImp.Builder<?> builder) {
+        this.currency = builder.currency;
+        this.max = builder.max;
+        this.price = builder.price;
+        this.size = builder.size;
+        this.unitName = builder.unitName;
+    }
+    protected TieredBlockPriceOverrideImp() { }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public Double getMax() {
+        return this.max;
+    }
+    @Override
+    public BigDecimal getPrice() {
+        return this.price;
+    }
+    @Override
+    public Double getSize() {
+        return this.size;
+    }
+    @Override
+    public String getUnitName() {
+        return this.unitName;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TieredBlockPriceOverrideImp that = (TieredBlockPriceOverrideImp) o;
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.max, that.max) ) {
+            return false;
+        }
+        if( ( this.price != null ) ? ( 0 != this.price.compareTo(that.price) ) : ( that.price != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.size, that.size) ) {
+            return false;
+        }
+        if( !Objects.equals(this.unitName, that.unitName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.max);
+        result = ( 31 * result ) + Objects.hashCode(this.price);
+        result = ( 31 * result ) + Objects.hashCode(this.size);
+        result = ( 31 * result ) + Objects.hashCode(this.unitName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("max=").append(this.max);
+        sb.append(", ");
+        sb.append("price=").append(this.price);
+        sb.append(", ");
+        sb.append("size=").append(this.size);
+        sb.append(", ");
+        sb.append("unitName=");
+        if( this.unitName == null ) {
+            sb.append(this.unitName);
+        }else{
+            sb.append("'").append(this.unitName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TieredBlockPriceOverrideImp.Builder<T>> {
+
+        protected Currency currency;
+        protected Double max;
+        protected BigDecimal price;
+        protected Double size;
+        protected String unitName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.currency = that.currency;
+            this.max = that.max;
+            this.price = that.price;
+            this.size = that.size;
+            this.unitName = that.unitName;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withMax(final Double max) {
+            this.max = max;
+            return (T) this;
+        }
+        public T withPrice(final BigDecimal price) {
+            this.price = price;
+            return (T) this;
+        }
+        public T withSize(final Double size) {
+            this.size = size;
+            return (T) this;
+        }
+        public T withUnitName(final String unitName) {
+            this.unitName = unitName;
+            return (T) this;
+        }
+        public T source(final TieredBlockPriceOverride that) {
+            this.currency = that.getCurrency();
+            this.max = that.getMax();
+            this.price = that.getPrice();
+            this.size = that.getSize();
+            this.unitName = that.getUnitName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TieredBlockPriceOverrideImp build() {
+            return new TieredBlockPriceOverrideImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/UnitImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/UnitImp.java
@@ -1,0 +1,128 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Unit;
+
+@JsonDeserialize( builder = UnitImp.Builder.class )
+public class UnitImp implements Unit, Serializable {
+
+    private static final long serialVersionUID = 0xA4C176CA323A34E3L;
+
+    protected String name;
+    protected String prettyName;
+
+    public UnitImp(final UnitImp that) {
+        this.name = that.name;
+        this.prettyName = that.prettyName;
+    }
+    protected UnitImp(final UnitImp.Builder<?> builder) {
+        this.name = builder.name;
+        this.prettyName = builder.prettyName;
+    }
+    protected UnitImp() { }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public String getPrettyName() {
+        return this.prettyName;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final UnitImp that = (UnitImp) o;
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyName, that.prettyName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyName=");
+        if( this.prettyName == null ) {
+            sb.append(this.prettyName);
+        }else{
+            sb.append("'").append(this.prettyName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends UnitImp.Builder<T>> {
+
+        protected String name;
+        protected String prettyName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.name = that.name;
+            this.prettyName = that.prettyName;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withPrettyName(final String prettyName) {
+            this.prettyName = prettyName;
+            return (T) this;
+        }
+        public T source(final Unit that) {
+            this.name = that.getName();
+            this.prettyName = that.getPrettyName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public UnitImp build() {
+            return new UnitImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/UsageImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/UsageImp.java
@@ -1,0 +1,341 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingMode;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.Block;
+import org.killbill.billing.catalog.api.InternationalPrice;
+import org.killbill.billing.catalog.api.Limit;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.Tier;
+import org.killbill.billing.catalog.api.TierBlockPolicy;
+import org.killbill.billing.catalog.api.Usage;
+import org.killbill.billing.catalog.api.UsageType;
+
+@JsonDeserialize( builder = UsageImp.Builder.class )
+public class UsageImp implements Usage, Serializable {
+
+    private static final long serialVersionUID = 0x11BB994DEC17BA4FL;
+
+    protected BillingMode billingMode;
+    protected BillingPeriod billingPeriod;
+    protected Block[] blocks;
+    protected StaticCatalog catalog;
+    protected InternationalPrice fixedPrice;
+    protected Limit[] limits;
+    protected String name;
+    protected String prettyName;
+    protected InternationalPrice recurringPrice;
+    protected TierBlockPolicy tierBlockPolicy;
+    protected Tier[] tiers;
+    protected UsageType usageType;
+
+    public UsageImp(final UsageImp that) {
+        this.billingMode = that.billingMode;
+        this.billingPeriod = that.billingPeriod;
+        this.blocks = that.blocks;
+        this.catalog = that.catalog;
+        this.fixedPrice = that.fixedPrice;
+        this.limits = that.limits;
+        this.name = that.name;
+        this.prettyName = that.prettyName;
+        this.recurringPrice = that.recurringPrice;
+        this.tierBlockPolicy = that.tierBlockPolicy;
+        this.tiers = that.tiers;
+        this.usageType = that.usageType;
+    }
+    protected UsageImp(final UsageImp.Builder<?> builder) {
+        this.billingMode = builder.billingMode;
+        this.billingPeriod = builder.billingPeriod;
+        this.blocks = builder.blocks;
+        this.catalog = builder.catalog;
+        this.fixedPrice = builder.fixedPrice;
+        this.limits = builder.limits;
+        this.name = builder.name;
+        this.prettyName = builder.prettyName;
+        this.recurringPrice = builder.recurringPrice;
+        this.tierBlockPolicy = builder.tierBlockPolicy;
+        this.tiers = builder.tiers;
+        this.usageType = builder.usageType;
+    }
+    protected UsageImp() { }
+    @Override
+    public BillingMode getBillingMode() {
+        return this.billingMode;
+    }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public Block[] getBlocks() {
+        return this.blocks;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public InternationalPrice getFixedPrice() {
+        return this.fixedPrice;
+    }
+    @Override
+    public Limit[] getLimits() {
+        return this.limits;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public String getPrettyName() {
+        return this.prettyName;
+    }
+    @Override
+    public InternationalPrice getRecurringPrice() {
+        return this.recurringPrice;
+    }
+    @Override
+    public TierBlockPolicy getTierBlockPolicy() {
+        return this.tierBlockPolicy;
+    }
+    @Override
+    public Tier[] getTiers() {
+        return this.tiers;
+    }
+    @Override
+    public UsageType getUsageType() {
+        return this.usageType;
+    }
+    @Override
+    public boolean compliesWithLimits(final String unit, final double value) {
+        throw new UnsupportedOperationException("compliesWithLimits(java.lang.String, double) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final UsageImp that = (UsageImp) o;
+        if( !Objects.equals(this.billingMode, that.billingMode) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.blocks, that.blocks) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fixedPrice, that.fixedPrice) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.limits, that.limits) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyName, that.prettyName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recurringPrice, that.recurringPrice) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tierBlockPolicy, that.tierBlockPolicy) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.tiers, that.tiers) ) {
+            return false;
+        }
+        if( !Objects.equals(this.usageType, that.usageType) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingMode);
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.blocks);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.fixedPrice);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.limits);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyName);
+        result = ( 31 * result ) + Objects.hashCode(this.recurringPrice);
+        result = ( 31 * result ) + Objects.hashCode(this.tierBlockPolicy);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.tiers);
+        result = ( 31 * result ) + Objects.hashCode(this.usageType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingMode=").append(this.billingMode);
+        sb.append(", ");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("blocks=").append(Arrays.toString(this.blocks));
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("fixedPrice=").append(this.fixedPrice);
+        sb.append(", ");
+        sb.append("limits=").append(Arrays.toString(this.limits));
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyName=");
+        if( this.prettyName == null ) {
+            sb.append(this.prettyName);
+        }else{
+            sb.append("'").append(this.prettyName).append("'");
+        }
+        sb.append(", ");
+        sb.append("recurringPrice=").append(this.recurringPrice);
+        sb.append(", ");
+        sb.append("tierBlockPolicy=").append(this.tierBlockPolicy);
+        sb.append(", ");
+        sb.append("tiers=").append(Arrays.toString(this.tiers));
+        sb.append(", ");
+        sb.append("usageType=").append(this.usageType);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends UsageImp.Builder<T>> {
+
+        protected BillingMode billingMode;
+        protected BillingPeriod billingPeriod;
+        protected Block[] blocks;
+        protected StaticCatalog catalog;
+        protected InternationalPrice fixedPrice;
+        protected Limit[] limits;
+        protected String name;
+        protected String prettyName;
+        protected InternationalPrice recurringPrice;
+        protected TierBlockPolicy tierBlockPolicy;
+        protected Tier[] tiers;
+        protected UsageType usageType;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingMode = that.billingMode;
+            this.billingPeriod = that.billingPeriod;
+            this.blocks = that.blocks;
+            this.catalog = that.catalog;
+            this.fixedPrice = that.fixedPrice;
+            this.limits = that.limits;
+            this.name = that.name;
+            this.prettyName = that.prettyName;
+            this.recurringPrice = that.recurringPrice;
+            this.tierBlockPolicy = that.tierBlockPolicy;
+            this.tiers = that.tiers;
+            this.usageType = that.usageType;
+        }
+        public T withBillingMode(final BillingMode billingMode) {
+            this.billingMode = billingMode;
+            return (T) this;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withBlocks(final Block[] blocks) {
+            this.blocks = blocks;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withFixedPrice(final InternationalPrice fixedPrice) {
+            this.fixedPrice = fixedPrice;
+            return (T) this;
+        }
+        public T withLimits(final Limit[] limits) {
+            this.limits = limits;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withPrettyName(final String prettyName) {
+            this.prettyName = prettyName;
+            return (T) this;
+        }
+        public T withRecurringPrice(final InternationalPrice recurringPrice) {
+            this.recurringPrice = recurringPrice;
+            return (T) this;
+        }
+        public T withTierBlockPolicy(final TierBlockPolicy tierBlockPolicy) {
+            this.tierBlockPolicy = tierBlockPolicy;
+            return (T) this;
+        }
+        public T withTiers(final Tier[] tiers) {
+            this.tiers = tiers;
+            return (T) this;
+        }
+        public T withUsageType(final UsageType usageType) {
+            this.usageType = usageType;
+            return (T) this;
+        }
+        public T source(final Usage that) {
+            this.billingMode = that.getBillingMode();
+            this.billingPeriod = that.getBillingPeriod();
+            this.blocks = that.getBlocks();
+            this.catalog = that.getCatalog();
+            this.fixedPrice = that.getFixedPrice();
+            this.limits = that.getLimits();
+            this.name = that.getName();
+            this.prettyName = that.getPrettyName();
+            this.recurringPrice = that.getRecurringPrice();
+            this.tierBlockPolicy = that.getTierBlockPolicy();
+            this.tiers = that.getTiers();
+            this.usageType = that.getUsageType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public UsageImp build() {
+            return new UsageImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/UsagePriceOverrideImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/UsagePriceOverrideImp.java
@@ -1,0 +1,146 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.TierPriceOverride;
+import org.killbill.billing.catalog.api.UsagePriceOverride;
+import org.killbill.billing.catalog.api.UsageType;
+
+@JsonDeserialize( builder = UsagePriceOverrideImp.Builder.class )
+public class UsagePriceOverrideImp implements UsagePriceOverride, Serializable {
+
+    private static final long serialVersionUID = 0x8569E26A79BC90A8L;
+
+    protected String name;
+    protected List<TierPriceOverride> tierPriceOverrides;
+    protected UsageType usageType;
+
+    public UsagePriceOverrideImp(final UsagePriceOverrideImp that) {
+        this.name = that.name;
+        this.tierPriceOverrides = that.tierPriceOverrides;
+        this.usageType = that.usageType;
+    }
+    protected UsagePriceOverrideImp(final UsagePriceOverrideImp.Builder<?> builder) {
+        this.name = builder.name;
+        this.tierPriceOverrides = builder.tierPriceOverrides;
+        this.usageType = builder.usageType;
+    }
+    protected UsagePriceOverrideImp() { }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public List<TierPriceOverride> getTierPriceOverrides() {
+        return this.tierPriceOverrides;
+    }
+    @Override
+    public UsageType getUsageType() {
+        return this.usageType;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final UsagePriceOverrideImp that = (UsagePriceOverrideImp) o;
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tierPriceOverrides, that.tierPriceOverrides) ) {
+            return false;
+        }
+        if( !Objects.equals(this.usageType, that.usageType) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.tierPriceOverrides);
+        result = ( 31 * result ) + Objects.hashCode(this.usageType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("tierPriceOverrides=").append(this.tierPriceOverrides);
+        sb.append(", ");
+        sb.append("usageType=").append(this.usageType);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends UsagePriceOverrideImp.Builder<T>> {
+
+        protected String name;
+        protected List<TierPriceOverride> tierPriceOverrides;
+        protected UsageType usageType;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.name = that.name;
+            this.tierPriceOverrides = that.tierPriceOverrides;
+            this.usageType = that.usageType;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withTierPriceOverrides(final List<TierPriceOverride> tierPriceOverrides) {
+            this.tierPriceOverrides = tierPriceOverrides;
+            return (T) this;
+        }
+        public T withUsageType(final UsageType usageType) {
+            this.usageType = usageType;
+            return (T) this;
+        }
+        public T source(final UsagePriceOverride that) {
+            this.name = that.getName();
+            this.tierPriceOverrides = that.getTierPriceOverrides();
+            this.usageType = that.getUsageType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public UsagePriceOverrideImp build() {
+            return new UsagePriceOverrideImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/VersionedCatalogImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/VersionedCatalogImp.java
@@ -1,0 +1,150 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.VersionedCatalog;
+
+@JsonDeserialize( builder = VersionedCatalogImp.Builder.class )
+public class VersionedCatalogImp implements VersionedCatalog, Serializable {
+
+    private static final long serialVersionUID = 0x8BE07D85C907BBD7L;
+
+    protected String catalogName;
+    protected StaticCatalog currentVersion;
+    protected List<StaticCatalog> versions;
+
+    public VersionedCatalogImp(final VersionedCatalogImp that) {
+        this.catalogName = that.catalogName;
+        this.currentVersion = that.currentVersion;
+        this.versions = that.versions;
+    }
+    protected VersionedCatalogImp(final VersionedCatalogImp.Builder<?> builder) {
+        this.catalogName = builder.catalogName;
+        this.currentVersion = builder.currentVersion;
+        this.versions = builder.versions;
+    }
+    protected VersionedCatalogImp() { }
+    @Override
+    public String getCatalogName() {
+        return this.catalogName;
+    }
+    @Override
+    public StaticCatalog getCurrentVersion() {
+        return this.currentVersion;
+    }
+    @Override
+    public List<StaticCatalog> getVersions() {
+        return this.versions;
+    }
+    @Override
+    public StaticCatalog getVersion(final Date targetDate) {
+        throw new UnsupportedOperationException("getVersion(java.util.Date) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final VersionedCatalogImp that = (VersionedCatalogImp) o;
+        if( !Objects.equals(this.catalogName, that.catalogName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currentVersion, that.currentVersion) ) {
+            return false;
+        }
+        if( !Objects.equals(this.versions, that.versions) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.catalogName);
+        result = ( 31 * result ) + Objects.hashCode(this.currentVersion);
+        result = ( 31 * result ) + Objects.hashCode(this.versions);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("catalogName=");
+        if( this.catalogName == null ) {
+            sb.append(this.catalogName);
+        }else{
+            sb.append("'").append(this.catalogName).append("'");
+        }
+        sb.append(", ");
+        sb.append("currentVersion=").append(this.currentVersion);
+        sb.append(", ");
+        sb.append("versions=").append(this.versions);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends VersionedCatalogImp.Builder<T>> {
+
+        protected String catalogName;
+        protected StaticCatalog currentVersion;
+        protected List<StaticCatalog> versions;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.catalogName = that.catalogName;
+            this.currentVersion = that.currentVersion;
+            this.versions = that.versions;
+        }
+        public T withCatalogName(final String catalogName) {
+            this.catalogName = catalogName;
+            return (T) this;
+        }
+        public T withCurrentVersion(final StaticCatalog currentVersion) {
+            this.currentVersion = currentVersion;
+            return (T) this;
+        }
+        public T withVersions(final List<StaticCatalog> versions) {
+            this.versions = versions;
+            return (T) this;
+        }
+        public T source(final VersionedCatalog that) {
+            this.catalogName = that.getCatalogName();
+            this.currentVersion = that.getCurrentVersion();
+            this.versions = that.getVersions();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public VersionedCatalogImp build() {
+            return new VersionedCatalogImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseBillingAlignmentImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseBillingAlignmentImp.java
@@ -1,0 +1,225 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingAlignment;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CaseBillingAlignment;
+
+@JsonDeserialize( builder = CaseBillingAlignmentImp.Builder.class )
+public class CaseBillingAlignmentImp implements CaseBillingAlignment, Serializable {
+
+    private static final long serialVersionUID = 0xD6A4C0E45541455L;
+
+    protected BillingAlignment billingAlignment;
+    protected BillingPeriod billingPeriod;
+    protected StaticCatalog catalog;
+    protected PhaseType phaseType;
+    protected PriceList priceList;
+    protected Product product;
+    protected ProductCategory productCategory;
+
+    public CaseBillingAlignmentImp(final CaseBillingAlignmentImp that) {
+        this.billingAlignment = that.billingAlignment;
+        this.billingPeriod = that.billingPeriod;
+        this.catalog = that.catalog;
+        this.phaseType = that.phaseType;
+        this.priceList = that.priceList;
+        this.product = that.product;
+        this.productCategory = that.productCategory;
+    }
+    protected CaseBillingAlignmentImp(final CaseBillingAlignmentImp.Builder<?> builder) {
+        this.billingAlignment = builder.billingAlignment;
+        this.billingPeriod = builder.billingPeriod;
+        this.catalog = builder.catalog;
+        this.phaseType = builder.phaseType;
+        this.priceList = builder.priceList;
+        this.product = builder.product;
+        this.productCategory = builder.productCategory;
+    }
+    protected CaseBillingAlignmentImp() { }
+    @Override
+    public BillingAlignment getBillingAlignment() {
+        return this.billingAlignment;
+    }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public PhaseType getPhaseType() {
+        return this.phaseType;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public Product getProduct() {
+        return this.product;
+    }
+    @Override
+    public ProductCategory getProductCategory() {
+        return this.productCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CaseBillingAlignmentImp that = (CaseBillingAlignmentImp) o;
+        if( !Objects.equals(this.billingAlignment, that.billingAlignment) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseType, that.phaseType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.product, that.product) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productCategory, that.productCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingAlignment);
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseType);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.product);
+        result = ( 31 * result ) + Objects.hashCode(this.productCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingAlignment=").append(this.billingAlignment);
+        sb.append(", ");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("phaseType=").append(this.phaseType);
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append(", ");
+        sb.append("product=").append(this.product);
+        sb.append(", ");
+        sb.append("productCategory=").append(this.productCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CaseBillingAlignmentImp.Builder<T>> {
+
+        protected BillingAlignment billingAlignment;
+        protected BillingPeriod billingPeriod;
+        protected StaticCatalog catalog;
+        protected PhaseType phaseType;
+        protected PriceList priceList;
+        protected Product product;
+        protected ProductCategory productCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingAlignment = that.billingAlignment;
+            this.billingPeriod = that.billingPeriod;
+            this.catalog = that.catalog;
+            this.phaseType = that.phaseType;
+            this.priceList = that.priceList;
+            this.product = that.product;
+            this.productCategory = that.productCategory;
+        }
+        public T withBillingAlignment(final BillingAlignment billingAlignment) {
+            this.billingAlignment = billingAlignment;
+            return (T) this;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withPhaseType(final PhaseType phaseType) {
+            this.phaseType = phaseType;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProduct(final Product product) {
+            this.product = product;
+            return (T) this;
+        }
+        public T withProductCategory(final ProductCategory productCategory) {
+            this.productCategory = productCategory;
+            return (T) this;
+        }
+        public T source(final CaseBillingAlignment that) {
+            this.billingAlignment = that.getBillingAlignment();
+            this.billingPeriod = that.getBillingPeriod();
+            this.catalog = that.getCatalog();
+            this.phaseType = that.getPhaseType();
+            this.priceList = that.getPriceList();
+            this.product = that.getProduct();
+            this.productCategory = that.getProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CaseBillingAlignmentImp build() {
+            return new CaseBillingAlignmentImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseCancelPolicyImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseCancelPolicyImp.java
@@ -1,0 +1,225 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CaseCancelPolicy;
+
+@JsonDeserialize( builder = CaseCancelPolicyImp.Builder.class )
+public class CaseCancelPolicyImp implements CaseCancelPolicy, Serializable {
+
+    private static final long serialVersionUID = 0xE1E7268A5F18FDA4L;
+
+    protected BillingActionPolicy billingActionPolicy;
+    protected BillingPeriod billingPeriod;
+    protected StaticCatalog catalog;
+    protected PhaseType phaseType;
+    protected PriceList priceList;
+    protected Product product;
+    protected ProductCategory productCategory;
+
+    public CaseCancelPolicyImp(final CaseCancelPolicyImp that) {
+        this.billingActionPolicy = that.billingActionPolicy;
+        this.billingPeriod = that.billingPeriod;
+        this.catalog = that.catalog;
+        this.phaseType = that.phaseType;
+        this.priceList = that.priceList;
+        this.product = that.product;
+        this.productCategory = that.productCategory;
+    }
+    protected CaseCancelPolicyImp(final CaseCancelPolicyImp.Builder<?> builder) {
+        this.billingActionPolicy = builder.billingActionPolicy;
+        this.billingPeriod = builder.billingPeriod;
+        this.catalog = builder.catalog;
+        this.phaseType = builder.phaseType;
+        this.priceList = builder.priceList;
+        this.product = builder.product;
+        this.productCategory = builder.productCategory;
+    }
+    protected CaseCancelPolicyImp() { }
+    @Override
+    public BillingActionPolicy getBillingActionPolicy() {
+        return this.billingActionPolicy;
+    }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public PhaseType getPhaseType() {
+        return this.phaseType;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public Product getProduct() {
+        return this.product;
+    }
+    @Override
+    public ProductCategory getProductCategory() {
+        return this.productCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CaseCancelPolicyImp that = (CaseCancelPolicyImp) o;
+        if( !Objects.equals(this.billingActionPolicy, that.billingActionPolicy) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseType, that.phaseType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.product, that.product) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productCategory, that.productCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingActionPolicy);
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseType);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.product);
+        result = ( 31 * result ) + Objects.hashCode(this.productCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingActionPolicy=").append(this.billingActionPolicy);
+        sb.append(", ");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("phaseType=").append(this.phaseType);
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append(", ");
+        sb.append("product=").append(this.product);
+        sb.append(", ");
+        sb.append("productCategory=").append(this.productCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CaseCancelPolicyImp.Builder<T>> {
+
+        protected BillingActionPolicy billingActionPolicy;
+        protected BillingPeriod billingPeriod;
+        protected StaticCatalog catalog;
+        protected PhaseType phaseType;
+        protected PriceList priceList;
+        protected Product product;
+        protected ProductCategory productCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingActionPolicy = that.billingActionPolicy;
+            this.billingPeriod = that.billingPeriod;
+            this.catalog = that.catalog;
+            this.phaseType = that.phaseType;
+            this.priceList = that.priceList;
+            this.product = that.product;
+            this.productCategory = that.productCategory;
+        }
+        public T withBillingActionPolicy(final BillingActionPolicy billingActionPolicy) {
+            this.billingActionPolicy = billingActionPolicy;
+            return (T) this;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withPhaseType(final PhaseType phaseType) {
+            this.phaseType = phaseType;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProduct(final Product product) {
+            this.product = product;
+            return (T) this;
+        }
+        public T withProductCategory(final ProductCategory productCategory) {
+            this.productCategory = productCategory;
+            return (T) this;
+        }
+        public T source(final CaseCancelPolicy that) {
+            this.billingActionPolicy = that.getBillingActionPolicy();
+            this.billingPeriod = that.getBillingPeriod();
+            this.catalog = that.getCatalog();
+            this.phaseType = that.getPhaseType();
+            this.priceList = that.getPriceList();
+            this.product = that.getProduct();
+            this.productCategory = that.getProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CaseCancelPolicyImp build() {
+            return new CaseCancelPolicyImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseChangeImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseChangeImp.java
@@ -1,0 +1,284 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CaseChange;
+
+@JsonDeserialize( builder = CaseChangeImp.Builder.class )
+public class CaseChangeImp implements CaseChange, Serializable {
+
+    private static final long serialVersionUID = 0x2C17027C3FF1BA76L;
+
+    protected StaticCatalog catalog;
+    protected BillingPeriod fromBillingPeriod;
+    protected PriceList fromPriceList;
+    protected Product fromProduct;
+    protected ProductCategory fromProductCategory;
+    protected PhaseType phaseType;
+    protected BillingPeriod toBillingPeriod;
+    protected PriceList toPriceList;
+    protected Product toProduct;
+    protected ProductCategory toProductCategory;
+
+    public CaseChangeImp(final CaseChangeImp that) {
+        this.catalog = that.catalog;
+        this.fromBillingPeriod = that.fromBillingPeriod;
+        this.fromPriceList = that.fromPriceList;
+        this.fromProduct = that.fromProduct;
+        this.fromProductCategory = that.fromProductCategory;
+        this.phaseType = that.phaseType;
+        this.toBillingPeriod = that.toBillingPeriod;
+        this.toPriceList = that.toPriceList;
+        this.toProduct = that.toProduct;
+        this.toProductCategory = that.toProductCategory;
+    }
+    protected CaseChangeImp(final CaseChangeImp.Builder<?> builder) {
+        this.catalog = builder.catalog;
+        this.fromBillingPeriod = builder.fromBillingPeriod;
+        this.fromPriceList = builder.fromPriceList;
+        this.fromProduct = builder.fromProduct;
+        this.fromProductCategory = builder.fromProductCategory;
+        this.phaseType = builder.phaseType;
+        this.toBillingPeriod = builder.toBillingPeriod;
+        this.toPriceList = builder.toPriceList;
+        this.toProduct = builder.toProduct;
+        this.toProductCategory = builder.toProductCategory;
+    }
+    protected CaseChangeImp() { }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public BillingPeriod getFromBillingPeriod() {
+        return this.fromBillingPeriod;
+    }
+    @Override
+    public PriceList getFromPriceList() {
+        return this.fromPriceList;
+    }
+    @Override
+    public Product getFromProduct() {
+        return this.fromProduct;
+    }
+    @Override
+    public ProductCategory getFromProductCategory() {
+        return this.fromProductCategory;
+    }
+    @Override
+    public PhaseType getPhaseType() {
+        return this.phaseType;
+    }
+    @Override
+    public BillingPeriod getToBillingPeriod() {
+        return this.toBillingPeriod;
+    }
+    @Override
+    public PriceList getToPriceList() {
+        return this.toPriceList;
+    }
+    @Override
+    public Product getToProduct() {
+        return this.toProduct;
+    }
+    @Override
+    public ProductCategory getToProductCategory() {
+        return this.toProductCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CaseChangeImp that = (CaseChangeImp) o;
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromBillingPeriod, that.fromBillingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromPriceList, that.fromPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromProduct, that.fromProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromProductCategory, that.fromProductCategory) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseType, that.phaseType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toBillingPeriod, that.toBillingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toPriceList, that.toPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toProduct, that.toProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toProductCategory, that.toProductCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.fromBillingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.fromPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.fromProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.fromProductCategory);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseType);
+        result = ( 31 * result ) + Objects.hashCode(this.toBillingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.toPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.toProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.toProductCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("fromBillingPeriod=").append(this.fromBillingPeriod);
+        sb.append(", ");
+        sb.append("fromPriceList=").append(this.fromPriceList);
+        sb.append(", ");
+        sb.append("fromProduct=").append(this.fromProduct);
+        sb.append(", ");
+        sb.append("fromProductCategory=").append(this.fromProductCategory);
+        sb.append(", ");
+        sb.append("phaseType=").append(this.phaseType);
+        sb.append(", ");
+        sb.append("toBillingPeriod=").append(this.toBillingPeriod);
+        sb.append(", ");
+        sb.append("toPriceList=").append(this.toPriceList);
+        sb.append(", ");
+        sb.append("toProduct=").append(this.toProduct);
+        sb.append(", ");
+        sb.append("toProductCategory=").append(this.toProductCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CaseChangeImp.Builder<T>> {
+
+        protected StaticCatalog catalog;
+        protected BillingPeriod fromBillingPeriod;
+        protected PriceList fromPriceList;
+        protected Product fromProduct;
+        protected ProductCategory fromProductCategory;
+        protected PhaseType phaseType;
+        protected BillingPeriod toBillingPeriod;
+        protected PriceList toPriceList;
+        protected Product toProduct;
+        protected ProductCategory toProductCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.catalog = that.catalog;
+            this.fromBillingPeriod = that.fromBillingPeriod;
+            this.fromPriceList = that.fromPriceList;
+            this.fromProduct = that.fromProduct;
+            this.fromProductCategory = that.fromProductCategory;
+            this.phaseType = that.phaseType;
+            this.toBillingPeriod = that.toBillingPeriod;
+            this.toPriceList = that.toPriceList;
+            this.toProduct = that.toProduct;
+            this.toProductCategory = that.toProductCategory;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withFromBillingPeriod(final BillingPeriod fromBillingPeriod) {
+            this.fromBillingPeriod = fromBillingPeriod;
+            return (T) this;
+        }
+        public T withFromPriceList(final PriceList fromPriceList) {
+            this.fromPriceList = fromPriceList;
+            return (T) this;
+        }
+        public T withFromProduct(final Product fromProduct) {
+            this.fromProduct = fromProduct;
+            return (T) this;
+        }
+        public T withFromProductCategory(final ProductCategory fromProductCategory) {
+            this.fromProductCategory = fromProductCategory;
+            return (T) this;
+        }
+        public T withPhaseType(final PhaseType phaseType) {
+            this.phaseType = phaseType;
+            return (T) this;
+        }
+        public T withToBillingPeriod(final BillingPeriod toBillingPeriod) {
+            this.toBillingPeriod = toBillingPeriod;
+            return (T) this;
+        }
+        public T withToPriceList(final PriceList toPriceList) {
+            this.toPriceList = toPriceList;
+            return (T) this;
+        }
+        public T withToProduct(final Product toProduct) {
+            this.toProduct = toProduct;
+            return (T) this;
+        }
+        public T withToProductCategory(final ProductCategory toProductCategory) {
+            this.toProductCategory = toProductCategory;
+            return (T) this;
+        }
+        public T source(final CaseChange that) {
+            this.catalog = that.getCatalog();
+            this.fromBillingPeriod = that.getFromBillingPeriod();
+            this.fromPriceList = that.getFromPriceList();
+            this.fromProduct = that.getFromProduct();
+            this.fromProductCategory = that.getFromProductCategory();
+            this.phaseType = that.getPhaseType();
+            this.toBillingPeriod = that.getToBillingPeriod();
+            this.toPriceList = that.getToPriceList();
+            this.toProduct = that.getToProduct();
+            this.toProductCategory = that.getToProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CaseChangeImp build() {
+            return new CaseChangeImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseChangePlanAlignmentImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseChangePlanAlignmentImp.java
@@ -1,0 +1,305 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.PlanAlignmentChange;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CaseChangePlanAlignment;
+
+@JsonDeserialize( builder = CaseChangePlanAlignmentImp.Builder.class )
+public class CaseChangePlanAlignmentImp implements CaseChangePlanAlignment, Serializable {
+
+    private static final long serialVersionUID = 0x38AC3D2990AAF96BL;
+
+    protected PlanAlignmentChange alignment;
+    protected StaticCatalog catalog;
+    protected BillingPeriod fromBillingPeriod;
+    protected PriceList fromPriceList;
+    protected Product fromProduct;
+    protected ProductCategory fromProductCategory;
+    protected PhaseType phaseType;
+    protected BillingPeriod toBillingPeriod;
+    protected PriceList toPriceList;
+    protected Product toProduct;
+    protected ProductCategory toProductCategory;
+
+    public CaseChangePlanAlignmentImp(final CaseChangePlanAlignmentImp that) {
+        this.alignment = that.alignment;
+        this.catalog = that.catalog;
+        this.fromBillingPeriod = that.fromBillingPeriod;
+        this.fromPriceList = that.fromPriceList;
+        this.fromProduct = that.fromProduct;
+        this.fromProductCategory = that.fromProductCategory;
+        this.phaseType = that.phaseType;
+        this.toBillingPeriod = that.toBillingPeriod;
+        this.toPriceList = that.toPriceList;
+        this.toProduct = that.toProduct;
+        this.toProductCategory = that.toProductCategory;
+    }
+    protected CaseChangePlanAlignmentImp(final CaseChangePlanAlignmentImp.Builder<?> builder) {
+        this.alignment = builder.alignment;
+        this.catalog = builder.catalog;
+        this.fromBillingPeriod = builder.fromBillingPeriod;
+        this.fromPriceList = builder.fromPriceList;
+        this.fromProduct = builder.fromProduct;
+        this.fromProductCategory = builder.fromProductCategory;
+        this.phaseType = builder.phaseType;
+        this.toBillingPeriod = builder.toBillingPeriod;
+        this.toPriceList = builder.toPriceList;
+        this.toProduct = builder.toProduct;
+        this.toProductCategory = builder.toProductCategory;
+    }
+    protected CaseChangePlanAlignmentImp() { }
+    @Override
+    public PlanAlignmentChange getAlignment() {
+        return this.alignment;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public BillingPeriod getFromBillingPeriod() {
+        return this.fromBillingPeriod;
+    }
+    @Override
+    public PriceList getFromPriceList() {
+        return this.fromPriceList;
+    }
+    @Override
+    public Product getFromProduct() {
+        return this.fromProduct;
+    }
+    @Override
+    public ProductCategory getFromProductCategory() {
+        return this.fromProductCategory;
+    }
+    @Override
+    public PhaseType getPhaseType() {
+        return this.phaseType;
+    }
+    @Override
+    public BillingPeriod getToBillingPeriod() {
+        return this.toBillingPeriod;
+    }
+    @Override
+    public PriceList getToPriceList() {
+        return this.toPriceList;
+    }
+    @Override
+    public Product getToProduct() {
+        return this.toProduct;
+    }
+    @Override
+    public ProductCategory getToProductCategory() {
+        return this.toProductCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CaseChangePlanAlignmentImp that = (CaseChangePlanAlignmentImp) o;
+        if( !Objects.equals(this.alignment, that.alignment) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromBillingPeriod, that.fromBillingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromPriceList, that.fromPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromProduct, that.fromProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromProductCategory, that.fromProductCategory) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseType, that.phaseType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toBillingPeriod, that.toBillingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toPriceList, that.toPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toProduct, that.toProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toProductCategory, that.toProductCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.alignment);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.fromBillingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.fromPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.fromProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.fromProductCategory);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseType);
+        result = ( 31 * result ) + Objects.hashCode(this.toBillingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.toPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.toProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.toProductCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("alignment=").append(this.alignment);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("fromBillingPeriod=").append(this.fromBillingPeriod);
+        sb.append(", ");
+        sb.append("fromPriceList=").append(this.fromPriceList);
+        sb.append(", ");
+        sb.append("fromProduct=").append(this.fromProduct);
+        sb.append(", ");
+        sb.append("fromProductCategory=").append(this.fromProductCategory);
+        sb.append(", ");
+        sb.append("phaseType=").append(this.phaseType);
+        sb.append(", ");
+        sb.append("toBillingPeriod=").append(this.toBillingPeriod);
+        sb.append(", ");
+        sb.append("toPriceList=").append(this.toPriceList);
+        sb.append(", ");
+        sb.append("toProduct=").append(this.toProduct);
+        sb.append(", ");
+        sb.append("toProductCategory=").append(this.toProductCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CaseChangePlanAlignmentImp.Builder<T>> {
+
+        protected PlanAlignmentChange alignment;
+        protected StaticCatalog catalog;
+        protected BillingPeriod fromBillingPeriod;
+        protected PriceList fromPriceList;
+        protected Product fromProduct;
+        protected ProductCategory fromProductCategory;
+        protected PhaseType phaseType;
+        protected BillingPeriod toBillingPeriod;
+        protected PriceList toPriceList;
+        protected Product toProduct;
+        protected ProductCategory toProductCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.alignment = that.alignment;
+            this.catalog = that.catalog;
+            this.fromBillingPeriod = that.fromBillingPeriod;
+            this.fromPriceList = that.fromPriceList;
+            this.fromProduct = that.fromProduct;
+            this.fromProductCategory = that.fromProductCategory;
+            this.phaseType = that.phaseType;
+            this.toBillingPeriod = that.toBillingPeriod;
+            this.toPriceList = that.toPriceList;
+            this.toProduct = that.toProduct;
+            this.toProductCategory = that.toProductCategory;
+        }
+        public T withAlignment(final PlanAlignmentChange alignment) {
+            this.alignment = alignment;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withFromBillingPeriod(final BillingPeriod fromBillingPeriod) {
+            this.fromBillingPeriod = fromBillingPeriod;
+            return (T) this;
+        }
+        public T withFromPriceList(final PriceList fromPriceList) {
+            this.fromPriceList = fromPriceList;
+            return (T) this;
+        }
+        public T withFromProduct(final Product fromProduct) {
+            this.fromProduct = fromProduct;
+            return (T) this;
+        }
+        public T withFromProductCategory(final ProductCategory fromProductCategory) {
+            this.fromProductCategory = fromProductCategory;
+            return (T) this;
+        }
+        public T withPhaseType(final PhaseType phaseType) {
+            this.phaseType = phaseType;
+            return (T) this;
+        }
+        public T withToBillingPeriod(final BillingPeriod toBillingPeriod) {
+            this.toBillingPeriod = toBillingPeriod;
+            return (T) this;
+        }
+        public T withToPriceList(final PriceList toPriceList) {
+            this.toPriceList = toPriceList;
+            return (T) this;
+        }
+        public T withToProduct(final Product toProduct) {
+            this.toProduct = toProduct;
+            return (T) this;
+        }
+        public T withToProductCategory(final ProductCategory toProductCategory) {
+            this.toProductCategory = toProductCategory;
+            return (T) this;
+        }
+        public T source(final CaseChangePlanAlignment that) {
+            this.alignment = that.getAlignment();
+            this.catalog = that.getCatalog();
+            this.fromBillingPeriod = that.getFromBillingPeriod();
+            this.fromPriceList = that.getFromPriceList();
+            this.fromProduct = that.getFromProduct();
+            this.fromProductCategory = that.getFromProductCategory();
+            this.phaseType = that.getPhaseType();
+            this.toBillingPeriod = that.getToBillingPeriod();
+            this.toPriceList = that.getToPriceList();
+            this.toProduct = that.getToProduct();
+            this.toProductCategory = that.getToProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CaseChangePlanAlignmentImp build() {
+            return new CaseChangePlanAlignmentImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseChangePlanPolicyImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseChangePlanPolicyImp.java
@@ -1,0 +1,305 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CaseChangePlanPolicy;
+
+@JsonDeserialize( builder = CaseChangePlanPolicyImp.Builder.class )
+public class CaseChangePlanPolicyImp implements CaseChangePlanPolicy, Serializable {
+
+    private static final long serialVersionUID = 0xA77F2F23913B6A4L;
+
+    protected BillingActionPolicy billingActionPolicy;
+    protected StaticCatalog catalog;
+    protected BillingPeriod fromBillingPeriod;
+    protected PriceList fromPriceList;
+    protected Product fromProduct;
+    protected ProductCategory fromProductCategory;
+    protected PhaseType phaseType;
+    protected BillingPeriod toBillingPeriod;
+    protected PriceList toPriceList;
+    protected Product toProduct;
+    protected ProductCategory toProductCategory;
+
+    public CaseChangePlanPolicyImp(final CaseChangePlanPolicyImp that) {
+        this.billingActionPolicy = that.billingActionPolicy;
+        this.catalog = that.catalog;
+        this.fromBillingPeriod = that.fromBillingPeriod;
+        this.fromPriceList = that.fromPriceList;
+        this.fromProduct = that.fromProduct;
+        this.fromProductCategory = that.fromProductCategory;
+        this.phaseType = that.phaseType;
+        this.toBillingPeriod = that.toBillingPeriod;
+        this.toPriceList = that.toPriceList;
+        this.toProduct = that.toProduct;
+        this.toProductCategory = that.toProductCategory;
+    }
+    protected CaseChangePlanPolicyImp(final CaseChangePlanPolicyImp.Builder<?> builder) {
+        this.billingActionPolicy = builder.billingActionPolicy;
+        this.catalog = builder.catalog;
+        this.fromBillingPeriod = builder.fromBillingPeriod;
+        this.fromPriceList = builder.fromPriceList;
+        this.fromProduct = builder.fromProduct;
+        this.fromProductCategory = builder.fromProductCategory;
+        this.phaseType = builder.phaseType;
+        this.toBillingPeriod = builder.toBillingPeriod;
+        this.toPriceList = builder.toPriceList;
+        this.toProduct = builder.toProduct;
+        this.toProductCategory = builder.toProductCategory;
+    }
+    protected CaseChangePlanPolicyImp() { }
+    @Override
+    public BillingActionPolicy getBillingActionPolicy() {
+        return this.billingActionPolicy;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public BillingPeriod getFromBillingPeriod() {
+        return this.fromBillingPeriod;
+    }
+    @Override
+    public PriceList getFromPriceList() {
+        return this.fromPriceList;
+    }
+    @Override
+    public Product getFromProduct() {
+        return this.fromProduct;
+    }
+    @Override
+    public ProductCategory getFromProductCategory() {
+        return this.fromProductCategory;
+    }
+    @Override
+    public PhaseType getPhaseType() {
+        return this.phaseType;
+    }
+    @Override
+    public BillingPeriod getToBillingPeriod() {
+        return this.toBillingPeriod;
+    }
+    @Override
+    public PriceList getToPriceList() {
+        return this.toPriceList;
+    }
+    @Override
+    public Product getToProduct() {
+        return this.toProduct;
+    }
+    @Override
+    public ProductCategory getToProductCategory() {
+        return this.toProductCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CaseChangePlanPolicyImp that = (CaseChangePlanPolicyImp) o;
+        if( !Objects.equals(this.billingActionPolicy, that.billingActionPolicy) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromBillingPeriod, that.fromBillingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromPriceList, that.fromPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromProduct, that.fromProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fromProductCategory, that.fromProductCategory) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseType, that.phaseType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toBillingPeriod, that.toBillingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toPriceList, that.toPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toProduct, that.toProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.toProductCategory, that.toProductCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingActionPolicy);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.fromBillingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.fromPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.fromProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.fromProductCategory);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseType);
+        result = ( 31 * result ) + Objects.hashCode(this.toBillingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.toPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.toProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.toProductCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingActionPolicy=").append(this.billingActionPolicy);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("fromBillingPeriod=").append(this.fromBillingPeriod);
+        sb.append(", ");
+        sb.append("fromPriceList=").append(this.fromPriceList);
+        sb.append(", ");
+        sb.append("fromProduct=").append(this.fromProduct);
+        sb.append(", ");
+        sb.append("fromProductCategory=").append(this.fromProductCategory);
+        sb.append(", ");
+        sb.append("phaseType=").append(this.phaseType);
+        sb.append(", ");
+        sb.append("toBillingPeriod=").append(this.toBillingPeriod);
+        sb.append(", ");
+        sb.append("toPriceList=").append(this.toPriceList);
+        sb.append(", ");
+        sb.append("toProduct=").append(this.toProduct);
+        sb.append(", ");
+        sb.append("toProductCategory=").append(this.toProductCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CaseChangePlanPolicyImp.Builder<T>> {
+
+        protected BillingActionPolicy billingActionPolicy;
+        protected StaticCatalog catalog;
+        protected BillingPeriod fromBillingPeriod;
+        protected PriceList fromPriceList;
+        protected Product fromProduct;
+        protected ProductCategory fromProductCategory;
+        protected PhaseType phaseType;
+        protected BillingPeriod toBillingPeriod;
+        protected PriceList toPriceList;
+        protected Product toProduct;
+        protected ProductCategory toProductCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingActionPolicy = that.billingActionPolicy;
+            this.catalog = that.catalog;
+            this.fromBillingPeriod = that.fromBillingPeriod;
+            this.fromPriceList = that.fromPriceList;
+            this.fromProduct = that.fromProduct;
+            this.fromProductCategory = that.fromProductCategory;
+            this.phaseType = that.phaseType;
+            this.toBillingPeriod = that.toBillingPeriod;
+            this.toPriceList = that.toPriceList;
+            this.toProduct = that.toProduct;
+            this.toProductCategory = that.toProductCategory;
+        }
+        public T withBillingActionPolicy(final BillingActionPolicy billingActionPolicy) {
+            this.billingActionPolicy = billingActionPolicy;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withFromBillingPeriod(final BillingPeriod fromBillingPeriod) {
+            this.fromBillingPeriod = fromBillingPeriod;
+            return (T) this;
+        }
+        public T withFromPriceList(final PriceList fromPriceList) {
+            this.fromPriceList = fromPriceList;
+            return (T) this;
+        }
+        public T withFromProduct(final Product fromProduct) {
+            this.fromProduct = fromProduct;
+            return (T) this;
+        }
+        public T withFromProductCategory(final ProductCategory fromProductCategory) {
+            this.fromProductCategory = fromProductCategory;
+            return (T) this;
+        }
+        public T withPhaseType(final PhaseType phaseType) {
+            this.phaseType = phaseType;
+            return (T) this;
+        }
+        public T withToBillingPeriod(final BillingPeriod toBillingPeriod) {
+            this.toBillingPeriod = toBillingPeriod;
+            return (T) this;
+        }
+        public T withToPriceList(final PriceList toPriceList) {
+            this.toPriceList = toPriceList;
+            return (T) this;
+        }
+        public T withToProduct(final Product toProduct) {
+            this.toProduct = toProduct;
+            return (T) this;
+        }
+        public T withToProductCategory(final ProductCategory toProductCategory) {
+            this.toProductCategory = toProductCategory;
+            return (T) this;
+        }
+        public T source(final CaseChangePlanPolicy that) {
+            this.billingActionPolicy = that.getBillingActionPolicy();
+            this.catalog = that.getCatalog();
+            this.fromBillingPeriod = that.getFromBillingPeriod();
+            this.fromPriceList = that.getFromPriceList();
+            this.fromProduct = that.getFromProduct();
+            this.fromProductCategory = that.getFromProductCategory();
+            this.phaseType = that.getPhaseType();
+            this.toBillingPeriod = that.getToBillingPeriod();
+            this.toPriceList = that.getToPriceList();
+            this.toProduct = that.getToProduct();
+            this.toProductCategory = that.getToProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CaseChangePlanPolicyImp build() {
+            return new CaseChangePlanPolicyImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseCreateAlignmentImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseCreateAlignmentImp.java
@@ -1,0 +1,204 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PlanAlignmentCreate;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CaseCreateAlignment;
+
+@JsonDeserialize( builder = CaseCreateAlignmentImp.Builder.class )
+public class CaseCreateAlignmentImp implements CaseCreateAlignment, Serializable {
+
+    private static final long serialVersionUID = 0xADD02147DA69A7CCL;
+
+    protected BillingPeriod billingPeriod;
+    protected StaticCatalog catalog;
+    protected PlanAlignmentCreate planAlignmentCreate;
+    protected PriceList priceList;
+    protected Product product;
+    protected ProductCategory productCategory;
+
+    public CaseCreateAlignmentImp(final CaseCreateAlignmentImp that) {
+        this.billingPeriod = that.billingPeriod;
+        this.catalog = that.catalog;
+        this.planAlignmentCreate = that.planAlignmentCreate;
+        this.priceList = that.priceList;
+        this.product = that.product;
+        this.productCategory = that.productCategory;
+    }
+    protected CaseCreateAlignmentImp(final CaseCreateAlignmentImp.Builder<?> builder) {
+        this.billingPeriod = builder.billingPeriod;
+        this.catalog = builder.catalog;
+        this.planAlignmentCreate = builder.planAlignmentCreate;
+        this.priceList = builder.priceList;
+        this.product = builder.product;
+        this.productCategory = builder.productCategory;
+    }
+    protected CaseCreateAlignmentImp() { }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public PlanAlignmentCreate getPlanAlignmentCreate() {
+        return this.planAlignmentCreate;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public Product getProduct() {
+        return this.product;
+    }
+    @Override
+    public ProductCategory getProductCategory() {
+        return this.productCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CaseCreateAlignmentImp that = (CaseCreateAlignmentImp) o;
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.planAlignmentCreate, that.planAlignmentCreate) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.product, that.product) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productCategory, that.productCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.planAlignmentCreate);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.product);
+        result = ( 31 * result ) + Objects.hashCode(this.productCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("planAlignmentCreate=").append(this.planAlignmentCreate);
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append(", ");
+        sb.append("product=").append(this.product);
+        sb.append(", ");
+        sb.append("productCategory=").append(this.productCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CaseCreateAlignmentImp.Builder<T>> {
+
+        protected BillingPeriod billingPeriod;
+        protected StaticCatalog catalog;
+        protected PlanAlignmentCreate planAlignmentCreate;
+        protected PriceList priceList;
+        protected Product product;
+        protected ProductCategory productCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingPeriod = that.billingPeriod;
+            this.catalog = that.catalog;
+            this.planAlignmentCreate = that.planAlignmentCreate;
+            this.priceList = that.priceList;
+            this.product = that.product;
+            this.productCategory = that.productCategory;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withPlanAlignmentCreate(final PlanAlignmentCreate planAlignmentCreate) {
+            this.planAlignmentCreate = planAlignmentCreate;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProduct(final Product product) {
+            this.product = product;
+            return (T) this;
+        }
+        public T withProductCategory(final ProductCategory productCategory) {
+            this.productCategory = productCategory;
+            return (T) this;
+        }
+        public T source(final CaseCreateAlignment that) {
+            this.billingPeriod = that.getBillingPeriod();
+            this.catalog = that.getCatalog();
+            this.planAlignmentCreate = that.getPlanAlignmentCreate();
+            this.priceList = that.getPriceList();
+            this.product = that.getProduct();
+            this.productCategory = that.getProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CaseCreateAlignmentImp build() {
+            return new CaseCreateAlignmentImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CaseImp.java
@@ -1,0 +1,183 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.Case;
+
+@JsonDeserialize( builder = CaseImp.Builder.class )
+public class CaseImp implements Case, Serializable {
+
+    private static final long serialVersionUID = 0x64C7AD305395C264L;
+
+    protected BillingPeriod billingPeriod;
+    protected StaticCatalog catalog;
+    protected PriceList priceList;
+    protected Product product;
+    protected ProductCategory productCategory;
+
+    public CaseImp(final CaseImp that) {
+        this.billingPeriod = that.billingPeriod;
+        this.catalog = that.catalog;
+        this.priceList = that.priceList;
+        this.product = that.product;
+        this.productCategory = that.productCategory;
+    }
+    protected CaseImp(final CaseImp.Builder<?> builder) {
+        this.billingPeriod = builder.billingPeriod;
+        this.catalog = builder.catalog;
+        this.priceList = builder.priceList;
+        this.product = builder.product;
+        this.productCategory = builder.productCategory;
+    }
+    protected CaseImp() { }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public Product getProduct() {
+        return this.product;
+    }
+    @Override
+    public ProductCategory getProductCategory() {
+        return this.productCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CaseImp that = (CaseImp) o;
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.product, that.product) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productCategory, that.productCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.product);
+        result = ( 31 * result ) + Objects.hashCode(this.productCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append(", ");
+        sb.append("product=").append(this.product);
+        sb.append(", ");
+        sb.append("productCategory=").append(this.productCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CaseImp.Builder<T>> {
+
+        protected BillingPeriod billingPeriod;
+        protected StaticCatalog catalog;
+        protected PriceList priceList;
+        protected Product product;
+        protected ProductCategory productCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingPeriod = that.billingPeriod;
+            this.catalog = that.catalog;
+            this.priceList = that.priceList;
+            this.product = that.product;
+            this.productCategory = that.productCategory;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProduct(final Product product) {
+            this.product = product;
+            return (T) this;
+        }
+        public T withProductCategory(final ProductCategory productCategory) {
+            this.productCategory = productCategory;
+            return (T) this;
+        }
+        public T source(final Case that) {
+            this.billingPeriod = that.getBillingPeriod();
+            this.catalog = that.getCatalog();
+            this.priceList = that.getPriceList();
+            this.product = that.getProduct();
+            this.productCategory = that.getProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CaseImp build() {
+            return new CaseImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CasePhaseImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CasePhaseImp.java
@@ -1,0 +1,204 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CasePhase;
+
+@JsonDeserialize( builder = CasePhaseImp.Builder.class )
+public class CasePhaseImp implements CasePhase, Serializable {
+
+    private static final long serialVersionUID = 0xF4576A9E7E96405BL;
+
+    protected BillingPeriod billingPeriod;
+    protected StaticCatalog catalog;
+    protected PhaseType phaseType;
+    protected PriceList priceList;
+    protected Product product;
+    protected ProductCategory productCategory;
+
+    public CasePhaseImp(final CasePhaseImp that) {
+        this.billingPeriod = that.billingPeriod;
+        this.catalog = that.catalog;
+        this.phaseType = that.phaseType;
+        this.priceList = that.priceList;
+        this.product = that.product;
+        this.productCategory = that.productCategory;
+    }
+    protected CasePhaseImp(final CasePhaseImp.Builder<?> builder) {
+        this.billingPeriod = builder.billingPeriod;
+        this.catalog = builder.catalog;
+        this.phaseType = builder.phaseType;
+        this.priceList = builder.priceList;
+        this.product = builder.product;
+        this.productCategory = builder.productCategory;
+    }
+    protected CasePhaseImp() { }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public PhaseType getPhaseType() {
+        return this.phaseType;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public Product getProduct() {
+        return this.product;
+    }
+    @Override
+    public ProductCategory getProductCategory() {
+        return this.productCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CasePhaseImp that = (CasePhaseImp) o;
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseType, that.phaseType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.product, that.product) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productCategory, that.productCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseType);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.product);
+        result = ( 31 * result ) + Objects.hashCode(this.productCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("phaseType=").append(this.phaseType);
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append(", ");
+        sb.append("product=").append(this.product);
+        sb.append(", ");
+        sb.append("productCategory=").append(this.productCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CasePhaseImp.Builder<T>> {
+
+        protected BillingPeriod billingPeriod;
+        protected StaticCatalog catalog;
+        protected PhaseType phaseType;
+        protected PriceList priceList;
+        protected Product product;
+        protected ProductCategory productCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingPeriod = that.billingPeriod;
+            this.catalog = that.catalog;
+            this.phaseType = that.phaseType;
+            this.priceList = that.priceList;
+            this.product = that.product;
+            this.productCategory = that.productCategory;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withPhaseType(final PhaseType phaseType) {
+            this.phaseType = phaseType;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProduct(final Product product) {
+            this.product = product;
+            return (T) this;
+        }
+        public T withProductCategory(final ProductCategory productCategory) {
+            this.productCategory = productCategory;
+            return (T) this;
+        }
+        public T source(final CasePhase that) {
+            this.billingPeriod = that.getBillingPeriod();
+            this.catalog = that.getCatalog();
+            this.phaseType = that.getPhaseType();
+            this.priceList = that.getPriceList();
+            this.product = that.getProduct();
+            this.productCategory = that.getProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CasePhaseImp build() {
+            return new CasePhaseImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CasePriceListImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/CasePriceListImp.java
@@ -1,0 +1,203 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CasePriceList;
+
+@JsonDeserialize( builder = CasePriceListImp.Builder.class )
+public class CasePriceListImp implements CasePriceList, Serializable {
+
+    private static final long serialVersionUID = 0x38E049510E90B5DEL;
+
+    protected BillingPeriod billingPeriod;
+    protected StaticCatalog catalog;
+    protected PriceList destinationPriceList;
+    protected PriceList priceList;
+    protected Product product;
+    protected ProductCategory productCategory;
+
+    public CasePriceListImp(final CasePriceListImp that) {
+        this.billingPeriod = that.billingPeriod;
+        this.catalog = that.catalog;
+        this.destinationPriceList = that.destinationPriceList;
+        this.priceList = that.priceList;
+        this.product = that.product;
+        this.productCategory = that.productCategory;
+    }
+    protected CasePriceListImp(final CasePriceListImp.Builder<?> builder) {
+        this.billingPeriod = builder.billingPeriod;
+        this.catalog = builder.catalog;
+        this.destinationPriceList = builder.destinationPriceList;
+        this.priceList = builder.priceList;
+        this.product = builder.product;
+        this.productCategory = builder.productCategory;
+    }
+    protected CasePriceListImp() { }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public PriceList getDestinationPriceList() {
+        return this.destinationPriceList;
+    }
+    @Override
+    public PriceList getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public Product getProduct() {
+        return this.product;
+    }
+    @Override
+    public ProductCategory getProductCategory() {
+        return this.productCategory;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CasePriceListImp that = (CasePriceListImp) o;
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        if( !Objects.equals(this.destinationPriceList, that.destinationPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.product, that.product) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productCategory, that.productCategory) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        result = ( 31 * result ) + Objects.hashCode(this.destinationPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.product);
+        result = ( 31 * result ) + Objects.hashCode(this.productCategory);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append(", ");
+        sb.append("destinationPriceList=").append(this.destinationPriceList);
+        sb.append(", ");
+        sb.append("priceList=").append(this.priceList);
+        sb.append(", ");
+        sb.append("product=").append(this.product);
+        sb.append(", ");
+        sb.append("productCategory=").append(this.productCategory);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CasePriceListImp.Builder<T>> {
+
+        protected BillingPeriod billingPeriod;
+        protected StaticCatalog catalog;
+        protected PriceList destinationPriceList;
+        protected PriceList priceList;
+        protected Product product;
+        protected ProductCategory productCategory;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingPeriod = that.billingPeriod;
+            this.catalog = that.catalog;
+            this.destinationPriceList = that.destinationPriceList;
+            this.priceList = that.priceList;
+            this.product = that.product;
+            this.productCategory = that.productCategory;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T withDestinationPriceList(final PriceList destinationPriceList) {
+            this.destinationPriceList = destinationPriceList;
+            return (T) this;
+        }
+        public T withPriceList(final PriceList priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProduct(final Product product) {
+            this.product = product;
+            return (T) this;
+        }
+        public T withProductCategory(final ProductCategory productCategory) {
+            this.productCategory = productCategory;
+            return (T) this;
+        }
+        public T source(final CasePriceList that) {
+            this.billingPeriod = that.getBillingPeriod();
+            this.catalog = that.getCatalog();
+            this.destinationPriceList = that.getDestinationPriceList();
+            this.priceList = that.getPriceList();
+            this.product = that.getProduct();
+            this.productCategory = that.getProductCategory();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CasePriceListImp build() {
+            return new CasePriceListImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.catalog.api.rules.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/PlanRulesImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/PlanRulesImp.java
@@ -1,0 +1,248 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.catalog.api.BillingAlignment;
+import org.killbill.billing.catalog.api.CatalogApiException;
+import org.killbill.billing.catalog.api.PlanAlignmentCreate;
+import org.killbill.billing.catalog.api.PlanChangeResult;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.catalog.api.PlanSpecifier;
+import org.killbill.billing.catalog.api.StaticCatalog;
+import org.killbill.billing.catalog.api.rules.CaseBillingAlignment;
+import org.killbill.billing.catalog.api.rules.CaseCancelPolicy;
+import org.killbill.billing.catalog.api.rules.CaseChangePlanAlignment;
+import org.killbill.billing.catalog.api.rules.CaseChangePlanPolicy;
+import org.killbill.billing.catalog.api.rules.CaseCreateAlignment;
+import org.killbill.billing.catalog.api.rules.CasePriceList;
+import org.killbill.billing.catalog.api.rules.PlanRules;
+
+@JsonDeserialize( builder = PlanRulesImp.Builder.class )
+public class PlanRulesImp implements PlanRules, Serializable {
+
+    private static final long serialVersionUID = 0x56422BAD281B1B82L;
+
+    protected Iterable<CaseBillingAlignment> caseBillingAlignment;
+    protected Iterable<CaseCancelPolicy> caseCancelPolicy;
+    protected Iterable<CaseChangePlanAlignment> caseChangePlanAlignment;
+    protected Iterable<CaseChangePlanPolicy> caseChangePlanPolicy;
+    protected Iterable<CaseCreateAlignment> caseCreateAlignment;
+    protected Iterable<CasePriceList> casePriceList;
+    protected StaticCatalog catalog;
+
+    public PlanRulesImp(final PlanRulesImp that) {
+        this.caseBillingAlignment = that.caseBillingAlignment;
+        this.caseCancelPolicy = that.caseCancelPolicy;
+        this.caseChangePlanAlignment = that.caseChangePlanAlignment;
+        this.caseChangePlanPolicy = that.caseChangePlanPolicy;
+        this.caseCreateAlignment = that.caseCreateAlignment;
+        this.casePriceList = that.casePriceList;
+        this.catalog = that.catalog;
+    }
+    protected PlanRulesImp(final PlanRulesImp.Builder<?> builder) {
+        this.caseBillingAlignment = builder.caseBillingAlignment;
+        this.caseCancelPolicy = builder.caseCancelPolicy;
+        this.caseChangePlanAlignment = builder.caseChangePlanAlignment;
+        this.caseChangePlanPolicy = builder.caseChangePlanPolicy;
+        this.caseCreateAlignment = builder.caseCreateAlignment;
+        this.casePriceList = builder.casePriceList;
+        this.catalog = builder.catalog;
+    }
+    protected PlanRulesImp() { }
+    @Override
+    public Iterable<CaseBillingAlignment> getCaseBillingAlignment() {
+        return this.caseBillingAlignment;
+    }
+    @Override
+    public Iterable<CaseCancelPolicy> getCaseCancelPolicy() {
+        return this.caseCancelPolicy;
+    }
+    @Override
+    public Iterable<CaseChangePlanAlignment> getCaseChangePlanAlignment() {
+        return this.caseChangePlanAlignment;
+    }
+    @Override
+    public Iterable<CaseChangePlanPolicy> getCaseChangePlanPolicy() {
+        return this.caseChangePlanPolicy;
+    }
+    @Override
+    public Iterable<CaseCreateAlignment> getCaseCreateAlignment() {
+        return this.caseCreateAlignment;
+    }
+    @Override
+    public Iterable<CasePriceList> getCasePriceList() {
+        return this.casePriceList;
+    }
+    @Override
+    public StaticCatalog getCatalog() {
+        return this.catalog;
+    }
+    @Override
+    public PlanAlignmentCreate getPlanCreateAlignment(final PlanSpecifier specifier) {
+        throw new UnsupportedOperationException("getPlanCreateAlignment(org.killbill.billing.catalog.api.PlanSpecifier) must be implemented.");
+    }
+    @Override
+    public BillingAlignment getBillingAlignment(final PlanPhaseSpecifier planPhase) {
+        throw new UnsupportedOperationException("getBillingAlignment(org.killbill.billing.catalog.api.PlanPhaseSpecifier) must be implemented.");
+    }
+    @Override
+    public PlanChangeResult getPlanChangeResult(final PlanPhaseSpecifier from, final PlanSpecifier to) {
+        throw new UnsupportedOperationException("getPlanChangeResult(org.killbill.billing.catalog.api.PlanPhaseSpecifier, org.killbill.billing.catalog.api.PlanSpecifier) must be implemented.");
+    }
+    @Override
+    public BillingActionPolicy getPlanCancelPolicy(final PlanPhaseSpecifier planPhase) {
+        throw new UnsupportedOperationException("getPlanCancelPolicy(org.killbill.billing.catalog.api.PlanPhaseSpecifier) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PlanRulesImp that = (PlanRulesImp) o;
+        if( !Objects.equals(this.caseBillingAlignment, that.caseBillingAlignment) ) {
+            return false;
+        }
+        if( !Objects.equals(this.caseCancelPolicy, that.caseCancelPolicy) ) {
+            return false;
+        }
+        if( !Objects.equals(this.caseChangePlanAlignment, that.caseChangePlanAlignment) ) {
+            return false;
+        }
+        if( !Objects.equals(this.caseChangePlanPolicy, that.caseChangePlanPolicy) ) {
+            return false;
+        }
+        if( !Objects.equals(this.caseCreateAlignment, that.caseCreateAlignment) ) {
+            return false;
+        }
+        if( !Objects.equals(this.casePriceList, that.casePriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalog, that.catalog) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.caseBillingAlignment);
+        result = ( 31 * result ) + Objects.hashCode(this.caseCancelPolicy);
+        result = ( 31 * result ) + Objects.hashCode(this.caseChangePlanAlignment);
+        result = ( 31 * result ) + Objects.hashCode(this.caseChangePlanPolicy);
+        result = ( 31 * result ) + Objects.hashCode(this.caseCreateAlignment);
+        result = ( 31 * result ) + Objects.hashCode(this.casePriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.catalog);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("caseBillingAlignment=").append(this.caseBillingAlignment);
+        sb.append(", ");
+        sb.append("caseCancelPolicy=").append(this.caseCancelPolicy);
+        sb.append(", ");
+        sb.append("caseChangePlanAlignment=").append(this.caseChangePlanAlignment);
+        sb.append(", ");
+        sb.append("caseChangePlanPolicy=").append(this.caseChangePlanPolicy);
+        sb.append(", ");
+        sb.append("caseCreateAlignment=").append(this.caseCreateAlignment);
+        sb.append(", ");
+        sb.append("casePriceList=").append(this.casePriceList);
+        sb.append(", ");
+        sb.append("catalog=").append(this.catalog);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PlanRulesImp.Builder<T>> {
+
+        protected Iterable<CaseBillingAlignment> caseBillingAlignment;
+        protected Iterable<CaseCancelPolicy> caseCancelPolicy;
+        protected Iterable<CaseChangePlanAlignment> caseChangePlanAlignment;
+        protected Iterable<CaseChangePlanPolicy> caseChangePlanPolicy;
+        protected Iterable<CaseCreateAlignment> caseCreateAlignment;
+        protected Iterable<CasePriceList> casePriceList;
+        protected StaticCatalog catalog;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.caseBillingAlignment = that.caseBillingAlignment;
+            this.caseCancelPolicy = that.caseCancelPolicy;
+            this.caseChangePlanAlignment = that.caseChangePlanAlignment;
+            this.caseChangePlanPolicy = that.caseChangePlanPolicy;
+            this.caseCreateAlignment = that.caseCreateAlignment;
+            this.casePriceList = that.casePriceList;
+            this.catalog = that.catalog;
+        }
+        public T withCaseBillingAlignment(final Iterable<CaseBillingAlignment> caseBillingAlignment) {
+            this.caseBillingAlignment = caseBillingAlignment;
+            return (T) this;
+        }
+        public T withCaseCancelPolicy(final Iterable<CaseCancelPolicy> caseCancelPolicy) {
+            this.caseCancelPolicy = caseCancelPolicy;
+            return (T) this;
+        }
+        public T withCaseChangePlanAlignment(final Iterable<CaseChangePlanAlignment> caseChangePlanAlignment) {
+            this.caseChangePlanAlignment = caseChangePlanAlignment;
+            return (T) this;
+        }
+        public T withCaseChangePlanPolicy(final Iterable<CaseChangePlanPolicy> caseChangePlanPolicy) {
+            this.caseChangePlanPolicy = caseChangePlanPolicy;
+            return (T) this;
+        }
+        public T withCaseCreateAlignment(final Iterable<CaseCreateAlignment> caseCreateAlignment) {
+            this.caseCreateAlignment = caseCreateAlignment;
+            return (T) this;
+        }
+        public T withCasePriceList(final Iterable<CasePriceList> casePriceList) {
+            this.casePriceList = casePriceList;
+            return (T) this;
+        }
+        public T withCatalog(final StaticCatalog catalog) {
+            this.catalog = catalog;
+            return (T) this;
+        }
+        public T source(final PlanRules that) {
+            this.caseBillingAlignment = that.getCaseBillingAlignment();
+            this.caseCancelPolicy = that.getCaseCancelPolicy();
+            this.caseChangePlanAlignment = that.getCaseChangePlanAlignment();
+            this.caseChangePlanPolicy = that.getCaseChangePlanPolicy();
+            this.caseCreateAlignment = that.getCaseCreateAlignment();
+            this.casePriceList = that.getCasePriceList();
+            this.catalog = that.getCatalog();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PlanRulesImp build() {
+            return new PlanRulesImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/catalog/api/rules/boilerplate/Resolver.java
@@ -1,0 +1,45 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.catalog.api.rules.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.catalog.api.rules.Case;
+import org.killbill.billing.catalog.api.rules.CaseBillingAlignment;
+import org.killbill.billing.catalog.api.rules.CaseCancelPolicy;
+import org.killbill.billing.catalog.api.rules.CaseChange;
+import org.killbill.billing.catalog.api.rules.CaseChangePlanAlignment;
+import org.killbill.billing.catalog.api.rules.CaseChangePlanPolicy;
+import org.killbill.billing.catalog.api.rules.CaseCreateAlignment;
+import org.killbill.billing.catalog.api.rules.CasePhase;
+import org.killbill.billing.catalog.api.rules.CasePriceList;
+import org.killbill.billing.catalog.api.rules.PlanRules;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(CaseBillingAlignment.class, CaseBillingAlignmentImp.class);
+        this.addMapping(CaseCancelPolicy.class, CaseCancelPolicyImp.class);
+        this.addMapping(CaseChange.class, CaseChangeImp.class);
+        this.addMapping(CaseChangePlanAlignment.class, CaseChangePlanAlignmentImp.class);
+        this.addMapping(CaseChangePlanPolicy.class, CaseChangePlanPolicyImp.class);
+        this.addMapping(CaseCreateAlignment.class, CaseCreateAlignmentImp.class);
+        this.addMapping(Case.class, CaseImp.class);
+        this.addMapping(CasePhase.class, CasePhaseImp.class);
+        this.addMapping(CasePriceList.class, CasePriceListImp.class);
+        this.addMapping(PlanRules.class, PlanRulesImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/currency/api/boilerplate/CurrencyConversionApiImp.java
+++ b/src/main/java/org/killbill/billing/currency/api/boilerplate/CurrencyConversionApiImp.java
@@ -1,0 +1,111 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.currency.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.currency.api.CurrencyConversion;
+import org.killbill.billing.currency.api.CurrencyConversionApi;
+import org.killbill.billing.currency.api.CurrencyConversionException;
+
+@JsonDeserialize( builder = CurrencyConversionApiImp.Builder.class )
+public class CurrencyConversionApiImp implements CurrencyConversionApi, Serializable {
+
+    private static final long serialVersionUID = 0xC831A56BB2A16681L;
+
+    protected Set<Currency> baseRates;
+
+    public CurrencyConversionApiImp(final CurrencyConversionApiImp that) {
+        this.baseRates = that.baseRates;
+    }
+    protected CurrencyConversionApiImp(final CurrencyConversionApiImp.Builder<?> builder) {
+        this.baseRates = builder.baseRates;
+    }
+    protected CurrencyConversionApiImp() { }
+    @Override
+    public Set<Currency> getBaseRates() {
+        return this.baseRates;
+    }
+    @Override
+    public CurrencyConversion getCurrentCurrencyConversion(final Currency baseCurrency) {
+        throw new UnsupportedOperationException("getCurrentCurrencyConversion(org.killbill.billing.catalog.api.Currency) must be implemented.");
+    }
+    @Override
+    public CurrencyConversion getCurrencyConversion(final Currency baseCurrency, final DateTime dateConversion) {
+        throw new UnsupportedOperationException("getCurrencyConversion(org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CurrencyConversionApiImp that = (CurrencyConversionApiImp) o;
+        if( !Objects.equals(this.baseRates, that.baseRates) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.baseRates);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("baseRates=").append(this.baseRates);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CurrencyConversionApiImp.Builder<T>> {
+
+        protected Set<Currency> baseRates;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.baseRates = that.baseRates;
+        }
+        public T withBaseRates(final Set<Currency> baseRates) {
+            this.baseRates = baseRates;
+            return (T) this;
+        }
+        public T source(final CurrencyConversionApi that) throws CurrencyConversionException {
+            this.baseRates = that.getBaseRates();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CurrencyConversionApiImp build() {
+            return new CurrencyConversionApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/currency/api/boilerplate/CurrencyConversionImp.java
+++ b/src/main/java/org/killbill/billing/currency/api/boilerplate/CurrencyConversionImp.java
@@ -1,0 +1,121 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.currency.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.currency.api.CurrencyConversion;
+import org.killbill.billing.currency.api.Rate;
+
+@JsonDeserialize( builder = CurrencyConversionImp.Builder.class )
+public class CurrencyConversionImp implements CurrencyConversion, Serializable {
+
+    private static final long serialVersionUID = 0x3137D29113B8AFC2L;
+
+    protected Currency baseCurrency;
+    protected Set<Rate> rates;
+
+    public CurrencyConversionImp(final CurrencyConversionImp that) {
+        this.baseCurrency = that.baseCurrency;
+        this.rates = that.rates;
+    }
+    protected CurrencyConversionImp(final CurrencyConversionImp.Builder<?> builder) {
+        this.baseCurrency = builder.baseCurrency;
+        this.rates = builder.rates;
+    }
+    protected CurrencyConversionImp() { }
+    @Override
+    public Currency getBaseCurrency() {
+        return this.baseCurrency;
+    }
+    @Override
+    public Set<Rate> getRates() {
+        return this.rates;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CurrencyConversionImp that = (CurrencyConversionImp) o;
+        if( !Objects.equals(this.baseCurrency, that.baseCurrency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.rates, that.rates) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.baseCurrency);
+        result = ( 31 * result ) + Objects.hashCode(this.rates);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("baseCurrency=").append(this.baseCurrency);
+        sb.append(", ");
+        sb.append("rates=").append(this.rates);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CurrencyConversionImp.Builder<T>> {
+
+        protected Currency baseCurrency;
+        protected Set<Rate> rates;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.baseCurrency = that.baseCurrency;
+            this.rates = that.rates;
+        }
+        public T withBaseCurrency(final Currency baseCurrency) {
+            this.baseCurrency = baseCurrency;
+            return (T) this;
+        }
+        public T withRates(final Set<Rate> rates) {
+            this.rates = rates;
+            return (T) this;
+        }
+        public T source(final CurrencyConversion that) {
+            this.baseCurrency = that.getBaseCurrency();
+            this.rates = that.getRates();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CurrencyConversionImp build() {
+            return new CurrencyConversionImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/currency/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/currency/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.currency.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.currency.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/currency/api/boilerplate/RateImp.java
+++ b/src/main/java/org/killbill/billing/currency/api/boilerplate/RateImp.java
@@ -1,0 +1,161 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.currency.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.currency.api.Rate;
+
+@JsonDeserialize( builder = RateImp.Builder.class )
+public class RateImp implements Rate, Serializable {
+
+    private static final long serialVersionUID = 0xCA692346157DBC69L;
+
+    protected Currency baseCurrency;
+    protected DateTime conversionDate;
+    protected Currency currency;
+    protected BigDecimal value;
+
+    public RateImp(final RateImp that) {
+        this.baseCurrency = that.baseCurrency;
+        this.conversionDate = that.conversionDate;
+        this.currency = that.currency;
+        this.value = that.value;
+    }
+    protected RateImp(final RateImp.Builder<?> builder) {
+        this.baseCurrency = builder.baseCurrency;
+        this.conversionDate = builder.conversionDate;
+        this.currency = builder.currency;
+        this.value = builder.value;
+    }
+    protected RateImp() { }
+    @Override
+    public Currency getBaseCurrency() {
+        return this.baseCurrency;
+    }
+    @Override
+    public DateTime getConversionDate() {
+        return this.conversionDate;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public BigDecimal getValue() {
+        return this.value;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final RateImp that = (RateImp) o;
+        if( !Objects.equals(this.baseCurrency, that.baseCurrency) ) {
+            return false;
+        }
+        if( ( this.conversionDate != null ) ? ( 0 != this.conversionDate.compareTo(that.conversionDate) ) : ( that.conversionDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( ( this.value != null ) ? ( 0 != this.value.compareTo(that.value) ) : ( that.value != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.baseCurrency);
+        result = ( 31 * result ) + Objects.hashCode(this.conversionDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.value);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("baseCurrency=").append(this.baseCurrency);
+        sb.append(", ");
+        sb.append("conversionDate=").append(this.conversionDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("value=").append(this.value);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends RateImp.Builder<T>> {
+
+        protected Currency baseCurrency;
+        protected DateTime conversionDate;
+        protected Currency currency;
+        protected BigDecimal value;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.baseCurrency = that.baseCurrency;
+            this.conversionDate = that.conversionDate;
+            this.currency = that.currency;
+            this.value = that.value;
+        }
+        public T withBaseCurrency(final Currency baseCurrency) {
+            this.baseCurrency = baseCurrency;
+            return (T) this;
+        }
+        public T withConversionDate(final DateTime conversionDate) {
+            this.conversionDate = conversionDate;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withValue(final BigDecimal value) {
+            this.value = value;
+            return (T) this;
+        }
+        public T source(final Rate that) {
+            this.baseCurrency = that.getBaseCurrency();
+            this.conversionDate = that.getConversionDate();
+            this.currency = that.getCurrency();
+            this.value = that.getValue();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public RateImp build() {
+            return new RateImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/currency/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/currency/api/boilerplate/Resolver.java
@@ -1,0 +1,31 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.currency.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.currency.api.CurrencyConversion;
+import org.killbill.billing.currency.api.CurrencyConversionApi;
+import org.killbill.billing.currency.api.Rate;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(CurrencyConversionApi.class, CurrencyConversionApiImp.class);
+        this.addMapping(CurrencyConversion.class, CurrencyConversionImp.class);
+        this.addMapping(Rate.class, RateImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BaseEntitlementWithAddOnsSpecifierImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BaseEntitlementWithAddOnsSpecifierImp.java
@@ -1,0 +1,207 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.entitlement.api.BaseEntitlementWithAddOnsSpecifier;
+import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+
+@JsonDeserialize( builder = BaseEntitlementWithAddOnsSpecifierImp.Builder.class )
+public class BaseEntitlementWithAddOnsSpecifierImp implements BaseEntitlementWithAddOnsSpecifier, Serializable {
+
+    private static final long serialVersionUID = 0x8ACE98B2CF2F0A9EL;
+
+    protected LocalDate billingEffectiveDate;
+    protected String bundleExternalKey;
+    protected UUID bundleId;
+    protected LocalDate entitlementEffectiveDate;
+    protected Iterable<EntitlementSpecifier> entitlementSpecifier;
+    protected boolean isMigrated;
+
+    public BaseEntitlementWithAddOnsSpecifierImp(final BaseEntitlementWithAddOnsSpecifierImp that) {
+        this.billingEffectiveDate = that.billingEffectiveDate;
+        this.bundleExternalKey = that.bundleExternalKey;
+        this.bundleId = that.bundleId;
+        this.entitlementEffectiveDate = that.entitlementEffectiveDate;
+        this.entitlementSpecifier = that.entitlementSpecifier;
+        this.isMigrated = that.isMigrated;
+    }
+    protected BaseEntitlementWithAddOnsSpecifierImp(final BaseEntitlementWithAddOnsSpecifierImp.Builder<?> builder) {
+        this.billingEffectiveDate = builder.billingEffectiveDate;
+        this.bundleExternalKey = builder.bundleExternalKey;
+        this.bundleId = builder.bundleId;
+        this.entitlementEffectiveDate = builder.entitlementEffectiveDate;
+        this.entitlementSpecifier = builder.entitlementSpecifier;
+        this.isMigrated = builder.isMigrated;
+    }
+    protected BaseEntitlementWithAddOnsSpecifierImp() { }
+    @Override
+    public LocalDate getBillingEffectiveDate() {
+        return this.billingEffectiveDate;
+    }
+    @Override
+    public String getBundleExternalKey() {
+        return this.bundleExternalKey;
+    }
+    @Override
+    public UUID getBundleId() {
+        return this.bundleId;
+    }
+    @Override
+    public LocalDate getEntitlementEffectiveDate() {
+        return this.entitlementEffectiveDate;
+    }
+    @Override
+    public Iterable<EntitlementSpecifier> getEntitlementSpecifier() {
+        return this.entitlementSpecifier;
+    }
+    @Override
+    @JsonGetter("isMigrated")
+    public boolean isMigrated() {
+        return this.isMigrated;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final BaseEntitlementWithAddOnsSpecifierImp that = (BaseEntitlementWithAddOnsSpecifierImp) o;
+        if( ( this.billingEffectiveDate != null ) ? ( 0 != this.billingEffectiveDate.compareTo(that.billingEffectiveDate) ) : ( that.billingEffectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleExternalKey, that.bundleExternalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleId, that.bundleId) ) {
+            return false;
+        }
+        if( ( this.entitlementEffectiveDate != null ) ? ( 0 != this.entitlementEffectiveDate.compareTo(that.entitlementEffectiveDate) ) : ( that.entitlementEffectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.entitlementSpecifier, that.entitlementSpecifier) ) {
+            return false;
+        }
+        if( this.isMigrated != that.isMigrated ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingEffectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleExternalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleId);
+        result = ( 31 * result ) + Objects.hashCode(this.entitlementEffectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.entitlementSpecifier);
+        result = ( 31 * result ) + Objects.hashCode(this.isMigrated);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingEffectiveDate=").append(this.billingEffectiveDate);
+        sb.append(", ");
+        sb.append("bundleExternalKey=");
+        if( this.bundleExternalKey == null ) {
+            sb.append(this.bundleExternalKey);
+        }else{
+            sb.append("'").append(this.bundleExternalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("bundleId=").append(this.bundleId);
+        sb.append(", ");
+        sb.append("entitlementEffectiveDate=").append(this.entitlementEffectiveDate);
+        sb.append(", ");
+        sb.append("entitlementSpecifier=").append(this.entitlementSpecifier);
+        sb.append(", ");
+        sb.append("isMigrated=").append(this.isMigrated);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends BaseEntitlementWithAddOnsSpecifierImp.Builder<T>> {
+
+        protected LocalDate billingEffectiveDate;
+        protected String bundleExternalKey;
+        protected UUID bundleId;
+        protected LocalDate entitlementEffectiveDate;
+        protected Iterable<EntitlementSpecifier> entitlementSpecifier;
+        protected boolean isMigrated;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingEffectiveDate = that.billingEffectiveDate;
+            this.bundleExternalKey = that.bundleExternalKey;
+            this.bundleId = that.bundleId;
+            this.entitlementEffectiveDate = that.entitlementEffectiveDate;
+            this.entitlementSpecifier = that.entitlementSpecifier;
+            this.isMigrated = that.isMigrated;
+        }
+        public T withBillingEffectiveDate(final LocalDate billingEffectiveDate) {
+            this.billingEffectiveDate = billingEffectiveDate;
+            return (T) this;
+        }
+        public T withBundleExternalKey(final String bundleExternalKey) {
+            this.bundleExternalKey = bundleExternalKey;
+            return (T) this;
+        }
+        public T withBundleId(final UUID bundleId) {
+            this.bundleId = bundleId;
+            return (T) this;
+        }
+        public T withEntitlementEffectiveDate(final LocalDate entitlementEffectiveDate) {
+            this.entitlementEffectiveDate = entitlementEffectiveDate;
+            return (T) this;
+        }
+        public T withEntitlementSpecifier(final Iterable<EntitlementSpecifier> entitlementSpecifier) {
+            this.entitlementSpecifier = entitlementSpecifier;
+            return (T) this;
+        }
+        public T withIsMigrated(final boolean isMigrated) {
+            this.isMigrated = isMigrated;
+            return (T) this;
+        }
+        public T source(final BaseEntitlementWithAddOnsSpecifier that) {
+            this.billingEffectiveDate = that.getBillingEffectiveDate();
+            this.bundleExternalKey = that.getBundleExternalKey();
+            this.bundleId = that.getBundleId();
+            this.entitlementEffectiveDate = that.getEntitlementEffectiveDate();
+            this.entitlementSpecifier = that.getEntitlementSpecifier();
+            this.isMigrated = that.isMigrated();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public BaseEntitlementWithAddOnsSpecifierImp build() {
+            return new BaseEntitlementWithAddOnsSpecifierImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BlockableImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BlockableImp.java
@@ -1,0 +1,140 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.entitlement.api.Blockable;
+
+@JsonDeserialize( builder = BlockableImp.Builder.class )
+public class BlockableImp implements Blockable, Serializable {
+
+    private static final long serialVersionUID = 0x82D5CD205D905748L;
+
+    protected DateTime createdDate;
+    protected UUID id;
+    protected DateTime updatedDate;
+
+    public BlockableImp(final BlockableImp that) {
+        this.createdDate = that.createdDate;
+        this.id = that.id;
+        this.updatedDate = that.updatedDate;
+    }
+    protected BlockableImp(final BlockableImp.Builder<?> builder) {
+        this.createdDate = builder.createdDate;
+        this.id = builder.id;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected BlockableImp() { }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final BlockableImp that = (BlockableImp) o;
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends BlockableImp.Builder<T>> {
+
+        protected DateTime createdDate;
+        protected UUID id;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.createdDate = that.createdDate;
+            this.id = that.id;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Blockable that) {
+            this.createdDate = that.getCreatedDate();
+            this.id = that.getId();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public BlockableImp build() {
+            return new BlockableImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BlockingStateImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BlockingStateImp.java
@@ -1,0 +1,343 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.entitlement.api.BlockingState;
+import org.killbill.billing.entitlement.api.BlockingStateType;
+
+@JsonDeserialize( builder = BlockingStateImp.Builder.class )
+public class BlockingStateImp implements BlockingState, Serializable {
+
+    private static final long serialVersionUID = 0x31C0C2B0A0CB238AL;
+
+    protected UUID blockedId;
+    protected DateTime createdDate;
+    protected String description;
+    protected DateTime effectiveDate;
+    protected UUID id;
+    protected boolean isBlockBilling;
+    protected boolean isBlockChange;
+    protected boolean isBlockEntitlement;
+    protected String service;
+    protected String stateName;
+    protected BlockingStateType type;
+    protected DateTime updatedDate;
+
+    public BlockingStateImp(final BlockingStateImp that) {
+        this.blockedId = that.blockedId;
+        this.createdDate = that.createdDate;
+        this.description = that.description;
+        this.effectiveDate = that.effectiveDate;
+        this.id = that.id;
+        this.isBlockBilling = that.isBlockBilling;
+        this.isBlockChange = that.isBlockChange;
+        this.isBlockEntitlement = that.isBlockEntitlement;
+        this.service = that.service;
+        this.stateName = that.stateName;
+        this.type = that.type;
+        this.updatedDate = that.updatedDate;
+    }
+    protected BlockingStateImp(final BlockingStateImp.Builder<?> builder) {
+        this.blockedId = builder.blockedId;
+        this.createdDate = builder.createdDate;
+        this.description = builder.description;
+        this.effectiveDate = builder.effectiveDate;
+        this.id = builder.id;
+        this.isBlockBilling = builder.isBlockBilling;
+        this.isBlockChange = builder.isBlockChange;
+        this.isBlockEntitlement = builder.isBlockEntitlement;
+        this.service = builder.service;
+        this.stateName = builder.stateName;
+        this.type = builder.type;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected BlockingStateImp() { }
+    @Override
+    public UUID getBlockedId() {
+        return this.blockedId;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+    @Override
+    public DateTime getEffectiveDate() {
+        return this.effectiveDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    @JsonGetter("isBlockBilling")
+    public boolean isBlockBilling() {
+        return this.isBlockBilling;
+    }
+    @Override
+    @JsonGetter("isBlockChange")
+    public boolean isBlockChange() {
+        return this.isBlockChange;
+    }
+    @Override
+    @JsonGetter("isBlockEntitlement")
+    public boolean isBlockEntitlement() {
+        return this.isBlockEntitlement;
+    }
+    @Override
+    public String getService() {
+        return this.service;
+    }
+    @Override
+    public String getStateName() {
+        return this.stateName;
+    }
+    @Override
+    public BlockingStateType getType() {
+        return this.type;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public int compareTo(final BlockingState arg0) {
+        throw new UnsupportedOperationException("compareTo(org.killbill.billing.entitlement.api.BlockingState) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final BlockingStateImp that = (BlockingStateImp) o;
+        if( !Objects.equals(this.blockedId, that.blockedId) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.description, that.description) ) {
+            return false;
+        }
+        if( ( this.effectiveDate != null ) ? ( 0 != this.effectiveDate.compareTo(that.effectiveDate) ) : ( that.effectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( this.isBlockBilling != that.isBlockBilling ) {
+            return false;
+        }
+        if( this.isBlockChange != that.isBlockChange ) {
+            return false;
+        }
+        if( this.isBlockEntitlement != that.isBlockEntitlement ) {
+            return false;
+        }
+        if( !Objects.equals(this.service, that.service) ) {
+            return false;
+        }
+        if( !Objects.equals(this.stateName, that.stateName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.type, that.type) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.blockedId);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.description);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.isBlockBilling);
+        result = ( 31 * result ) + Objects.hashCode(this.isBlockChange);
+        result = ( 31 * result ) + Objects.hashCode(this.isBlockEntitlement);
+        result = ( 31 * result ) + Objects.hashCode(this.service);
+        result = ( 31 * result ) + Objects.hashCode(this.stateName);
+        result = ( 31 * result ) + Objects.hashCode(this.type);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("blockedId=").append(this.blockedId);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("description=");
+        if( this.description == null ) {
+            sb.append(this.description);
+        }else{
+            sb.append("'").append(this.description).append("'");
+        }
+        sb.append(", ");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("isBlockBilling=").append(this.isBlockBilling);
+        sb.append(", ");
+        sb.append("isBlockChange=").append(this.isBlockChange);
+        sb.append(", ");
+        sb.append("isBlockEntitlement=").append(this.isBlockEntitlement);
+        sb.append(", ");
+        sb.append("service=");
+        if( this.service == null ) {
+            sb.append(this.service);
+        }else{
+            sb.append("'").append(this.service).append("'");
+        }
+        sb.append(", ");
+        sb.append("stateName=");
+        if( this.stateName == null ) {
+            sb.append(this.stateName);
+        }else{
+            sb.append("'").append(this.stateName).append("'");
+        }
+        sb.append(", ");
+        sb.append("type=").append(this.type);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends BlockingStateImp.Builder<T>> {
+
+        protected UUID blockedId;
+        protected DateTime createdDate;
+        protected String description;
+        protected DateTime effectiveDate;
+        protected UUID id;
+        protected boolean isBlockBilling;
+        protected boolean isBlockChange;
+        protected boolean isBlockEntitlement;
+        protected String service;
+        protected String stateName;
+        protected BlockingStateType type;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.blockedId = that.blockedId;
+            this.createdDate = that.createdDate;
+            this.description = that.description;
+            this.effectiveDate = that.effectiveDate;
+            this.id = that.id;
+            this.isBlockBilling = that.isBlockBilling;
+            this.isBlockChange = that.isBlockChange;
+            this.isBlockEntitlement = that.isBlockEntitlement;
+            this.service = that.service;
+            this.stateName = that.stateName;
+            this.type = that.type;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withBlockedId(final UUID blockedId) {
+            this.blockedId = blockedId;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withDescription(final String description) {
+            this.description = description;
+            return (T) this;
+        }
+        public T withEffectiveDate(final DateTime effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withIsBlockBilling(final boolean isBlockBilling) {
+            this.isBlockBilling = isBlockBilling;
+            return (T) this;
+        }
+        public T withIsBlockChange(final boolean isBlockChange) {
+            this.isBlockChange = isBlockChange;
+            return (T) this;
+        }
+        public T withIsBlockEntitlement(final boolean isBlockEntitlement) {
+            this.isBlockEntitlement = isBlockEntitlement;
+            return (T) this;
+        }
+        public T withService(final String service) {
+            this.service = service;
+            return (T) this;
+        }
+        public T withStateName(final String stateName) {
+            this.stateName = stateName;
+            return (T) this;
+        }
+        public T withType(final BlockingStateType type) {
+            this.type = type;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final BlockingState that) {
+            this.blockedId = that.getBlockedId();
+            this.createdDate = that.getCreatedDate();
+            this.description = that.getDescription();
+            this.effectiveDate = that.getEffectiveDate();
+            this.id = that.getId();
+            this.isBlockBilling = that.isBlockBilling();
+            this.isBlockChange = that.isBlockChange();
+            this.isBlockEntitlement = that.isBlockEntitlement();
+            this.service = that.getService();
+            this.stateName = that.getStateName();
+            this.type = that.getType();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public BlockingStateImp build() {
+            return new BlockingStateImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementAOStatusDryRunImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementAOStatusDryRunImp.java
@@ -1,0 +1,211 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.PhaseType;
+import org.killbill.billing.entitlement.api.EntitlementAOStatusDryRun;
+
+@JsonDeserialize( builder = EntitlementAOStatusDryRunImp.Builder.class )
+public class EntitlementAOStatusDryRunImp implements EntitlementAOStatusDryRun, Serializable {
+
+    private static final long serialVersionUID = 0xFA53649A6CD7E597L;
+
+    protected BillingPeriod billingPeriod;
+    protected UUID id;
+    protected PhaseType phaseType;
+    protected String priceList;
+    protected String productName;
+    protected EntitlementAOStatusDryRun.DryRunChangeReason reason;
+
+    public EntitlementAOStatusDryRunImp(final EntitlementAOStatusDryRunImp that) {
+        this.billingPeriod = that.billingPeriod;
+        this.id = that.id;
+        this.phaseType = that.phaseType;
+        this.priceList = that.priceList;
+        this.productName = that.productName;
+        this.reason = that.reason;
+    }
+    protected EntitlementAOStatusDryRunImp(final EntitlementAOStatusDryRunImp.Builder<?> builder) {
+        this.billingPeriod = builder.billingPeriod;
+        this.id = builder.id;
+        this.phaseType = builder.phaseType;
+        this.priceList = builder.priceList;
+        this.productName = builder.productName;
+        this.reason = builder.reason;
+    }
+    protected EntitlementAOStatusDryRunImp() { }
+    @Override
+    public BillingPeriod getBillingPeriod() {
+        return this.billingPeriod;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public PhaseType getPhaseType() {
+        return this.phaseType;
+    }
+    @Override
+    public String getPriceList() {
+        return this.priceList;
+    }
+    @Override
+    public String getProductName() {
+        return this.productName;
+    }
+    @Override
+    public EntitlementAOStatusDryRun.DryRunChangeReason getReason() {
+        return this.reason;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final EntitlementAOStatusDryRunImp that = (EntitlementAOStatusDryRunImp) o;
+        if( !Objects.equals(this.billingPeriod, that.billingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseType, that.phaseType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.priceList, that.priceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productName, that.productName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.reason, that.reason) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseType);
+        result = ( 31 * result ) + Objects.hashCode(this.priceList);
+        result = ( 31 * result ) + Objects.hashCode(this.productName);
+        result = ( 31 * result ) + Objects.hashCode(this.reason);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billingPeriod=").append(this.billingPeriod);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("phaseType=").append(this.phaseType);
+        sb.append(", ");
+        sb.append("priceList=");
+        if( this.priceList == null ) {
+            sb.append(this.priceList);
+        }else{
+            sb.append("'").append(this.priceList).append("'");
+        }
+        sb.append(", ");
+        sb.append("productName=");
+        if( this.productName == null ) {
+            sb.append(this.productName);
+        }else{
+            sb.append("'").append(this.productName).append("'");
+        }
+        sb.append(", ");
+        sb.append("reason=").append(this.reason);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends EntitlementAOStatusDryRunImp.Builder<T>> {
+
+        protected BillingPeriod billingPeriod;
+        protected UUID id;
+        protected PhaseType phaseType;
+        protected String priceList;
+        protected String productName;
+        protected EntitlementAOStatusDryRun.DryRunChangeReason reason;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billingPeriod = that.billingPeriod;
+            this.id = that.id;
+            this.phaseType = that.phaseType;
+            this.priceList = that.priceList;
+            this.productName = that.productName;
+            this.reason = that.reason;
+        }
+        public T withBillingPeriod(final BillingPeriod billingPeriod) {
+            this.billingPeriod = billingPeriod;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withPhaseType(final PhaseType phaseType) {
+            this.phaseType = phaseType;
+            return (T) this;
+        }
+        public T withPriceList(final String priceList) {
+            this.priceList = priceList;
+            return (T) this;
+        }
+        public T withProductName(final String productName) {
+            this.productName = productName;
+            return (T) this;
+        }
+        public T withReason(final EntitlementAOStatusDryRun.DryRunChangeReason reason) {
+            this.reason = reason;
+            return (T) this;
+        }
+        public T source(final EntitlementAOStatusDryRun that) {
+            this.billingPeriod = that.getBillingPeriod();
+            this.id = that.getId();
+            this.phaseType = that.getPhaseType();
+            this.priceList = that.getPriceList();
+            this.productName = that.getProductName();
+            this.reason = that.getReason();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public EntitlementAOStatusDryRunImp build() {
+            return new EntitlementAOStatusDryRunImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementApiImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementApiImp.java
@@ -1,0 +1,139 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.entitlement.api.BaseEntitlementWithAddOnsSpecifier;
+import org.killbill.billing.entitlement.api.Entitlement;
+import org.killbill.billing.entitlement.api.EntitlementAOStatusDryRun;
+import org.killbill.billing.entitlement.api.EntitlementApi;
+import org.killbill.billing.entitlement.api.EntitlementApiException;
+import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = EntitlementApiImp.Builder.class )
+public class EntitlementApiImp implements EntitlementApi, Serializable {
+
+    private static final long serialVersionUID = 0x377EE5F1D9AD91C2L;
+
+
+    public EntitlementApiImp(final EntitlementApiImp that) {
+    }
+    protected EntitlementApiImp(final EntitlementApiImp.Builder<?> builder) {
+    }
+    protected EntitlementApiImp() { }
+    @Override
+    public List<Entitlement> getAllEntitlementsForAccountId(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getAllEntitlementsForAccountId(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<Entitlement> getAllEntitlementsForBundle(final UUID bundleId, final TenantContext context) {
+        throw new UnsupportedOperationException("getAllEntitlementsForBundle(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Entitlement getEntitlementForId(final UUID id, final TenantContext context) {
+        throw new UnsupportedOperationException("getEntitlementForId(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void resume(final UUID bundleId, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("resume(java.util.UUID, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<EntitlementAOStatusDryRun> getDryRunStatusForChange(final UUID bundleId, final String targetProductName, final LocalDate effectiveDate, final TenantContext context) {
+        throw new UnsupportedOperationException("getDryRunStatusForChange(java.util.UUID, java.lang.String, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void pause(final UUID bundleId, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("pause(java.util.UUID, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public UUID transferEntitlements(final UUID sourceAccountId, final UUID destAccountId, final String bundleExternalKey, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("transferEntitlements(java.util.UUID, java.util.UUID, java.lang.String, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public UUID transferEntitlementsOverrideBillingPolicy(final UUID sourceAccountId, final UUID destAccountId, final String bundleExternalKey, final LocalDate effectiveDate, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("transferEntitlementsOverrideBillingPolicy(java.util.UUID, java.util.UUID, java.lang.String, org.joda.time.LocalDate, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<Entitlement> getAllEntitlementsForAccountIdAndBundleExternalKey(final UUID accountId, final String bundleExternalKey, final TenantContext context) {
+        throw new UnsupportedOperationException("getAllEntitlementsForAccountIdAndBundleExternalKey(java.util.UUID, java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public UUID createBaseEntitlement(final UUID accountId, final EntitlementSpecifier spec, final String bundleExternalKey, final LocalDate entitlementEffectiveDate, final LocalDate billingEffectiveDate, final boolean isMigrated, final boolean renameCancelledBundleIfExist, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("createBaseEntitlement(java.util.UUID, org.killbill.billing.entitlement.api.EntitlementSpecifier, java.lang.String, org.joda.time.LocalDate, org.joda.time.LocalDate, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public UUID addEntitlement(final UUID bundleId, final EntitlementSpecifier spec, final LocalDate entitlementEffectiveDate, final LocalDate billingEffectiveDate, final boolean isMigrated, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("addEntitlement(java.util.UUID, org.killbill.billing.entitlement.api.EntitlementSpecifier, org.joda.time.LocalDate, org.joda.time.LocalDate, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<UUID> createBaseEntitlementsWithAddOns(final UUID accountId, final Iterable<BaseEntitlementWithAddOnsSpecifier> baseEntitlementWithAddOnsSpecifier, final boolean renameCancelledBundleIfExist, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("createBaseEntitlementsWithAddOns(java.util.UUID, java.lang.Iterable<org.killbill.billing.entitlement.api.BaseEntitlementWithAddOnsSpecifier>, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final EntitlementApiImp that = (EntitlementApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends EntitlementApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final EntitlementApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public EntitlementApiImp build() {
+            return new EntitlementApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementImp.java
@@ -1,0 +1,501 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.entitlement.api.Entitlement;
+import org.killbill.billing.entitlement.api.EntitlementApiException;
+import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.callcontext.CallContext;
+
+@JsonDeserialize( builder = EntitlementImp.Builder.class )
+public class EntitlementImp implements Entitlement, Serializable {
+
+    private static final long serialVersionUID = 0xA45D9D5CD7043073L;
+
+    protected UUID accountId;
+    protected UUID baseEntitlementId;
+    protected Integer billCycleDayLocal;
+    protected String bundleExternalKey;
+    protected UUID bundleId;
+    protected DateTime createdDate;
+    protected LocalDate effectiveEndDate;
+    protected LocalDate effectiveStartDate;
+    protected String externalKey;
+    protected UUID id;
+    protected PlanPhase lastActivePhase;
+    protected Plan lastActivePlan;
+    protected PriceList lastActivePriceList;
+    protected Product lastActiveProduct;
+    protected ProductCategory lastActiveProductCategory;
+    protected Entitlement.EntitlementSourceType sourceType;
+    protected Entitlement.EntitlementState state;
+    protected DateTime updatedDate;
+
+    public EntitlementImp(final EntitlementImp that) {
+        this.accountId = that.accountId;
+        this.baseEntitlementId = that.baseEntitlementId;
+        this.billCycleDayLocal = that.billCycleDayLocal;
+        this.bundleExternalKey = that.bundleExternalKey;
+        this.bundleId = that.bundleId;
+        this.createdDate = that.createdDate;
+        this.effectiveEndDate = that.effectiveEndDate;
+        this.effectiveStartDate = that.effectiveStartDate;
+        this.externalKey = that.externalKey;
+        this.id = that.id;
+        this.lastActivePhase = that.lastActivePhase;
+        this.lastActivePlan = that.lastActivePlan;
+        this.lastActivePriceList = that.lastActivePriceList;
+        this.lastActiveProduct = that.lastActiveProduct;
+        this.lastActiveProductCategory = that.lastActiveProductCategory;
+        this.sourceType = that.sourceType;
+        this.state = that.state;
+        this.updatedDate = that.updatedDate;
+    }
+    protected EntitlementImp(final EntitlementImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.baseEntitlementId = builder.baseEntitlementId;
+        this.billCycleDayLocal = builder.billCycleDayLocal;
+        this.bundleExternalKey = builder.bundleExternalKey;
+        this.bundleId = builder.bundleId;
+        this.createdDate = builder.createdDate;
+        this.effectiveEndDate = builder.effectiveEndDate;
+        this.effectiveStartDate = builder.effectiveStartDate;
+        this.externalKey = builder.externalKey;
+        this.id = builder.id;
+        this.lastActivePhase = builder.lastActivePhase;
+        this.lastActivePlan = builder.lastActivePlan;
+        this.lastActivePriceList = builder.lastActivePriceList;
+        this.lastActiveProduct = builder.lastActiveProduct;
+        this.lastActiveProductCategory = builder.lastActiveProductCategory;
+        this.sourceType = builder.sourceType;
+        this.state = builder.state;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected EntitlementImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public UUID getBaseEntitlementId() {
+        return this.baseEntitlementId;
+    }
+    @Override
+    public Integer getBillCycleDayLocal() {
+        return this.billCycleDayLocal;
+    }
+    @Override
+    public String getBundleExternalKey() {
+        return this.bundleExternalKey;
+    }
+    @Override
+    public UUID getBundleId() {
+        return this.bundleId;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public LocalDate getEffectiveEndDate() {
+        return this.effectiveEndDate;
+    }
+    @Override
+    public LocalDate getEffectiveStartDate() {
+        return this.effectiveStartDate;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public PlanPhase getLastActivePhase() {
+        return this.lastActivePhase;
+    }
+    @Override
+    public Plan getLastActivePlan() {
+        return this.lastActivePlan;
+    }
+    @Override
+    public PriceList getLastActivePriceList() {
+        return this.lastActivePriceList;
+    }
+    @Override
+    public Product getLastActiveProduct() {
+        return this.lastActiveProduct;
+    }
+    @Override
+    public ProductCategory getLastActiveProductCategory() {
+        return this.lastActiveProductCategory;
+    }
+    @Override
+    public Entitlement.EntitlementSourceType getSourceType() {
+        return this.sourceType;
+    }
+    @Override
+    public Entitlement.EntitlementState getState() {
+        return this.state;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public void uncancelEntitlement(final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("uncancelEntitlement(java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement changePlanOverrideBillingPolicy(final EntitlementSpecifier spec, final LocalDate effectiveDate, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("changePlanOverrideBillingPolicy(org.killbill.billing.entitlement.api.EntitlementSpecifier, org.joda.time.LocalDate, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement changePlan(final EntitlementSpecifier spec, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("changePlan(org.killbill.billing.entitlement.api.EntitlementSpecifier, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void undoChangePlan(final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("undoChangePlan(java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement cancelEntitlementWithPolicyOverrideBillingPolicy(final Entitlement.EntitlementActionPolicy policy, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("cancelEntitlementWithPolicyOverrideBillingPolicy(org.killbill.billing.entitlement.api.Entitlement.EntitlementActionPolicy, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement cancelEntitlementWithDate(final LocalDate effectiveDate, final boolean overrideBillingEffectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("cancelEntitlementWithDate(org.joda.time.LocalDate, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement cancelEntitlementWithPolicy(final Entitlement.EntitlementActionPolicy policy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("cancelEntitlementWithPolicy(org.killbill.billing.entitlement.api.Entitlement.EntitlementActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement cancelEntitlementWithDateOverrideBillingPolicy(final LocalDate effectiveDate, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("cancelEntitlementWithDateOverrideBillingPolicy(org.joda.time.LocalDate, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void updateBCD(final int bcd, final LocalDate effectiveFromDate, final CallContext context) {
+        throw new UnsupportedOperationException("updateBCD(int, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement changePlanWithDate(final EntitlementSpecifier spec, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("changePlanWithDate(org.killbill.billing.entitlement.api.EntitlementSpecifier, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final EntitlementImp that = (EntitlementImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.baseEntitlementId, that.baseEntitlementId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billCycleDayLocal, that.billCycleDayLocal) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleExternalKey, that.bundleExternalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleId, that.bundleId) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( ( this.effectiveEndDate != null ) ? ( 0 != this.effectiveEndDate.compareTo(that.effectiveEndDate) ) : ( that.effectiveEndDate != null ) ) {
+            return false;
+        }
+        if( ( this.effectiveStartDate != null ) ? ( 0 != this.effectiveStartDate.compareTo(that.effectiveStartDate) ) : ( that.effectiveStartDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActivePhase, that.lastActivePhase) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActivePlan, that.lastActivePlan) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActivePriceList, that.lastActivePriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActiveProduct, that.lastActiveProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActiveProductCategory, that.lastActiveProductCategory) ) {
+            return false;
+        }
+        if( !Objects.equals(this.sourceType, that.sourceType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.state, that.state) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.baseEntitlementId);
+        result = ( 31 * result ) + Objects.hashCode(this.billCycleDayLocal);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleExternalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleId);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveEndDate);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveStartDate);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActivePhase);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActivePlan);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActivePriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActiveProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActiveProductCategory);
+        result = ( 31 * result ) + Objects.hashCode(this.sourceType);
+        result = ( 31 * result ) + Objects.hashCode(this.state);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("baseEntitlementId=").append(this.baseEntitlementId);
+        sb.append(", ");
+        sb.append("billCycleDayLocal=").append(this.billCycleDayLocal);
+        sb.append(", ");
+        sb.append("bundleExternalKey=");
+        if( this.bundleExternalKey == null ) {
+            sb.append(this.bundleExternalKey);
+        }else{
+            sb.append("'").append(this.bundleExternalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("bundleId=").append(this.bundleId);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("effectiveEndDate=").append(this.effectiveEndDate);
+        sb.append(", ");
+        sb.append("effectiveStartDate=").append(this.effectiveStartDate);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("lastActivePhase=").append(this.lastActivePhase);
+        sb.append(", ");
+        sb.append("lastActivePlan=").append(this.lastActivePlan);
+        sb.append(", ");
+        sb.append("lastActivePriceList=").append(this.lastActivePriceList);
+        sb.append(", ");
+        sb.append("lastActiveProduct=").append(this.lastActiveProduct);
+        sb.append(", ");
+        sb.append("lastActiveProductCategory=").append(this.lastActiveProductCategory);
+        sb.append(", ");
+        sb.append("sourceType=").append(this.sourceType);
+        sb.append(", ");
+        sb.append("state=").append(this.state);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends EntitlementImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected UUID baseEntitlementId;
+        protected Integer billCycleDayLocal;
+        protected String bundleExternalKey;
+        protected UUID bundleId;
+        protected DateTime createdDate;
+        protected LocalDate effectiveEndDate;
+        protected LocalDate effectiveStartDate;
+        protected String externalKey;
+        protected UUID id;
+        protected PlanPhase lastActivePhase;
+        protected Plan lastActivePlan;
+        protected PriceList lastActivePriceList;
+        protected Product lastActiveProduct;
+        protected ProductCategory lastActiveProductCategory;
+        protected Entitlement.EntitlementSourceType sourceType;
+        protected Entitlement.EntitlementState state;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.baseEntitlementId = that.baseEntitlementId;
+            this.billCycleDayLocal = that.billCycleDayLocal;
+            this.bundleExternalKey = that.bundleExternalKey;
+            this.bundleId = that.bundleId;
+            this.createdDate = that.createdDate;
+            this.effectiveEndDate = that.effectiveEndDate;
+            this.effectiveStartDate = that.effectiveStartDate;
+            this.externalKey = that.externalKey;
+            this.id = that.id;
+            this.lastActivePhase = that.lastActivePhase;
+            this.lastActivePlan = that.lastActivePlan;
+            this.lastActivePriceList = that.lastActivePriceList;
+            this.lastActiveProduct = that.lastActiveProduct;
+            this.lastActiveProductCategory = that.lastActiveProductCategory;
+            this.sourceType = that.sourceType;
+            this.state = that.state;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withBaseEntitlementId(final UUID baseEntitlementId) {
+            this.baseEntitlementId = baseEntitlementId;
+            return (T) this;
+        }
+        public T withBillCycleDayLocal(final Integer billCycleDayLocal) {
+            this.billCycleDayLocal = billCycleDayLocal;
+            return (T) this;
+        }
+        public T withBundleExternalKey(final String bundleExternalKey) {
+            this.bundleExternalKey = bundleExternalKey;
+            return (T) this;
+        }
+        public T withBundleId(final UUID bundleId) {
+            this.bundleId = bundleId;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withEffectiveEndDate(final LocalDate effectiveEndDate) {
+            this.effectiveEndDate = effectiveEndDate;
+            return (T) this;
+        }
+        public T withEffectiveStartDate(final LocalDate effectiveStartDate) {
+            this.effectiveStartDate = effectiveStartDate;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withLastActivePhase(final PlanPhase lastActivePhase) {
+            this.lastActivePhase = lastActivePhase;
+            return (T) this;
+        }
+        public T withLastActivePlan(final Plan lastActivePlan) {
+            this.lastActivePlan = lastActivePlan;
+            return (T) this;
+        }
+        public T withLastActivePriceList(final PriceList lastActivePriceList) {
+            this.lastActivePriceList = lastActivePriceList;
+            return (T) this;
+        }
+        public T withLastActiveProduct(final Product lastActiveProduct) {
+            this.lastActiveProduct = lastActiveProduct;
+            return (T) this;
+        }
+        public T withLastActiveProductCategory(final ProductCategory lastActiveProductCategory) {
+            this.lastActiveProductCategory = lastActiveProductCategory;
+            return (T) this;
+        }
+        public T withSourceType(final Entitlement.EntitlementSourceType sourceType) {
+            this.sourceType = sourceType;
+            return (T) this;
+        }
+        public T withState(final Entitlement.EntitlementState state) {
+            this.state = state;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Entitlement that) {
+            this.accountId = that.getAccountId();
+            this.baseEntitlementId = that.getBaseEntitlementId();
+            this.billCycleDayLocal = that.getBillCycleDayLocal();
+            this.bundleExternalKey = that.getBundleExternalKey();
+            this.bundleId = that.getBundleId();
+            this.createdDate = that.getCreatedDate();
+            this.effectiveEndDate = that.getEffectiveEndDate();
+            this.effectiveStartDate = that.getEffectiveStartDate();
+            this.externalKey = that.getExternalKey();
+            this.id = that.getId();
+            this.lastActivePhase = that.getLastActivePhase();
+            this.lastActivePlan = that.getLastActivePlan();
+            this.lastActivePriceList = that.getLastActivePriceList();
+            this.lastActiveProduct = that.getLastActiveProduct();
+            this.lastActiveProductCategory = that.getLastActiveProductCategory();
+            this.sourceType = that.getSourceType();
+            this.state = that.getState();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public EntitlementImp build() {
+            return new EntitlementImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementSpecifierImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementSpecifierImp.java
@@ -1,0 +1,166 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+
+@JsonDeserialize( builder = EntitlementSpecifierImp.Builder.class )
+public class EntitlementSpecifierImp implements EntitlementSpecifier, Serializable {
+
+    private static final long serialVersionUID = 0x2216884C686BC006L;
+
+    protected Integer billCycleDay;
+    protected String externalKey;
+    protected List<PlanPhasePriceOverride> overrides;
+    protected PlanPhaseSpecifier planPhaseSpecifier;
+
+    public EntitlementSpecifierImp(final EntitlementSpecifierImp that) {
+        this.billCycleDay = that.billCycleDay;
+        this.externalKey = that.externalKey;
+        this.overrides = that.overrides;
+        this.planPhaseSpecifier = that.planPhaseSpecifier;
+    }
+    protected EntitlementSpecifierImp(final EntitlementSpecifierImp.Builder<?> builder) {
+        this.billCycleDay = builder.billCycleDay;
+        this.externalKey = builder.externalKey;
+        this.overrides = builder.overrides;
+        this.planPhaseSpecifier = builder.planPhaseSpecifier;
+    }
+    protected EntitlementSpecifierImp() { }
+    @Override
+    public Integer getBillCycleDay() {
+        return this.billCycleDay;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public List<PlanPhasePriceOverride> getOverrides() {
+        return this.overrides;
+    }
+    @Override
+    public PlanPhaseSpecifier getPlanPhaseSpecifier() {
+        return this.planPhaseSpecifier;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final EntitlementSpecifierImp that = (EntitlementSpecifierImp) o;
+        if( !Objects.equals(this.billCycleDay, that.billCycleDay) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.overrides, that.overrides) ) {
+            return false;
+        }
+        if( !Objects.equals(this.planPhaseSpecifier, that.planPhaseSpecifier) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.billCycleDay);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.overrides);
+        result = ( 31 * result ) + Objects.hashCode(this.planPhaseSpecifier);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("billCycleDay=").append(this.billCycleDay);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("overrides=").append(this.overrides);
+        sb.append(", ");
+        sb.append("planPhaseSpecifier=").append(this.planPhaseSpecifier);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends EntitlementSpecifierImp.Builder<T>> {
+
+        protected Integer billCycleDay;
+        protected String externalKey;
+        protected List<PlanPhasePriceOverride> overrides;
+        protected PlanPhaseSpecifier planPhaseSpecifier;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.billCycleDay = that.billCycleDay;
+            this.externalKey = that.externalKey;
+            this.overrides = that.overrides;
+            this.planPhaseSpecifier = that.planPhaseSpecifier;
+        }
+        public T withBillCycleDay(final Integer billCycleDay) {
+            this.billCycleDay = billCycleDay;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withOverrides(final List<PlanPhasePriceOverride> overrides) {
+            this.overrides = overrides;
+            return (T) this;
+        }
+        public T withPlanPhaseSpecifier(final PlanPhaseSpecifier planPhaseSpecifier) {
+            this.planPhaseSpecifier = planPhaseSpecifier;
+            return (T) this;
+        }
+        public T source(final EntitlementSpecifier that) {
+            this.billCycleDay = that.getBillCycleDay();
+            this.externalKey = that.getExternalKey();
+            this.overrides = that.getOverrides();
+            this.planPhaseSpecifier = that.getPlanPhaseSpecifier();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public EntitlementSpecifierImp build() {
+            return new EntitlementSpecifierImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.entitlement.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/Resolver.java
@@ -1,0 +1,49 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.entitlement.api.BaseEntitlementWithAddOnsSpecifier;
+import org.killbill.billing.entitlement.api.Blockable;
+import org.killbill.billing.entitlement.api.BlockingState;
+import org.killbill.billing.entitlement.api.Entitlement;
+import org.killbill.billing.entitlement.api.EntitlementAOStatusDryRun;
+import org.killbill.billing.entitlement.api.EntitlementApi;
+import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Subscription;
+import org.killbill.billing.entitlement.api.SubscriptionApi;
+import org.killbill.billing.entitlement.api.SubscriptionBundle;
+import org.killbill.billing.entitlement.api.SubscriptionBundleTimeline;
+import org.killbill.billing.entitlement.api.SubscriptionEvent;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(BaseEntitlementWithAddOnsSpecifier.class, BaseEntitlementWithAddOnsSpecifierImp.class);
+        this.addMapping(Blockable.class, BlockableImp.class);
+        this.addMapping(BlockingState.class, BlockingStateImp.class);
+        this.addMapping(EntitlementAOStatusDryRun.class, EntitlementAOStatusDryRunImp.class);
+        this.addMapping(EntitlementApi.class, EntitlementApiImp.class);
+        this.addMapping(Entitlement.class, EntitlementImp.class);
+        this.addMapping(EntitlementSpecifier.class, EntitlementSpecifierImp.class);
+        this.addMapping(SubscriptionApi.class, SubscriptionApiImp.class);
+        this.addMapping(SubscriptionBundle.class, SubscriptionBundleImp.class);
+        this.addMapping(SubscriptionBundleTimeline.class, SubscriptionBundleTimelineImp.class);
+        this.addMapping(SubscriptionEvent.class, SubscriptionEventImp.class);
+        this.addMapping(Subscription.class, SubscriptionImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionApiImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionApiImp.java
@@ -1,0 +1,159 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.OrderingType;
+import org.killbill.billing.entitlement.api.BlockingState;
+import org.killbill.billing.entitlement.api.BlockingStateType;
+import org.killbill.billing.entitlement.api.EntitlementApiException;
+import org.killbill.billing.entitlement.api.Subscription;
+import org.killbill.billing.entitlement.api.SubscriptionApi;
+import org.killbill.billing.entitlement.api.SubscriptionApiException;
+import org.killbill.billing.entitlement.api.SubscriptionBundle;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.api.AuditLevel;
+import org.killbill.billing.util.audit.AuditLogWithHistory;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.entity.Pagination;
+
+@JsonDeserialize( builder = SubscriptionApiImp.Builder.class )
+public class SubscriptionApiImp implements SubscriptionApi, Serializable {
+
+    private static final long serialVersionUID = 0xE8DBB39D0E927238L;
+
+
+    public SubscriptionApiImp(final SubscriptionApiImp that) {
+    }
+    protected SubscriptionApiImp(final SubscriptionApiImp.Builder<?> builder) {
+    }
+    protected SubscriptionApiImp() { }
+    @Override
+    public void updateExternalKey(final UUID bundleId, final String newExternalKey, final CallContext context) {
+        throw new UnsupportedOperationException("updateExternalKey(java.util.UUID, java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<SubscriptionBundle> searchSubscriptionBundles(final String searchKey, final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("searchSubscriptionBundles(java.lang.String, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Subscription getSubscriptionForEntitlementId(final UUID entitlementId, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionForEntitlementId(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public SubscriptionBundle getActiveSubscriptionBundleForExternalKey(final String externalKey, final TenantContext context) {
+        throw new UnsupportedOperationException("getActiveSubscriptionBundleForExternalKey(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getSubscriptionEventAuditLogsWithHistoryForId(final UUID EventId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionEventAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<SubscriptionBundle> getSubscriptionBundlesForExternalKey(final String externalKey, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionBundlesForExternalKey(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Subscription getSubscriptionForExternalKey(final String externalKey, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionForExternalKey(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public SubscriptionBundle getSubscriptionBundle(final UUID bundleId, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionBundle(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getBlockingStateAuditLogsWithHistoryForId(final UUID blockingId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getBlockingStateAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<SubscriptionBundle> getSubscriptionBundlesForAccountId(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionBundlesForAccountId(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void addBlockingState(final BlockingState blockingState, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("addBlockingState(org.killbill.billing.entitlement.api.BlockingState, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getSubscriptionAuditLogsWithHistoryForId(final UUID entitlementId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<SubscriptionBundle> getSubscriptionBundlesForAccountIdAndExternalKey(final UUID accountId, final String externalKey, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionBundlesForAccountIdAndExternalKey(java.util.UUID, java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<SubscriptionBundle> getSubscriptionBundles(final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionBundles(java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getSubscriptionBundleAuditLogsWithHistoryForId(final UUID bundleId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionBundleAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Iterable<BlockingState> getBlockingStates(final UUID accountId, final List<BlockingStateType> typeFilter, final List<String> svcsFilter, final OrderingType orderingType, final int timeFilter, final TenantContext context) {
+        throw new UnsupportedOperationException("getBlockingStates(java.util.UUID, java.util.List<org.killbill.billing.entitlement.api.BlockingStateType>, java.util.List<java.lang.String>, org.killbill.billing.OrderingType, int, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final SubscriptionApiImp that = (SubscriptionApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends SubscriptionApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final SubscriptionApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public SubscriptionApiImp build() {
+            return new SubscriptionApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionBundleImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionBundleImp.java
@@ -1,0 +1,248 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.entitlement.api.Subscription;
+import org.killbill.billing.entitlement.api.SubscriptionBundle;
+import org.killbill.billing.entitlement.api.SubscriptionBundleTimeline;
+
+@JsonDeserialize( builder = SubscriptionBundleImp.Builder.class )
+public class SubscriptionBundleImp implements SubscriptionBundle, Serializable {
+
+    private static final long serialVersionUID = 0x31F82D72491256B4L;
+
+    protected UUID accountId;
+    protected DateTime createdDate;
+    protected String externalKey;
+    protected UUID id;
+    protected DateTime originalCreatedDate;
+    protected List<Subscription> subscriptions;
+    protected SubscriptionBundleTimeline timeline;
+    protected DateTime updatedDate;
+
+    public SubscriptionBundleImp(final SubscriptionBundleImp that) {
+        this.accountId = that.accountId;
+        this.createdDate = that.createdDate;
+        this.externalKey = that.externalKey;
+        this.id = that.id;
+        this.originalCreatedDate = that.originalCreatedDate;
+        this.subscriptions = that.subscriptions;
+        this.timeline = that.timeline;
+        this.updatedDate = that.updatedDate;
+    }
+    protected SubscriptionBundleImp(final SubscriptionBundleImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.createdDate = builder.createdDate;
+        this.externalKey = builder.externalKey;
+        this.id = builder.id;
+        this.originalCreatedDate = builder.originalCreatedDate;
+        this.subscriptions = builder.subscriptions;
+        this.timeline = builder.timeline;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected SubscriptionBundleImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public DateTime getOriginalCreatedDate() {
+        return this.originalCreatedDate;
+    }
+    @Override
+    public List<Subscription> getSubscriptions() {
+        return this.subscriptions;
+    }
+    @Override
+    public SubscriptionBundleTimeline getTimeline() {
+        return this.timeline;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final SubscriptionBundleImp that = (SubscriptionBundleImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( ( this.originalCreatedDate != null ) ? ( 0 != this.originalCreatedDate.compareTo(that.originalCreatedDate) ) : ( that.originalCreatedDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptions, that.subscriptions) ) {
+            return false;
+        }
+        if( !Objects.equals(this.timeline, that.timeline) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.originalCreatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptions);
+        result = ( 31 * result ) + Objects.hashCode(this.timeline);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("originalCreatedDate=").append(this.originalCreatedDate);
+        sb.append(", ");
+        sb.append("subscriptions=").append(this.subscriptions);
+        sb.append(", ");
+        sb.append("timeline=").append(this.timeline);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends SubscriptionBundleImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected DateTime createdDate;
+        protected String externalKey;
+        protected UUID id;
+        protected DateTime originalCreatedDate;
+        protected List<Subscription> subscriptions;
+        protected SubscriptionBundleTimeline timeline;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.createdDate = that.createdDate;
+            this.externalKey = that.externalKey;
+            this.id = that.id;
+            this.originalCreatedDate = that.originalCreatedDate;
+            this.subscriptions = that.subscriptions;
+            this.timeline = that.timeline;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withOriginalCreatedDate(final DateTime originalCreatedDate) {
+            this.originalCreatedDate = originalCreatedDate;
+            return (T) this;
+        }
+        public T withSubscriptions(final List<Subscription> subscriptions) {
+            this.subscriptions = subscriptions;
+            return (T) this;
+        }
+        public T withTimeline(final SubscriptionBundleTimeline timeline) {
+            this.timeline = timeline;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final SubscriptionBundle that) {
+            this.accountId = that.getAccountId();
+            this.createdDate = that.getCreatedDate();
+            this.externalKey = that.getExternalKey();
+            this.id = that.getId();
+            this.originalCreatedDate = that.getOriginalCreatedDate();
+            this.subscriptions = that.getSubscriptions();
+            this.timeline = that.getTimeline();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public SubscriptionBundleImp build() {
+            return new SubscriptionBundleImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionBundleTimelineImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionBundleTimelineImp.java
@@ -1,0 +1,166 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.entitlement.api.SubscriptionBundleTimeline;
+import org.killbill.billing.entitlement.api.SubscriptionEvent;
+
+@JsonDeserialize( builder = SubscriptionBundleTimelineImp.Builder.class )
+public class SubscriptionBundleTimelineImp implements SubscriptionBundleTimeline, Serializable {
+
+    private static final long serialVersionUID = 0x318C9EEE4713FDCAL;
+
+    protected UUID accountId;
+    protected UUID bundleId;
+    protected String externalKey;
+    protected List<SubscriptionEvent> subscriptionEvents;
+
+    public SubscriptionBundleTimelineImp(final SubscriptionBundleTimelineImp that) {
+        this.accountId = that.accountId;
+        this.bundleId = that.bundleId;
+        this.externalKey = that.externalKey;
+        this.subscriptionEvents = that.subscriptionEvents;
+    }
+    protected SubscriptionBundleTimelineImp(final SubscriptionBundleTimelineImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.bundleId = builder.bundleId;
+        this.externalKey = builder.externalKey;
+        this.subscriptionEvents = builder.subscriptionEvents;
+    }
+    protected SubscriptionBundleTimelineImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public UUID getBundleId() {
+        return this.bundleId;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public List<SubscriptionEvent> getSubscriptionEvents() {
+        return this.subscriptionEvents;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final SubscriptionBundleTimelineImp that = (SubscriptionBundleTimelineImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleId, that.bundleId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionEvents, that.subscriptionEvents) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleId);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionEvents);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("bundleId=").append(this.bundleId);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("subscriptionEvents=").append(this.subscriptionEvents);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends SubscriptionBundleTimelineImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected UUID bundleId;
+        protected String externalKey;
+        protected List<SubscriptionEvent> subscriptionEvents;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.bundleId = that.bundleId;
+            this.externalKey = that.externalKey;
+            this.subscriptionEvents = that.subscriptionEvents;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withBundleId(final UUID bundleId) {
+            this.bundleId = bundleId;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withSubscriptionEvents(final List<SubscriptionEvent> subscriptionEvents) {
+            this.subscriptionEvents = subscriptionEvents;
+            return (T) this;
+        }
+        public T source(final SubscriptionBundleTimeline that) {
+            this.accountId = that.getAccountId();
+            this.bundleId = that.getBundleId();
+            this.externalKey = that.getExternalKey();
+            this.subscriptionEvents = that.getSubscriptionEvents();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public SubscriptionBundleTimelineImp build() {
+            return new SubscriptionBundleTimelineImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionEventImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionEventImp.java
@@ -1,0 +1,458 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingPeriod;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.entitlement.api.SubscriptionEvent;
+import org.killbill.billing.entitlement.api.SubscriptionEventType;
+
+@JsonDeserialize( builder = SubscriptionEventImp.Builder.class )
+public class SubscriptionEventImp implements SubscriptionEvent, Serializable {
+
+    private static final long serialVersionUID = 0x8275A9C29D208B9AL;
+
+    protected LocalDate effectiveDate;
+    protected UUID entitlementId;
+    protected UUID id;
+    protected boolean isBlockedBilling;
+    protected boolean isBlockedEntitlement;
+    protected BillingPeriod nextBillingPeriod;
+    protected PlanPhase nextPhase;
+    protected Plan nextPlan;
+    protected PriceList nextPriceList;
+    protected Product nextProduct;
+    protected BillingPeriod prevBillingPeriod;
+    protected PlanPhase prevPhase;
+    protected Plan prevPlan;
+    protected PriceList prevPriceList;
+    protected Product prevProduct;
+    protected String serviceName;
+    protected String serviceStateName;
+    protected SubscriptionEventType subscriptionEventType;
+
+    public SubscriptionEventImp(final SubscriptionEventImp that) {
+        this.effectiveDate = that.effectiveDate;
+        this.entitlementId = that.entitlementId;
+        this.id = that.id;
+        this.isBlockedBilling = that.isBlockedBilling;
+        this.isBlockedEntitlement = that.isBlockedEntitlement;
+        this.nextBillingPeriod = that.nextBillingPeriod;
+        this.nextPhase = that.nextPhase;
+        this.nextPlan = that.nextPlan;
+        this.nextPriceList = that.nextPriceList;
+        this.nextProduct = that.nextProduct;
+        this.prevBillingPeriod = that.prevBillingPeriod;
+        this.prevPhase = that.prevPhase;
+        this.prevPlan = that.prevPlan;
+        this.prevPriceList = that.prevPriceList;
+        this.prevProduct = that.prevProduct;
+        this.serviceName = that.serviceName;
+        this.serviceStateName = that.serviceStateName;
+        this.subscriptionEventType = that.subscriptionEventType;
+    }
+    protected SubscriptionEventImp(final SubscriptionEventImp.Builder<?> builder) {
+        this.effectiveDate = builder.effectiveDate;
+        this.entitlementId = builder.entitlementId;
+        this.id = builder.id;
+        this.isBlockedBilling = builder.isBlockedBilling;
+        this.isBlockedEntitlement = builder.isBlockedEntitlement;
+        this.nextBillingPeriod = builder.nextBillingPeriod;
+        this.nextPhase = builder.nextPhase;
+        this.nextPlan = builder.nextPlan;
+        this.nextPriceList = builder.nextPriceList;
+        this.nextProduct = builder.nextProduct;
+        this.prevBillingPeriod = builder.prevBillingPeriod;
+        this.prevPhase = builder.prevPhase;
+        this.prevPlan = builder.prevPlan;
+        this.prevPriceList = builder.prevPriceList;
+        this.prevProduct = builder.prevProduct;
+        this.serviceName = builder.serviceName;
+        this.serviceStateName = builder.serviceStateName;
+        this.subscriptionEventType = builder.subscriptionEventType;
+    }
+    protected SubscriptionEventImp() { }
+    @Override
+    public LocalDate getEffectiveDate() {
+        return this.effectiveDate;
+    }
+    @Override
+    public UUID getEntitlementId() {
+        return this.entitlementId;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    @JsonGetter("isBlockedBilling")
+    public boolean isBlockedBilling() {
+        return this.isBlockedBilling;
+    }
+    @Override
+    @JsonGetter("isBlockedEntitlement")
+    public boolean isBlockedEntitlement() {
+        return this.isBlockedEntitlement;
+    }
+    @Override
+    public BillingPeriod getNextBillingPeriod() {
+        return this.nextBillingPeriod;
+    }
+    @Override
+    public PlanPhase getNextPhase() {
+        return this.nextPhase;
+    }
+    @Override
+    public Plan getNextPlan() {
+        return this.nextPlan;
+    }
+    @Override
+    public PriceList getNextPriceList() {
+        return this.nextPriceList;
+    }
+    @Override
+    public Product getNextProduct() {
+        return this.nextProduct;
+    }
+    @Override
+    public BillingPeriod getPrevBillingPeriod() {
+        return this.prevBillingPeriod;
+    }
+    @Override
+    public PlanPhase getPrevPhase() {
+        return this.prevPhase;
+    }
+    @Override
+    public Plan getPrevPlan() {
+        return this.prevPlan;
+    }
+    @Override
+    public PriceList getPrevPriceList() {
+        return this.prevPriceList;
+    }
+    @Override
+    public Product getPrevProduct() {
+        return this.prevProduct;
+    }
+    @Override
+    public String getServiceName() {
+        return this.serviceName;
+    }
+    @Override
+    public String getServiceStateName() {
+        return this.serviceStateName;
+    }
+    @Override
+    public SubscriptionEventType getSubscriptionEventType() {
+        return this.subscriptionEventType;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final SubscriptionEventImp that = (SubscriptionEventImp) o;
+        if( ( this.effectiveDate != null ) ? ( 0 != this.effectiveDate.compareTo(that.effectiveDate) ) : ( that.effectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.entitlementId, that.entitlementId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( this.isBlockedBilling != that.isBlockedBilling ) {
+            return false;
+        }
+        if( this.isBlockedEntitlement != that.isBlockedEntitlement ) {
+            return false;
+        }
+        if( !Objects.equals(this.nextBillingPeriod, that.nextBillingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.nextPhase, that.nextPhase) ) {
+            return false;
+        }
+        if( !Objects.equals(this.nextPlan, that.nextPlan) ) {
+            return false;
+        }
+        if( !Objects.equals(this.nextPriceList, that.nextPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.nextProduct, that.nextProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prevBillingPeriod, that.prevBillingPeriod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prevPhase, that.prevPhase) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prevPlan, that.prevPlan) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prevPriceList, that.prevPriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prevProduct, that.prevProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.serviceName, that.serviceName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.serviceStateName, that.serviceStateName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionEventType, that.subscriptionEventType) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.entitlementId);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.isBlockedBilling);
+        result = ( 31 * result ) + Objects.hashCode(this.isBlockedEntitlement);
+        result = ( 31 * result ) + Objects.hashCode(this.nextBillingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.nextPhase);
+        result = ( 31 * result ) + Objects.hashCode(this.nextPlan);
+        result = ( 31 * result ) + Objects.hashCode(this.nextPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.nextProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.prevBillingPeriod);
+        result = ( 31 * result ) + Objects.hashCode(this.prevPhase);
+        result = ( 31 * result ) + Objects.hashCode(this.prevPlan);
+        result = ( 31 * result ) + Objects.hashCode(this.prevPriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.prevProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.serviceName);
+        result = ( 31 * result ) + Objects.hashCode(this.serviceStateName);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionEventType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("entitlementId=").append(this.entitlementId);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("isBlockedBilling=").append(this.isBlockedBilling);
+        sb.append(", ");
+        sb.append("isBlockedEntitlement=").append(this.isBlockedEntitlement);
+        sb.append(", ");
+        sb.append("nextBillingPeriod=").append(this.nextBillingPeriod);
+        sb.append(", ");
+        sb.append("nextPhase=").append(this.nextPhase);
+        sb.append(", ");
+        sb.append("nextPlan=").append(this.nextPlan);
+        sb.append(", ");
+        sb.append("nextPriceList=").append(this.nextPriceList);
+        sb.append(", ");
+        sb.append("nextProduct=").append(this.nextProduct);
+        sb.append(", ");
+        sb.append("prevBillingPeriod=").append(this.prevBillingPeriod);
+        sb.append(", ");
+        sb.append("prevPhase=").append(this.prevPhase);
+        sb.append(", ");
+        sb.append("prevPlan=").append(this.prevPlan);
+        sb.append(", ");
+        sb.append("prevPriceList=").append(this.prevPriceList);
+        sb.append(", ");
+        sb.append("prevProduct=").append(this.prevProduct);
+        sb.append(", ");
+        sb.append("serviceName=");
+        if( this.serviceName == null ) {
+            sb.append(this.serviceName);
+        }else{
+            sb.append("'").append(this.serviceName).append("'");
+        }
+        sb.append(", ");
+        sb.append("serviceStateName=");
+        if( this.serviceStateName == null ) {
+            sb.append(this.serviceStateName);
+        }else{
+            sb.append("'").append(this.serviceStateName).append("'");
+        }
+        sb.append(", ");
+        sb.append("subscriptionEventType=").append(this.subscriptionEventType);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends SubscriptionEventImp.Builder<T>> {
+
+        protected LocalDate effectiveDate;
+        protected UUID entitlementId;
+        protected UUID id;
+        protected boolean isBlockedBilling;
+        protected boolean isBlockedEntitlement;
+        protected BillingPeriod nextBillingPeriod;
+        protected PlanPhase nextPhase;
+        protected Plan nextPlan;
+        protected PriceList nextPriceList;
+        protected Product nextProduct;
+        protected BillingPeriod prevBillingPeriod;
+        protected PlanPhase prevPhase;
+        protected Plan prevPlan;
+        protected PriceList prevPriceList;
+        protected Product prevProduct;
+        protected String serviceName;
+        protected String serviceStateName;
+        protected SubscriptionEventType subscriptionEventType;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.effectiveDate = that.effectiveDate;
+            this.entitlementId = that.entitlementId;
+            this.id = that.id;
+            this.isBlockedBilling = that.isBlockedBilling;
+            this.isBlockedEntitlement = that.isBlockedEntitlement;
+            this.nextBillingPeriod = that.nextBillingPeriod;
+            this.nextPhase = that.nextPhase;
+            this.nextPlan = that.nextPlan;
+            this.nextPriceList = that.nextPriceList;
+            this.nextProduct = that.nextProduct;
+            this.prevBillingPeriod = that.prevBillingPeriod;
+            this.prevPhase = that.prevPhase;
+            this.prevPlan = that.prevPlan;
+            this.prevPriceList = that.prevPriceList;
+            this.prevProduct = that.prevProduct;
+            this.serviceName = that.serviceName;
+            this.serviceStateName = that.serviceStateName;
+            this.subscriptionEventType = that.subscriptionEventType;
+        }
+        public T withEffectiveDate(final LocalDate effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+        public T withEntitlementId(final UUID entitlementId) {
+            this.entitlementId = entitlementId;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withIsBlockedBilling(final boolean isBlockedBilling) {
+            this.isBlockedBilling = isBlockedBilling;
+            return (T) this;
+        }
+        public T withIsBlockedEntitlement(final boolean isBlockedEntitlement) {
+            this.isBlockedEntitlement = isBlockedEntitlement;
+            return (T) this;
+        }
+        public T withNextBillingPeriod(final BillingPeriod nextBillingPeriod) {
+            this.nextBillingPeriod = nextBillingPeriod;
+            return (T) this;
+        }
+        public T withNextPhase(final PlanPhase nextPhase) {
+            this.nextPhase = nextPhase;
+            return (T) this;
+        }
+        public T withNextPlan(final Plan nextPlan) {
+            this.nextPlan = nextPlan;
+            return (T) this;
+        }
+        public T withNextPriceList(final PriceList nextPriceList) {
+            this.nextPriceList = nextPriceList;
+            return (T) this;
+        }
+        public T withNextProduct(final Product nextProduct) {
+            this.nextProduct = nextProduct;
+            return (T) this;
+        }
+        public T withPrevBillingPeriod(final BillingPeriod prevBillingPeriod) {
+            this.prevBillingPeriod = prevBillingPeriod;
+            return (T) this;
+        }
+        public T withPrevPhase(final PlanPhase prevPhase) {
+            this.prevPhase = prevPhase;
+            return (T) this;
+        }
+        public T withPrevPlan(final Plan prevPlan) {
+            this.prevPlan = prevPlan;
+            return (T) this;
+        }
+        public T withPrevPriceList(final PriceList prevPriceList) {
+            this.prevPriceList = prevPriceList;
+            return (T) this;
+        }
+        public T withPrevProduct(final Product prevProduct) {
+            this.prevProduct = prevProduct;
+            return (T) this;
+        }
+        public T withServiceName(final String serviceName) {
+            this.serviceName = serviceName;
+            return (T) this;
+        }
+        public T withServiceStateName(final String serviceStateName) {
+            this.serviceStateName = serviceStateName;
+            return (T) this;
+        }
+        public T withSubscriptionEventType(final SubscriptionEventType subscriptionEventType) {
+            this.subscriptionEventType = subscriptionEventType;
+            return (T) this;
+        }
+        public T source(final SubscriptionEvent that) {
+            this.effectiveDate = that.getEffectiveDate();
+            this.entitlementId = that.getEntitlementId();
+            this.id = that.getId();
+            this.isBlockedBilling = that.isBlockedBilling();
+            this.isBlockedEntitlement = that.isBlockedEntitlement();
+            this.nextBillingPeriod = that.getNextBillingPeriod();
+            this.nextPhase = that.getNextPhase();
+            this.nextPlan = that.getNextPlan();
+            this.nextPriceList = that.getNextPriceList();
+            this.nextProduct = that.getNextProduct();
+            this.prevBillingPeriod = that.getPrevBillingPeriod();
+            this.prevPhase = that.getPrevPhase();
+            this.prevPlan = that.getPrevPlan();
+            this.prevPriceList = that.getPrevPriceList();
+            this.prevProduct = that.getPrevProduct();
+            this.serviceName = that.getServiceName();
+            this.serviceStateName = that.getServiceStateName();
+            this.subscriptionEventType = that.getSubscriptionEventType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public SubscriptionEventImp build() {
+            return new SubscriptionEventImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionImp.java
@@ -1,0 +1,584 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.entitlement.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.catalog.api.Plan;
+import org.killbill.billing.catalog.api.PlanPhase;
+import org.killbill.billing.catalog.api.PriceList;
+import org.killbill.billing.catalog.api.Product;
+import org.killbill.billing.catalog.api.ProductCategory;
+import org.killbill.billing.entitlement.api.Entitlement;
+import org.killbill.billing.entitlement.api.EntitlementApiException;
+import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+import org.killbill.billing.entitlement.api.Subscription;
+import org.killbill.billing.entitlement.api.SubscriptionEvent;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.callcontext.CallContext;
+
+@JsonDeserialize( builder = SubscriptionImp.Builder.class )
+public class SubscriptionImp implements Subscription, Serializable {
+
+    private static final long serialVersionUID = 0xED7E9E60C49D765L;
+
+    protected UUID accountId;
+    protected UUID baseEntitlementId;
+    protected Integer billCycleDayLocal;
+    protected LocalDate billingEndDate;
+    protected LocalDate billingStartDate;
+    protected String bundleExternalKey;
+    protected UUID bundleId;
+    protected LocalDate chargedThroughDate;
+    protected DateTime createdDate;
+    protected LocalDate effectiveEndDate;
+    protected LocalDate effectiveStartDate;
+    protected String externalKey;
+    protected UUID id;
+    protected PlanPhase lastActivePhase;
+    protected Plan lastActivePlan;
+    protected PriceList lastActivePriceList;
+    protected Product lastActiveProduct;
+    protected ProductCategory lastActiveProductCategory;
+    protected Entitlement.EntitlementSourceType sourceType;
+    protected Entitlement.EntitlementState state;
+    protected List<SubscriptionEvent> subscriptionEvents;
+    protected DateTime updatedDate;
+
+    public SubscriptionImp(final SubscriptionImp that) {
+        this.accountId = that.accountId;
+        this.baseEntitlementId = that.baseEntitlementId;
+        this.billCycleDayLocal = that.billCycleDayLocal;
+        this.billingEndDate = that.billingEndDate;
+        this.billingStartDate = that.billingStartDate;
+        this.bundleExternalKey = that.bundleExternalKey;
+        this.bundleId = that.bundleId;
+        this.chargedThroughDate = that.chargedThroughDate;
+        this.createdDate = that.createdDate;
+        this.effectiveEndDate = that.effectiveEndDate;
+        this.effectiveStartDate = that.effectiveStartDate;
+        this.externalKey = that.externalKey;
+        this.id = that.id;
+        this.lastActivePhase = that.lastActivePhase;
+        this.lastActivePlan = that.lastActivePlan;
+        this.lastActivePriceList = that.lastActivePriceList;
+        this.lastActiveProduct = that.lastActiveProduct;
+        this.lastActiveProductCategory = that.lastActiveProductCategory;
+        this.sourceType = that.sourceType;
+        this.state = that.state;
+        this.subscriptionEvents = that.subscriptionEvents;
+        this.updatedDate = that.updatedDate;
+    }
+    protected SubscriptionImp(final SubscriptionImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.baseEntitlementId = builder.baseEntitlementId;
+        this.billCycleDayLocal = builder.billCycleDayLocal;
+        this.billingEndDate = builder.billingEndDate;
+        this.billingStartDate = builder.billingStartDate;
+        this.bundleExternalKey = builder.bundleExternalKey;
+        this.bundleId = builder.bundleId;
+        this.chargedThroughDate = builder.chargedThroughDate;
+        this.createdDate = builder.createdDate;
+        this.effectiveEndDate = builder.effectiveEndDate;
+        this.effectiveStartDate = builder.effectiveStartDate;
+        this.externalKey = builder.externalKey;
+        this.id = builder.id;
+        this.lastActivePhase = builder.lastActivePhase;
+        this.lastActivePlan = builder.lastActivePlan;
+        this.lastActivePriceList = builder.lastActivePriceList;
+        this.lastActiveProduct = builder.lastActiveProduct;
+        this.lastActiveProductCategory = builder.lastActiveProductCategory;
+        this.sourceType = builder.sourceType;
+        this.state = builder.state;
+        this.subscriptionEvents = builder.subscriptionEvents;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected SubscriptionImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public UUID getBaseEntitlementId() {
+        return this.baseEntitlementId;
+    }
+    @Override
+    public Integer getBillCycleDayLocal() {
+        return this.billCycleDayLocal;
+    }
+    @Override
+    public LocalDate getBillingEndDate() {
+        return this.billingEndDate;
+    }
+    @Override
+    public LocalDate getBillingStartDate() {
+        return this.billingStartDate;
+    }
+    @Override
+    public String getBundleExternalKey() {
+        return this.bundleExternalKey;
+    }
+    @Override
+    public UUID getBundleId() {
+        return this.bundleId;
+    }
+    @Override
+    public LocalDate getChargedThroughDate() {
+        return this.chargedThroughDate;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public LocalDate getEffectiveEndDate() {
+        return this.effectiveEndDate;
+    }
+    @Override
+    public LocalDate getEffectiveStartDate() {
+        return this.effectiveStartDate;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public PlanPhase getLastActivePhase() {
+        return this.lastActivePhase;
+    }
+    @Override
+    public Plan getLastActivePlan() {
+        return this.lastActivePlan;
+    }
+    @Override
+    public PriceList getLastActivePriceList() {
+        return this.lastActivePriceList;
+    }
+    @Override
+    public Product getLastActiveProduct() {
+        return this.lastActiveProduct;
+    }
+    @Override
+    public ProductCategory getLastActiveProductCategory() {
+        return this.lastActiveProductCategory;
+    }
+    @Override
+    public Entitlement.EntitlementSourceType getSourceType() {
+        return this.sourceType;
+    }
+    @Override
+    public Entitlement.EntitlementState getState() {
+        return this.state;
+    }
+    @Override
+    public List<SubscriptionEvent> getSubscriptionEvents() {
+        return this.subscriptionEvents;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public void uncancelEntitlement(final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("uncancelEntitlement(java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement changePlanOverrideBillingPolicy(final EntitlementSpecifier spec, final LocalDate effectiveDate, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("changePlanOverrideBillingPolicy(org.killbill.billing.entitlement.api.EntitlementSpecifier, org.joda.time.LocalDate, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement changePlan(final EntitlementSpecifier spec, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("changePlan(org.killbill.billing.entitlement.api.EntitlementSpecifier, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void undoChangePlan(final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("undoChangePlan(java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement cancelEntitlementWithPolicyOverrideBillingPolicy(final Entitlement.EntitlementActionPolicy policy, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("cancelEntitlementWithPolicyOverrideBillingPolicy(org.killbill.billing.entitlement.api.Entitlement.EntitlementActionPolicy, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement cancelEntitlementWithDate(final LocalDate effectiveDate, final boolean overrideBillingEffectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("cancelEntitlementWithDate(org.joda.time.LocalDate, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement cancelEntitlementWithPolicy(final Entitlement.EntitlementActionPolicy policy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("cancelEntitlementWithPolicy(org.killbill.billing.entitlement.api.Entitlement.EntitlementActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement cancelEntitlementWithDateOverrideBillingPolicy(final LocalDate effectiveDate, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("cancelEntitlementWithDateOverrideBillingPolicy(org.joda.time.LocalDate, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void updateBCD(final int bcd, final LocalDate effectiveFromDate, final CallContext context) {
+        throw new UnsupportedOperationException("updateBCD(int, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Entitlement changePlanWithDate(final EntitlementSpecifier spec, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("changePlanWithDate(org.killbill.billing.entitlement.api.EntitlementSpecifier, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final SubscriptionImp that = (SubscriptionImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.baseEntitlementId, that.baseEntitlementId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billCycleDayLocal, that.billCycleDayLocal) ) {
+            return false;
+        }
+        if( ( this.billingEndDate != null ) ? ( 0 != this.billingEndDate.compareTo(that.billingEndDate) ) : ( that.billingEndDate != null ) ) {
+            return false;
+        }
+        if( ( this.billingStartDate != null ) ? ( 0 != this.billingStartDate.compareTo(that.billingStartDate) ) : ( that.billingStartDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleExternalKey, that.bundleExternalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleId, that.bundleId) ) {
+            return false;
+        }
+        if( ( this.chargedThroughDate != null ) ? ( 0 != this.chargedThroughDate.compareTo(that.chargedThroughDate) ) : ( that.chargedThroughDate != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( ( this.effectiveEndDate != null ) ? ( 0 != this.effectiveEndDate.compareTo(that.effectiveEndDate) ) : ( that.effectiveEndDate != null ) ) {
+            return false;
+        }
+        if( ( this.effectiveStartDate != null ) ? ( 0 != this.effectiveStartDate.compareTo(that.effectiveStartDate) ) : ( that.effectiveStartDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActivePhase, that.lastActivePhase) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActivePlan, that.lastActivePlan) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActivePriceList, that.lastActivePriceList) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActiveProduct, that.lastActiveProduct) ) {
+            return false;
+        }
+        if( !Objects.equals(this.lastActiveProductCategory, that.lastActiveProductCategory) ) {
+            return false;
+        }
+        if( !Objects.equals(this.sourceType, that.sourceType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.state, that.state) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionEvents, that.subscriptionEvents) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.baseEntitlementId);
+        result = ( 31 * result ) + Objects.hashCode(this.billCycleDayLocal);
+        result = ( 31 * result ) + Objects.hashCode(this.billingEndDate);
+        result = ( 31 * result ) + Objects.hashCode(this.billingStartDate);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleExternalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleId);
+        result = ( 31 * result ) + Objects.hashCode(this.chargedThroughDate);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveEndDate);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveStartDate);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActivePhase);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActivePlan);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActivePriceList);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActiveProduct);
+        result = ( 31 * result ) + Objects.hashCode(this.lastActiveProductCategory);
+        result = ( 31 * result ) + Objects.hashCode(this.sourceType);
+        result = ( 31 * result ) + Objects.hashCode(this.state);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionEvents);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("baseEntitlementId=").append(this.baseEntitlementId);
+        sb.append(", ");
+        sb.append("billCycleDayLocal=").append(this.billCycleDayLocal);
+        sb.append(", ");
+        sb.append("billingEndDate=").append(this.billingEndDate);
+        sb.append(", ");
+        sb.append("billingStartDate=").append(this.billingStartDate);
+        sb.append(", ");
+        sb.append("bundleExternalKey=");
+        if( this.bundleExternalKey == null ) {
+            sb.append(this.bundleExternalKey);
+        }else{
+            sb.append("'").append(this.bundleExternalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("bundleId=").append(this.bundleId);
+        sb.append(", ");
+        sb.append("chargedThroughDate=").append(this.chargedThroughDate);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("effectiveEndDate=").append(this.effectiveEndDate);
+        sb.append(", ");
+        sb.append("effectiveStartDate=").append(this.effectiveStartDate);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("lastActivePhase=").append(this.lastActivePhase);
+        sb.append(", ");
+        sb.append("lastActivePlan=").append(this.lastActivePlan);
+        sb.append(", ");
+        sb.append("lastActivePriceList=").append(this.lastActivePriceList);
+        sb.append(", ");
+        sb.append("lastActiveProduct=").append(this.lastActiveProduct);
+        sb.append(", ");
+        sb.append("lastActiveProductCategory=").append(this.lastActiveProductCategory);
+        sb.append(", ");
+        sb.append("sourceType=").append(this.sourceType);
+        sb.append(", ");
+        sb.append("state=").append(this.state);
+        sb.append(", ");
+        sb.append("subscriptionEvents=").append(this.subscriptionEvents);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends SubscriptionImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected UUID baseEntitlementId;
+        protected Integer billCycleDayLocal;
+        protected LocalDate billingEndDate;
+        protected LocalDate billingStartDate;
+        protected String bundleExternalKey;
+        protected UUID bundleId;
+        protected LocalDate chargedThroughDate;
+        protected DateTime createdDate;
+        protected LocalDate effectiveEndDate;
+        protected LocalDate effectiveStartDate;
+        protected String externalKey;
+        protected UUID id;
+        protected PlanPhase lastActivePhase;
+        protected Plan lastActivePlan;
+        protected PriceList lastActivePriceList;
+        protected Product lastActiveProduct;
+        protected ProductCategory lastActiveProductCategory;
+        protected Entitlement.EntitlementSourceType sourceType;
+        protected Entitlement.EntitlementState state;
+        protected List<SubscriptionEvent> subscriptionEvents;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.baseEntitlementId = that.baseEntitlementId;
+            this.billCycleDayLocal = that.billCycleDayLocal;
+            this.billingEndDate = that.billingEndDate;
+            this.billingStartDate = that.billingStartDate;
+            this.bundleExternalKey = that.bundleExternalKey;
+            this.bundleId = that.bundleId;
+            this.chargedThroughDate = that.chargedThroughDate;
+            this.createdDate = that.createdDate;
+            this.effectiveEndDate = that.effectiveEndDate;
+            this.effectiveStartDate = that.effectiveStartDate;
+            this.externalKey = that.externalKey;
+            this.id = that.id;
+            this.lastActivePhase = that.lastActivePhase;
+            this.lastActivePlan = that.lastActivePlan;
+            this.lastActivePriceList = that.lastActivePriceList;
+            this.lastActiveProduct = that.lastActiveProduct;
+            this.lastActiveProductCategory = that.lastActiveProductCategory;
+            this.sourceType = that.sourceType;
+            this.state = that.state;
+            this.subscriptionEvents = that.subscriptionEvents;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withBaseEntitlementId(final UUID baseEntitlementId) {
+            this.baseEntitlementId = baseEntitlementId;
+            return (T) this;
+        }
+        public T withBillCycleDayLocal(final Integer billCycleDayLocal) {
+            this.billCycleDayLocal = billCycleDayLocal;
+            return (T) this;
+        }
+        public T withBillingEndDate(final LocalDate billingEndDate) {
+            this.billingEndDate = billingEndDate;
+            return (T) this;
+        }
+        public T withBillingStartDate(final LocalDate billingStartDate) {
+            this.billingStartDate = billingStartDate;
+            return (T) this;
+        }
+        public T withBundleExternalKey(final String bundleExternalKey) {
+            this.bundleExternalKey = bundleExternalKey;
+            return (T) this;
+        }
+        public T withBundleId(final UUID bundleId) {
+            this.bundleId = bundleId;
+            return (T) this;
+        }
+        public T withChargedThroughDate(final LocalDate chargedThroughDate) {
+            this.chargedThroughDate = chargedThroughDate;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withEffectiveEndDate(final LocalDate effectiveEndDate) {
+            this.effectiveEndDate = effectiveEndDate;
+            return (T) this;
+        }
+        public T withEffectiveStartDate(final LocalDate effectiveStartDate) {
+            this.effectiveStartDate = effectiveStartDate;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withLastActivePhase(final PlanPhase lastActivePhase) {
+            this.lastActivePhase = lastActivePhase;
+            return (T) this;
+        }
+        public T withLastActivePlan(final Plan lastActivePlan) {
+            this.lastActivePlan = lastActivePlan;
+            return (T) this;
+        }
+        public T withLastActivePriceList(final PriceList lastActivePriceList) {
+            this.lastActivePriceList = lastActivePriceList;
+            return (T) this;
+        }
+        public T withLastActiveProduct(final Product lastActiveProduct) {
+            this.lastActiveProduct = lastActiveProduct;
+            return (T) this;
+        }
+        public T withLastActiveProductCategory(final ProductCategory lastActiveProductCategory) {
+            this.lastActiveProductCategory = lastActiveProductCategory;
+            return (T) this;
+        }
+        public T withSourceType(final Entitlement.EntitlementSourceType sourceType) {
+            this.sourceType = sourceType;
+            return (T) this;
+        }
+        public T withState(final Entitlement.EntitlementState state) {
+            this.state = state;
+            return (T) this;
+        }
+        public T withSubscriptionEvents(final List<SubscriptionEvent> subscriptionEvents) {
+            this.subscriptionEvents = subscriptionEvents;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Subscription that) {
+            this.accountId = that.getAccountId();
+            this.baseEntitlementId = that.getBaseEntitlementId();
+            this.billCycleDayLocal = that.getBillCycleDayLocal();
+            this.billingEndDate = that.getBillingEndDate();
+            this.billingStartDate = that.getBillingStartDate();
+            this.bundleExternalKey = that.getBundleExternalKey();
+            this.bundleId = that.getBundleId();
+            this.chargedThroughDate = that.getChargedThroughDate();
+            this.createdDate = that.getCreatedDate();
+            this.effectiveEndDate = that.getEffectiveEndDate();
+            this.effectiveStartDate = that.getEffectiveStartDate();
+            this.externalKey = that.getExternalKey();
+            this.id = that.getId();
+            this.lastActivePhase = that.getLastActivePhase();
+            this.lastActivePlan = that.getLastActivePlan();
+            this.lastActivePriceList = that.getLastActivePriceList();
+            this.lastActiveProduct = that.getLastActiveProduct();
+            this.lastActiveProductCategory = that.getLastActiveProductCategory();
+            this.sourceType = that.getSourceType();
+            this.state = that.getState();
+            this.subscriptionEvents = that.getSubscriptionEvents();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public SubscriptionImp build() {
+            return new SubscriptionImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/DryRunArgumentsImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/DryRunArgumentsImp.java
@@ -1,0 +1,224 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+import org.killbill.billing.entitlement.api.SubscriptionEventType;
+import org.killbill.billing.invoice.api.DryRunArguments;
+import org.killbill.billing.invoice.api.DryRunType;
+
+@JsonDeserialize( builder = DryRunArgumentsImp.Builder.class )
+public class DryRunArgumentsImp implements DryRunArguments, Serializable {
+
+    private static final long serialVersionUID = 0xC0A75EB539775834L;
+
+    protected SubscriptionEventType action;
+    protected BillingActionPolicy billingActionPolicy;
+    protected UUID bundleId;
+    protected DryRunType dryRunType;
+    protected LocalDate effectiveDate;
+    protected EntitlementSpecifier entitlementSpecifier;
+    protected UUID subscriptionId;
+
+    public DryRunArgumentsImp(final DryRunArgumentsImp that) {
+        this.action = that.action;
+        this.billingActionPolicy = that.billingActionPolicy;
+        this.bundleId = that.bundleId;
+        this.dryRunType = that.dryRunType;
+        this.effectiveDate = that.effectiveDate;
+        this.entitlementSpecifier = that.entitlementSpecifier;
+        this.subscriptionId = that.subscriptionId;
+    }
+    protected DryRunArgumentsImp(final DryRunArgumentsImp.Builder<?> builder) {
+        this.action = builder.action;
+        this.billingActionPolicy = builder.billingActionPolicy;
+        this.bundleId = builder.bundleId;
+        this.dryRunType = builder.dryRunType;
+        this.effectiveDate = builder.effectiveDate;
+        this.entitlementSpecifier = builder.entitlementSpecifier;
+        this.subscriptionId = builder.subscriptionId;
+    }
+    protected DryRunArgumentsImp() { }
+    @Override
+    public SubscriptionEventType getAction() {
+        return this.action;
+    }
+    @Override
+    public BillingActionPolicy getBillingActionPolicy() {
+        return this.billingActionPolicy;
+    }
+    @Override
+    public UUID getBundleId() {
+        return this.bundleId;
+    }
+    @Override
+    public DryRunType getDryRunType() {
+        return this.dryRunType;
+    }
+    @Override
+    public LocalDate getEffectiveDate() {
+        return this.effectiveDate;
+    }
+    @Override
+    public EntitlementSpecifier getEntitlementSpecifier() {
+        return this.entitlementSpecifier;
+    }
+    @Override
+    public UUID getSubscriptionId() {
+        return this.subscriptionId;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final DryRunArgumentsImp that = (DryRunArgumentsImp) o;
+        if( !Objects.equals(this.action, that.action) ) {
+            return false;
+        }
+        if( !Objects.equals(this.billingActionPolicy, that.billingActionPolicy) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleId, that.bundleId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.dryRunType, that.dryRunType) ) {
+            return false;
+        }
+        if( ( this.effectiveDate != null ) ? ( 0 != this.effectiveDate.compareTo(that.effectiveDate) ) : ( that.effectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.entitlementSpecifier, that.entitlementSpecifier) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionId, that.subscriptionId) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.action);
+        result = ( 31 * result ) + Objects.hashCode(this.billingActionPolicy);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleId);
+        result = ( 31 * result ) + Objects.hashCode(this.dryRunType);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.entitlementSpecifier);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionId);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("action=").append(this.action);
+        sb.append(", ");
+        sb.append("billingActionPolicy=").append(this.billingActionPolicy);
+        sb.append(", ");
+        sb.append("bundleId=").append(this.bundleId);
+        sb.append(", ");
+        sb.append("dryRunType=").append(this.dryRunType);
+        sb.append(", ");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("entitlementSpecifier=").append(this.entitlementSpecifier);
+        sb.append(", ");
+        sb.append("subscriptionId=").append(this.subscriptionId);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends DryRunArgumentsImp.Builder<T>> {
+
+        protected SubscriptionEventType action;
+        protected BillingActionPolicy billingActionPolicy;
+        protected UUID bundleId;
+        protected DryRunType dryRunType;
+        protected LocalDate effectiveDate;
+        protected EntitlementSpecifier entitlementSpecifier;
+        protected UUID subscriptionId;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.action = that.action;
+            this.billingActionPolicy = that.billingActionPolicy;
+            this.bundleId = that.bundleId;
+            this.dryRunType = that.dryRunType;
+            this.effectiveDate = that.effectiveDate;
+            this.entitlementSpecifier = that.entitlementSpecifier;
+            this.subscriptionId = that.subscriptionId;
+        }
+        public T withAction(final SubscriptionEventType action) {
+            this.action = action;
+            return (T) this;
+        }
+        public T withBillingActionPolicy(final BillingActionPolicy billingActionPolicy) {
+            this.billingActionPolicy = billingActionPolicy;
+            return (T) this;
+        }
+        public T withBundleId(final UUID bundleId) {
+            this.bundleId = bundleId;
+            return (T) this;
+        }
+        public T withDryRunType(final DryRunType dryRunType) {
+            this.dryRunType = dryRunType;
+            return (T) this;
+        }
+        public T withEffectiveDate(final LocalDate effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+        public T withEntitlementSpecifier(final EntitlementSpecifier entitlementSpecifier) {
+            this.entitlementSpecifier = entitlementSpecifier;
+            return (T) this;
+        }
+        public T withSubscriptionId(final UUID subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            return (T) this;
+        }
+        public T source(final DryRunArguments that) {
+            this.action = that.getAction();
+            this.billingActionPolicy = that.getBillingActionPolicy();
+            this.bundleId = that.getBundleId();
+            this.dryRunType = that.getDryRunType();
+            this.effectiveDate = that.getEffectiveDate();
+            this.entitlementSpecifier = that.getEntitlementSpecifier();
+            this.subscriptionId = that.getSubscriptionId();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public DryRunArgumentsImp build() {
+            return new DryRunArgumentsImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceCreationEventImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceCreationEventImp.java
@@ -1,0 +1,79 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.invoice.api.InvoiceCreationEvent;
+
+@JsonDeserialize( builder = InvoiceCreationEventImp.Builder.class )
+public class InvoiceCreationEventImp implements InvoiceCreationEvent, Serializable {
+
+    private static final long serialVersionUID = 0x16BB71F278A6B022L;
+
+
+    public InvoiceCreationEventImp(final InvoiceCreationEventImp that) {
+    }
+    protected InvoiceCreationEventImp(final InvoiceCreationEventImp.Builder<?> builder) {
+    }
+    protected InvoiceCreationEventImp() { }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoiceCreationEventImp that = (InvoiceCreationEventImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoiceCreationEventImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final InvoiceCreationEvent that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoiceCreationEventImp build() {
+            return new InvoiceCreationEventImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceImp.java
@@ -1,0 +1,594 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoicePayment;
+import org.killbill.billing.invoice.api.InvoiceStatus;
+
+@JsonDeserialize( builder = InvoiceImp.Builder.class )
+public class InvoiceImp implements Invoice, Serializable {
+
+    private static final long serialVersionUID = 0x1911E930E2A49165L;
+
+    protected UUID accountId;
+    protected BigDecimal balance;
+    protected BigDecimal chargedAmount;
+    protected DateTime createdDate;
+    protected BigDecimal creditedAmount;
+    protected Currency currency;
+    protected UUID id;
+    protected LocalDate invoiceDate;
+    protected List<InvoiceItem> invoiceItems;
+    protected Integer invoiceNumber;
+    protected boolean isMigrationInvoice;
+    protected boolean isParentInvoice;
+    protected int numberOfItems;
+    protected int numberOfPayments;
+    protected BigDecimal originalChargedAmount;
+    protected BigDecimal paidAmount;
+    protected UUID parentAccountId;
+    protected UUID parentInvoiceId;
+    protected List<InvoicePayment> payments;
+    protected BigDecimal refundedAmount;
+    protected InvoiceStatus status;
+    protected LocalDate targetDate;
+    protected List<String> trackingIds;
+    protected DateTime updatedDate;
+
+    public InvoiceImp(final InvoiceImp that) {
+        this.accountId = that.accountId;
+        this.balance = that.balance;
+        this.chargedAmount = that.chargedAmount;
+        this.createdDate = that.createdDate;
+        this.creditedAmount = that.creditedAmount;
+        this.currency = that.currency;
+        this.id = that.id;
+        this.invoiceDate = that.invoiceDate;
+        this.invoiceItems = that.invoiceItems;
+        this.invoiceNumber = that.invoiceNumber;
+        this.isMigrationInvoice = that.isMigrationInvoice;
+        this.isParentInvoice = that.isParentInvoice;
+        this.numberOfItems = that.numberOfItems;
+        this.numberOfPayments = that.numberOfPayments;
+        this.originalChargedAmount = that.originalChargedAmount;
+        this.paidAmount = that.paidAmount;
+        this.parentAccountId = that.parentAccountId;
+        this.parentInvoiceId = that.parentInvoiceId;
+        this.payments = that.payments;
+        this.refundedAmount = that.refundedAmount;
+        this.status = that.status;
+        this.targetDate = that.targetDate;
+        this.trackingIds = that.trackingIds;
+        this.updatedDate = that.updatedDate;
+    }
+    protected InvoiceImp(final InvoiceImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.balance = builder.balance;
+        this.chargedAmount = builder.chargedAmount;
+        this.createdDate = builder.createdDate;
+        this.creditedAmount = builder.creditedAmount;
+        this.currency = builder.currency;
+        this.id = builder.id;
+        this.invoiceDate = builder.invoiceDate;
+        this.invoiceItems = builder.invoiceItems;
+        this.invoiceNumber = builder.invoiceNumber;
+        this.isMigrationInvoice = builder.isMigrationInvoice;
+        this.isParentInvoice = builder.isParentInvoice;
+        this.numberOfItems = builder.numberOfItems;
+        this.numberOfPayments = builder.numberOfPayments;
+        this.originalChargedAmount = builder.originalChargedAmount;
+        this.paidAmount = builder.paidAmount;
+        this.parentAccountId = builder.parentAccountId;
+        this.parentInvoiceId = builder.parentInvoiceId;
+        this.payments = builder.payments;
+        this.refundedAmount = builder.refundedAmount;
+        this.status = builder.status;
+        this.targetDate = builder.targetDate;
+        this.trackingIds = builder.trackingIds;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected InvoiceImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public BigDecimal getBalance() {
+        return this.balance;
+    }
+    @Override
+    public BigDecimal getChargedAmount() {
+        return this.chargedAmount;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public BigDecimal getCreditedAmount() {
+        return this.creditedAmount;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public LocalDate getInvoiceDate() {
+        return this.invoiceDate;
+    }
+    @Override
+    public List<InvoiceItem> getInvoiceItems() {
+        return this.invoiceItems;
+    }
+    @Override
+    public Integer getInvoiceNumber() {
+        return this.invoiceNumber;
+    }
+    @Override
+    @JsonGetter("isMigrationInvoice")
+    public boolean isMigrationInvoice() {
+        return this.isMigrationInvoice;
+    }
+    @Override
+    @JsonGetter("isParentInvoice")
+    public boolean isParentInvoice() {
+        return this.isParentInvoice;
+    }
+    @Override
+    public int getNumberOfItems() {
+        return this.numberOfItems;
+    }
+    @Override
+    public int getNumberOfPayments() {
+        return this.numberOfPayments;
+    }
+    @Override
+    public BigDecimal getOriginalChargedAmount() {
+        return this.originalChargedAmount;
+    }
+    @Override
+    public BigDecimal getPaidAmount() {
+        return this.paidAmount;
+    }
+    @Override
+    public UUID getParentAccountId() {
+        return this.parentAccountId;
+    }
+    @Override
+    public UUID getParentInvoiceId() {
+        return this.parentInvoiceId;
+    }
+    @Override
+    public List<InvoicePayment> getPayments() {
+        return this.payments;
+    }
+    @Override
+    public BigDecimal getRefundedAmount() {
+        return this.refundedAmount;
+    }
+    @Override
+    public InvoiceStatus getStatus() {
+        return this.status;
+    }
+    @Override
+    public LocalDate getTargetDate() {
+        return this.targetDate;
+    }
+    @Override
+    public List<String> getTrackingIds() {
+        return this.trackingIds;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean addInvoiceItem(final InvoiceItem item) {
+        throw new UnsupportedOperationException("addInvoiceItem(org.killbill.billing.invoice.api.InvoiceItem) must be implemented.");
+    }
+    @Override
+    public boolean addInvoiceItems(final Collection<InvoiceItem> items) {
+        throw new UnsupportedOperationException("addInvoiceItems(java.util.Collection<org.killbill.billing.invoice.api.InvoiceItem>) must be implemented.");
+    }
+    @Override
+    public boolean addPayment(final InvoicePayment payment) {
+        throw new UnsupportedOperationException("addPayment(org.killbill.billing.invoice.api.InvoicePayment) must be implemented.");
+    }
+    @Override
+    public boolean addTrackingIds(final Collection<String> trackingIds) {
+        throw new UnsupportedOperationException("addTrackingIds(java.util.Collection<java.lang.String>) must be implemented.");
+    }
+    @Override
+    public <T extends InvoiceItem> List<InvoiceItem> getInvoiceItems(final Class<T> clazz) {
+        throw new UnsupportedOperationException("getInvoiceItems(java.lang.Class<java.lang.Object>) must be implemented.");
+    }
+    @Override
+    public boolean addPayments(final Collection<InvoicePayment> payments) {
+        throw new UnsupportedOperationException("addPayments(java.util.Collection<org.killbill.billing.invoice.api.InvoicePayment>) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoiceImp that = (InvoiceImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.balance != null ) ? ( 0 != this.balance.compareTo(that.balance) ) : ( that.balance != null ) ) {
+            return false;
+        }
+        if( ( this.chargedAmount != null ) ? ( 0 != this.chargedAmount.compareTo(that.chargedAmount) ) : ( that.chargedAmount != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( ( this.creditedAmount != null ) ? ( 0 != this.creditedAmount.compareTo(that.creditedAmount) ) : ( that.creditedAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( ( this.invoiceDate != null ) ? ( 0 != this.invoiceDate.compareTo(that.invoiceDate) ) : ( that.invoiceDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceItems, that.invoiceItems) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceNumber, that.invoiceNumber) ) {
+            return false;
+        }
+        if( this.isMigrationInvoice != that.isMigrationInvoice ) {
+            return false;
+        }
+        if( this.isParentInvoice != that.isParentInvoice ) {
+            return false;
+        }
+        if( this.numberOfItems != that.numberOfItems ) {
+            return false;
+        }
+        if( this.numberOfPayments != that.numberOfPayments ) {
+            return false;
+        }
+        if( ( this.originalChargedAmount != null ) ? ( 0 != this.originalChargedAmount.compareTo(that.originalChargedAmount) ) : ( that.originalChargedAmount != null ) ) {
+            return false;
+        }
+        if( ( this.paidAmount != null ) ? ( 0 != this.paidAmount.compareTo(that.paidAmount) ) : ( that.paidAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.parentAccountId, that.parentAccountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.parentInvoiceId, that.parentInvoiceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.payments, that.payments) ) {
+            return false;
+        }
+        if( ( this.refundedAmount != null ) ? ( 0 != this.refundedAmount.compareTo(that.refundedAmount) ) : ( that.refundedAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.status, that.status) ) {
+            return false;
+        }
+        if( ( this.targetDate != null ) ? ( 0 != this.targetDate.compareTo(that.targetDate) ) : ( that.targetDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.trackingIds, that.trackingIds) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.balance);
+        result = ( 31 * result ) + Objects.hashCode(this.chargedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.creditedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceDate);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceItems);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceNumber);
+        result = ( 31 * result ) + Objects.hashCode(this.isMigrationInvoice);
+        result = ( 31 * result ) + Objects.hashCode(this.isParentInvoice);
+        result = ( 31 * result ) + Objects.hashCode(this.numberOfItems);
+        result = ( 31 * result ) + Objects.hashCode(this.numberOfPayments);
+        result = ( 31 * result ) + Objects.hashCode(this.originalChargedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.paidAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.parentAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.parentInvoiceId);
+        result = ( 31 * result ) + Objects.hashCode(this.payments);
+        result = ( 31 * result ) + Objects.hashCode(this.refundedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.status);
+        result = ( 31 * result ) + Objects.hashCode(this.targetDate);
+        result = ( 31 * result ) + Objects.hashCode(this.trackingIds);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("balance=").append(this.balance);
+        sb.append(", ");
+        sb.append("chargedAmount=").append(this.chargedAmount);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("creditedAmount=").append(this.creditedAmount);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("invoiceDate=").append(this.invoiceDate);
+        sb.append(", ");
+        sb.append("invoiceItems=").append(this.invoiceItems);
+        sb.append(", ");
+        sb.append("invoiceNumber=").append(this.invoiceNumber);
+        sb.append(", ");
+        sb.append("isMigrationInvoice=").append(this.isMigrationInvoice);
+        sb.append(", ");
+        sb.append("isParentInvoice=").append(this.isParentInvoice);
+        sb.append(", ");
+        sb.append("numberOfItems=").append(this.numberOfItems);
+        sb.append(", ");
+        sb.append("numberOfPayments=").append(this.numberOfPayments);
+        sb.append(", ");
+        sb.append("originalChargedAmount=").append(this.originalChargedAmount);
+        sb.append(", ");
+        sb.append("paidAmount=").append(this.paidAmount);
+        sb.append(", ");
+        sb.append("parentAccountId=").append(this.parentAccountId);
+        sb.append(", ");
+        sb.append("parentInvoiceId=").append(this.parentInvoiceId);
+        sb.append(", ");
+        sb.append("payments=").append(this.payments);
+        sb.append(", ");
+        sb.append("refundedAmount=").append(this.refundedAmount);
+        sb.append(", ");
+        sb.append("status=").append(this.status);
+        sb.append(", ");
+        sb.append("targetDate=").append(this.targetDate);
+        sb.append(", ");
+        sb.append("trackingIds=").append(this.trackingIds);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoiceImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected BigDecimal balance;
+        protected BigDecimal chargedAmount;
+        protected DateTime createdDate;
+        protected BigDecimal creditedAmount;
+        protected Currency currency;
+        protected UUID id;
+        protected LocalDate invoiceDate;
+        protected List<InvoiceItem> invoiceItems;
+        protected Integer invoiceNumber;
+        protected boolean isMigrationInvoice;
+        protected boolean isParentInvoice;
+        protected int numberOfItems;
+        protected int numberOfPayments;
+        protected BigDecimal originalChargedAmount;
+        protected BigDecimal paidAmount;
+        protected UUID parentAccountId;
+        protected UUID parentInvoiceId;
+        protected List<InvoicePayment> payments;
+        protected BigDecimal refundedAmount;
+        protected InvoiceStatus status;
+        protected LocalDate targetDate;
+        protected List<String> trackingIds;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.balance = that.balance;
+            this.chargedAmount = that.chargedAmount;
+            this.createdDate = that.createdDate;
+            this.creditedAmount = that.creditedAmount;
+            this.currency = that.currency;
+            this.id = that.id;
+            this.invoiceDate = that.invoiceDate;
+            this.invoiceItems = that.invoiceItems;
+            this.invoiceNumber = that.invoiceNumber;
+            this.isMigrationInvoice = that.isMigrationInvoice;
+            this.isParentInvoice = that.isParentInvoice;
+            this.numberOfItems = that.numberOfItems;
+            this.numberOfPayments = that.numberOfPayments;
+            this.originalChargedAmount = that.originalChargedAmount;
+            this.paidAmount = that.paidAmount;
+            this.parentAccountId = that.parentAccountId;
+            this.parentInvoiceId = that.parentInvoiceId;
+            this.payments = that.payments;
+            this.refundedAmount = that.refundedAmount;
+            this.status = that.status;
+            this.targetDate = that.targetDate;
+            this.trackingIds = that.trackingIds;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withBalance(final BigDecimal balance) {
+            this.balance = balance;
+            return (T) this;
+        }
+        public T withChargedAmount(final BigDecimal chargedAmount) {
+            this.chargedAmount = chargedAmount;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCreditedAmount(final BigDecimal creditedAmount) {
+            this.creditedAmount = creditedAmount;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withInvoiceDate(final LocalDate invoiceDate) {
+            this.invoiceDate = invoiceDate;
+            return (T) this;
+        }
+        public T withInvoiceItems(final List<InvoiceItem> invoiceItems) {
+            this.invoiceItems = invoiceItems;
+            return (T) this;
+        }
+        public T withInvoiceNumber(final Integer invoiceNumber) {
+            this.invoiceNumber = invoiceNumber;
+            return (T) this;
+        }
+        public T withIsMigrationInvoice(final boolean isMigrationInvoice) {
+            this.isMigrationInvoice = isMigrationInvoice;
+            return (T) this;
+        }
+        public T withIsParentInvoice(final boolean isParentInvoice) {
+            this.isParentInvoice = isParentInvoice;
+            return (T) this;
+        }
+        public T withNumberOfItems(final int numberOfItems) {
+            this.numberOfItems = numberOfItems;
+            return (T) this;
+        }
+        public T withNumberOfPayments(final int numberOfPayments) {
+            this.numberOfPayments = numberOfPayments;
+            return (T) this;
+        }
+        public T withOriginalChargedAmount(final BigDecimal originalChargedAmount) {
+            this.originalChargedAmount = originalChargedAmount;
+            return (T) this;
+        }
+        public T withPaidAmount(final BigDecimal paidAmount) {
+            this.paidAmount = paidAmount;
+            return (T) this;
+        }
+        public T withParentAccountId(final UUID parentAccountId) {
+            this.parentAccountId = parentAccountId;
+            return (T) this;
+        }
+        public T withParentInvoiceId(final UUID parentInvoiceId) {
+            this.parentInvoiceId = parentInvoiceId;
+            return (T) this;
+        }
+        public T withPayments(final List<InvoicePayment> payments) {
+            this.payments = payments;
+            return (T) this;
+        }
+        public T withRefundedAmount(final BigDecimal refundedAmount) {
+            this.refundedAmount = refundedAmount;
+            return (T) this;
+        }
+        public T withStatus(final InvoiceStatus status) {
+            this.status = status;
+            return (T) this;
+        }
+        public T withTargetDate(final LocalDate targetDate) {
+            this.targetDate = targetDate;
+            return (T) this;
+        }
+        public T withTrackingIds(final List<String> trackingIds) {
+            this.trackingIds = trackingIds;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Invoice that) {
+            this.accountId = that.getAccountId();
+            this.balance = that.getBalance();
+            this.chargedAmount = that.getChargedAmount();
+            this.createdDate = that.getCreatedDate();
+            this.creditedAmount = that.getCreditedAmount();
+            this.currency = that.getCurrency();
+            this.id = that.getId();
+            this.invoiceDate = that.getInvoiceDate();
+            this.invoiceItems = that.getInvoiceItems();
+            this.invoiceNumber = that.getInvoiceNumber();
+            this.isMigrationInvoice = that.isMigrationInvoice();
+            this.isParentInvoice = that.isParentInvoice();
+            this.numberOfItems = that.getNumberOfItems();
+            this.numberOfPayments = that.getNumberOfPayments();
+            this.originalChargedAmount = that.getOriginalChargedAmount();
+            this.paidAmount = that.getPaidAmount();
+            this.parentAccountId = that.getParentAccountId();
+            this.parentInvoiceId = that.getParentInvoiceId();
+            this.payments = that.getPayments();
+            this.refundedAmount = that.getRefundedAmount();
+            this.status = that.getStatus();
+            this.targetDate = that.getTargetDate();
+            this.trackingIds = that.getTrackingIds();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoiceImp build() {
+            return new InvoiceImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceItemImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceItemImp.java
@@ -1,0 +1,678 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+
+@JsonDeserialize( builder = InvoiceItemImp.Builder.class )
+public class InvoiceItemImp implements InvoiceItem, Serializable {
+
+    private static final long serialVersionUID = 0xEAED5A85CF301F11L;
+
+    protected UUID accountId;
+    protected BigDecimal amount;
+    protected UUID bundleId;
+    protected DateTime catalogEffectiveDate;
+    protected UUID childAccountId;
+    protected DateTime createdDate;
+    protected Currency currency;
+    protected String description;
+    protected LocalDate endDate;
+    protected UUID id;
+    protected UUID invoiceId;
+    protected InvoiceItemType invoiceItemType;
+    protected String itemDetails;
+    protected UUID linkedItemId;
+    protected String phaseName;
+    protected String planName;
+    protected String prettyPhaseName;
+    protected String prettyPlanName;
+    protected String prettyProductName;
+    protected String prettyUsageName;
+    protected String productName;
+    protected Integer quantity;
+    protected BigDecimal rate;
+    protected LocalDate startDate;
+    protected UUID subscriptionId;
+    protected DateTime updatedDate;
+    protected String usageName;
+
+    public InvoiceItemImp(final InvoiceItemImp that) {
+        this.accountId = that.accountId;
+        this.amount = that.amount;
+        this.bundleId = that.bundleId;
+        this.catalogEffectiveDate = that.catalogEffectiveDate;
+        this.childAccountId = that.childAccountId;
+        this.createdDate = that.createdDate;
+        this.currency = that.currency;
+        this.description = that.description;
+        this.endDate = that.endDate;
+        this.id = that.id;
+        this.invoiceId = that.invoiceId;
+        this.invoiceItemType = that.invoiceItemType;
+        this.itemDetails = that.itemDetails;
+        this.linkedItemId = that.linkedItemId;
+        this.phaseName = that.phaseName;
+        this.planName = that.planName;
+        this.prettyPhaseName = that.prettyPhaseName;
+        this.prettyPlanName = that.prettyPlanName;
+        this.prettyProductName = that.prettyProductName;
+        this.prettyUsageName = that.prettyUsageName;
+        this.productName = that.productName;
+        this.quantity = that.quantity;
+        this.rate = that.rate;
+        this.startDate = that.startDate;
+        this.subscriptionId = that.subscriptionId;
+        this.updatedDate = that.updatedDate;
+        this.usageName = that.usageName;
+    }
+    protected InvoiceItemImp(final InvoiceItemImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.amount = builder.amount;
+        this.bundleId = builder.bundleId;
+        this.catalogEffectiveDate = builder.catalogEffectiveDate;
+        this.childAccountId = builder.childAccountId;
+        this.createdDate = builder.createdDate;
+        this.currency = builder.currency;
+        this.description = builder.description;
+        this.endDate = builder.endDate;
+        this.id = builder.id;
+        this.invoiceId = builder.invoiceId;
+        this.invoiceItemType = builder.invoiceItemType;
+        this.itemDetails = builder.itemDetails;
+        this.linkedItemId = builder.linkedItemId;
+        this.phaseName = builder.phaseName;
+        this.planName = builder.planName;
+        this.prettyPhaseName = builder.prettyPhaseName;
+        this.prettyPlanName = builder.prettyPlanName;
+        this.prettyProductName = builder.prettyProductName;
+        this.prettyUsageName = builder.prettyUsageName;
+        this.productName = builder.productName;
+        this.quantity = builder.quantity;
+        this.rate = builder.rate;
+        this.startDate = builder.startDate;
+        this.subscriptionId = builder.subscriptionId;
+        this.updatedDate = builder.updatedDate;
+        this.usageName = builder.usageName;
+    }
+    protected InvoiceItemImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public BigDecimal getAmount() {
+        return this.amount;
+    }
+    @Override
+    public UUID getBundleId() {
+        return this.bundleId;
+    }
+    @Override
+    public DateTime getCatalogEffectiveDate() {
+        return this.catalogEffectiveDate;
+    }
+    @Override
+    public UUID getChildAccountId() {
+        return this.childAccountId;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+    @Override
+    public LocalDate getEndDate() {
+        return this.endDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public UUID getInvoiceId() {
+        return this.invoiceId;
+    }
+    @Override
+    public InvoiceItemType getInvoiceItemType() {
+        return this.invoiceItemType;
+    }
+    @Override
+    public String getItemDetails() {
+        return this.itemDetails;
+    }
+    @Override
+    public UUID getLinkedItemId() {
+        return this.linkedItemId;
+    }
+    @Override
+    public String getPhaseName() {
+        return this.phaseName;
+    }
+    @Override
+    public String getPlanName() {
+        return this.planName;
+    }
+    @Override
+    public String getPrettyPhaseName() {
+        return this.prettyPhaseName;
+    }
+    @Override
+    public String getPrettyPlanName() {
+        return this.prettyPlanName;
+    }
+    @Override
+    public String getPrettyProductName() {
+        return this.prettyProductName;
+    }
+    @Override
+    public String getPrettyUsageName() {
+        return this.prettyUsageName;
+    }
+    @Override
+    public String getProductName() {
+        return this.productName;
+    }
+    @Override
+    public Integer getQuantity() {
+        return this.quantity;
+    }
+    @Override
+    public BigDecimal getRate() {
+        return this.rate;
+    }
+    @Override
+    public LocalDate getStartDate() {
+        return this.startDate;
+    }
+    @Override
+    public UUID getSubscriptionId() {
+        return this.subscriptionId;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public String getUsageName() {
+        return this.usageName;
+    }
+    @Override
+    public boolean matches(final Object other) {
+        throw new UnsupportedOperationException("matches(java.lang.Object) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoiceItemImp that = (InvoiceItemImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.amount != null ) ? ( 0 != this.amount.compareTo(that.amount) ) : ( that.amount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleId, that.bundleId) ) {
+            return false;
+        }
+        if( ( this.catalogEffectiveDate != null ) ? ( 0 != this.catalogEffectiveDate.compareTo(that.catalogEffectiveDate) ) : ( that.catalogEffectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.childAccountId, that.childAccountId) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.description, that.description) ) {
+            return false;
+        }
+        if( ( this.endDate != null ) ? ( 0 != this.endDate.compareTo(that.endDate) ) : ( that.endDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceId, that.invoiceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceItemType, that.invoiceItemType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.itemDetails, that.itemDetails) ) {
+            return false;
+        }
+        if( !Objects.equals(this.linkedItemId, that.linkedItemId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseName, that.phaseName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.planName, that.planName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyPhaseName, that.prettyPhaseName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyPlanName, that.prettyPlanName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyProductName, that.prettyProductName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyUsageName, that.prettyUsageName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productName, that.productName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.quantity, that.quantity) ) {
+            return false;
+        }
+        if( ( this.rate != null ) ? ( 0 != this.rate.compareTo(that.rate) ) : ( that.rate != null ) ) {
+            return false;
+        }
+        if( ( this.startDate != null ) ? ( 0 != this.startDate.compareTo(that.startDate) ) : ( that.startDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionId, that.subscriptionId) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.usageName, that.usageName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleId);
+        result = ( 31 * result ) + Objects.hashCode(this.catalogEffectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.childAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.description);
+        result = ( 31 * result ) + Objects.hashCode(this.endDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceId);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceItemType);
+        result = ( 31 * result ) + Objects.hashCode(this.itemDetails);
+        result = ( 31 * result ) + Objects.hashCode(this.linkedItemId);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseName);
+        result = ( 31 * result ) + Objects.hashCode(this.planName);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyPhaseName);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyPlanName);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyProductName);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyUsageName);
+        result = ( 31 * result ) + Objects.hashCode(this.productName);
+        result = ( 31 * result ) + Objects.hashCode(this.quantity);
+        result = ( 31 * result ) + Objects.hashCode(this.rate);
+        result = ( 31 * result ) + Objects.hashCode(this.startDate);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionId);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.usageName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("bundleId=").append(this.bundleId);
+        sb.append(", ");
+        sb.append("catalogEffectiveDate=").append(this.catalogEffectiveDate);
+        sb.append(", ");
+        sb.append("childAccountId=").append(this.childAccountId);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("description=");
+        if( this.description == null ) {
+            sb.append(this.description);
+        }else{
+            sb.append("'").append(this.description).append("'");
+        }
+        sb.append(", ");
+        sb.append("endDate=").append(this.endDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("invoiceId=").append(this.invoiceId);
+        sb.append(", ");
+        sb.append("invoiceItemType=").append(this.invoiceItemType);
+        sb.append(", ");
+        sb.append("itemDetails=");
+        if( this.itemDetails == null ) {
+            sb.append(this.itemDetails);
+        }else{
+            sb.append("'").append(this.itemDetails).append("'");
+        }
+        sb.append(", ");
+        sb.append("linkedItemId=").append(this.linkedItemId);
+        sb.append(", ");
+        sb.append("phaseName=");
+        if( this.phaseName == null ) {
+            sb.append(this.phaseName);
+        }else{
+            sb.append("'").append(this.phaseName).append("'");
+        }
+        sb.append(", ");
+        sb.append("planName=");
+        if( this.planName == null ) {
+            sb.append(this.planName);
+        }else{
+            sb.append("'").append(this.planName).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyPhaseName=");
+        if( this.prettyPhaseName == null ) {
+            sb.append(this.prettyPhaseName);
+        }else{
+            sb.append("'").append(this.prettyPhaseName).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyPlanName=");
+        if( this.prettyPlanName == null ) {
+            sb.append(this.prettyPlanName);
+        }else{
+            sb.append("'").append(this.prettyPlanName).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyProductName=");
+        if( this.prettyProductName == null ) {
+            sb.append(this.prettyProductName);
+        }else{
+            sb.append("'").append(this.prettyProductName).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyUsageName=");
+        if( this.prettyUsageName == null ) {
+            sb.append(this.prettyUsageName);
+        }else{
+            sb.append("'").append(this.prettyUsageName).append("'");
+        }
+        sb.append(", ");
+        sb.append("productName=");
+        if( this.productName == null ) {
+            sb.append(this.productName);
+        }else{
+            sb.append("'").append(this.productName).append("'");
+        }
+        sb.append(", ");
+        sb.append("quantity=").append(this.quantity);
+        sb.append(", ");
+        sb.append("rate=").append(this.rate);
+        sb.append(", ");
+        sb.append("startDate=").append(this.startDate);
+        sb.append(", ");
+        sb.append("subscriptionId=").append(this.subscriptionId);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("usageName=");
+        if( this.usageName == null ) {
+            sb.append(this.usageName);
+        }else{
+            sb.append("'").append(this.usageName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoiceItemImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected BigDecimal amount;
+        protected UUID bundleId;
+        protected DateTime catalogEffectiveDate;
+        protected UUID childAccountId;
+        protected DateTime createdDate;
+        protected Currency currency;
+        protected String description;
+        protected LocalDate endDate;
+        protected UUID id;
+        protected UUID invoiceId;
+        protected InvoiceItemType invoiceItemType;
+        protected String itemDetails;
+        protected UUID linkedItemId;
+        protected String phaseName;
+        protected String planName;
+        protected String prettyPhaseName;
+        protected String prettyPlanName;
+        protected String prettyProductName;
+        protected String prettyUsageName;
+        protected String productName;
+        protected Integer quantity;
+        protected BigDecimal rate;
+        protected LocalDate startDate;
+        protected UUID subscriptionId;
+        protected DateTime updatedDate;
+        protected String usageName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.amount = that.amount;
+            this.bundleId = that.bundleId;
+            this.catalogEffectiveDate = that.catalogEffectiveDate;
+            this.childAccountId = that.childAccountId;
+            this.createdDate = that.createdDate;
+            this.currency = that.currency;
+            this.description = that.description;
+            this.endDate = that.endDate;
+            this.id = that.id;
+            this.invoiceId = that.invoiceId;
+            this.invoiceItemType = that.invoiceItemType;
+            this.itemDetails = that.itemDetails;
+            this.linkedItemId = that.linkedItemId;
+            this.phaseName = that.phaseName;
+            this.planName = that.planName;
+            this.prettyPhaseName = that.prettyPhaseName;
+            this.prettyPlanName = that.prettyPlanName;
+            this.prettyProductName = that.prettyProductName;
+            this.prettyUsageName = that.prettyUsageName;
+            this.productName = that.productName;
+            this.quantity = that.quantity;
+            this.rate = that.rate;
+            this.startDate = that.startDate;
+            this.subscriptionId = that.subscriptionId;
+            this.updatedDate = that.updatedDate;
+            this.usageName = that.usageName;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withAmount(final BigDecimal amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withBundleId(final UUID bundleId) {
+            this.bundleId = bundleId;
+            return (T) this;
+        }
+        public T withCatalogEffectiveDate(final DateTime catalogEffectiveDate) {
+            this.catalogEffectiveDate = catalogEffectiveDate;
+            return (T) this;
+        }
+        public T withChildAccountId(final UUID childAccountId) {
+            this.childAccountId = childAccountId;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withDescription(final String description) {
+            this.description = description;
+            return (T) this;
+        }
+        public T withEndDate(final LocalDate endDate) {
+            this.endDate = endDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withInvoiceId(final UUID invoiceId) {
+            this.invoiceId = invoiceId;
+            return (T) this;
+        }
+        public T withInvoiceItemType(final InvoiceItemType invoiceItemType) {
+            this.invoiceItemType = invoiceItemType;
+            return (T) this;
+        }
+        public T withItemDetails(final String itemDetails) {
+            this.itemDetails = itemDetails;
+            return (T) this;
+        }
+        public T withLinkedItemId(final UUID linkedItemId) {
+            this.linkedItemId = linkedItemId;
+            return (T) this;
+        }
+        public T withPhaseName(final String phaseName) {
+            this.phaseName = phaseName;
+            return (T) this;
+        }
+        public T withPlanName(final String planName) {
+            this.planName = planName;
+            return (T) this;
+        }
+        public T withPrettyPhaseName(final String prettyPhaseName) {
+            this.prettyPhaseName = prettyPhaseName;
+            return (T) this;
+        }
+        public T withPrettyPlanName(final String prettyPlanName) {
+            this.prettyPlanName = prettyPlanName;
+            return (T) this;
+        }
+        public T withPrettyProductName(final String prettyProductName) {
+            this.prettyProductName = prettyProductName;
+            return (T) this;
+        }
+        public T withPrettyUsageName(final String prettyUsageName) {
+            this.prettyUsageName = prettyUsageName;
+            return (T) this;
+        }
+        public T withProductName(final String productName) {
+            this.productName = productName;
+            return (T) this;
+        }
+        public T withQuantity(final Integer quantity) {
+            this.quantity = quantity;
+            return (T) this;
+        }
+        public T withRate(final BigDecimal rate) {
+            this.rate = rate;
+            return (T) this;
+        }
+        public T withStartDate(final LocalDate startDate) {
+            this.startDate = startDate;
+            return (T) this;
+        }
+        public T withSubscriptionId(final UUID subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T withUsageName(final String usageName) {
+            this.usageName = usageName;
+            return (T) this;
+        }
+        public T source(final InvoiceItem that) {
+            this.accountId = that.getAccountId();
+            this.amount = that.getAmount();
+            this.bundleId = that.getBundleId();
+            this.catalogEffectiveDate = that.getCatalogEffectiveDate();
+            this.childAccountId = that.getChildAccountId();
+            this.createdDate = that.getCreatedDate();
+            this.currency = that.getCurrency();
+            this.description = that.getDescription();
+            this.endDate = that.getEndDate();
+            this.id = that.getId();
+            this.invoiceId = that.getInvoiceId();
+            this.invoiceItemType = that.getInvoiceItemType();
+            this.itemDetails = that.getItemDetails();
+            this.linkedItemId = that.getLinkedItemId();
+            this.phaseName = that.getPhaseName();
+            this.planName = that.getPlanName();
+            this.prettyPhaseName = that.getPrettyPhaseName();
+            this.prettyPlanName = that.getPrettyPlanName();
+            this.prettyProductName = that.getPrettyProductName();
+            this.prettyUsageName = that.getPrettyUsageName();
+            this.productName = that.getProductName();
+            this.quantity = that.getQuantity();
+            this.rate = that.getRate();
+            this.startDate = that.getStartDate();
+            this.subscriptionId = that.getSubscriptionId();
+            this.updatedDate = that.getUpdatedDate();
+            this.usageName = that.getUsageName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoiceItemImp build() {
+            return new InvoiceItemImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceParentChildImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceParentChildImp.java
@@ -1,0 +1,200 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.invoice.api.InvoiceParentChild;
+
+@JsonDeserialize( builder = InvoiceParentChildImp.Builder.class )
+public class InvoiceParentChildImp implements InvoiceParentChild, Serializable {
+
+    private static final long serialVersionUID = 0x84A09113887080CCL;
+
+    protected UUID childAccountId;
+    protected UUID childInvoiceId;
+    protected DateTime createdDate;
+    protected UUID id;
+    protected UUID parentInvoiceId;
+    protected DateTime updatedDate;
+
+    public InvoiceParentChildImp(final InvoiceParentChildImp that) {
+        this.childAccountId = that.childAccountId;
+        this.childInvoiceId = that.childInvoiceId;
+        this.createdDate = that.createdDate;
+        this.id = that.id;
+        this.parentInvoiceId = that.parentInvoiceId;
+        this.updatedDate = that.updatedDate;
+    }
+    protected InvoiceParentChildImp(final InvoiceParentChildImp.Builder<?> builder) {
+        this.childAccountId = builder.childAccountId;
+        this.childInvoiceId = builder.childInvoiceId;
+        this.createdDate = builder.createdDate;
+        this.id = builder.id;
+        this.parentInvoiceId = builder.parentInvoiceId;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected InvoiceParentChildImp() { }
+    @Override
+    public UUID getChildAccountId() {
+        return this.childAccountId;
+    }
+    @Override
+    public UUID getChildInvoiceId() {
+        return this.childInvoiceId;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public UUID getParentInvoiceId() {
+        return this.parentInvoiceId;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoiceParentChildImp that = (InvoiceParentChildImp) o;
+        if( !Objects.equals(this.childAccountId, that.childAccountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.childInvoiceId, that.childInvoiceId) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.parentInvoiceId, that.parentInvoiceId) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.childAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.childInvoiceId);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.parentInvoiceId);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("childAccountId=").append(this.childAccountId);
+        sb.append(", ");
+        sb.append("childInvoiceId=").append(this.childInvoiceId);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("parentInvoiceId=").append(this.parentInvoiceId);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoiceParentChildImp.Builder<T>> {
+
+        protected UUID childAccountId;
+        protected UUID childInvoiceId;
+        protected DateTime createdDate;
+        protected UUID id;
+        protected UUID parentInvoiceId;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.childAccountId = that.childAccountId;
+            this.childInvoiceId = that.childInvoiceId;
+            this.createdDate = that.createdDate;
+            this.id = that.id;
+            this.parentInvoiceId = that.parentInvoiceId;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withChildAccountId(final UUID childAccountId) {
+            this.childAccountId = childAccountId;
+            return (T) this;
+        }
+        public T withChildInvoiceId(final UUID childInvoiceId) {
+            this.childInvoiceId = childInvoiceId;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withParentInvoiceId(final UUID parentInvoiceId) {
+            this.parentInvoiceId = parentInvoiceId;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final InvoiceParentChild that) {
+            this.childAccountId = that.getChildAccountId();
+            this.childInvoiceId = that.getChildInvoiceId();
+            this.createdDate = that.getCreatedDate();
+            this.id = that.getId();
+            this.parentInvoiceId = that.getParentInvoiceId();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoiceParentChildImp build() {
+            return new InvoiceParentChildImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoicePaymentImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoicePaymentImp.java
@@ -1,0 +1,349 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.InvoicePayment;
+import org.killbill.billing.invoice.api.InvoicePaymentType;
+
+@JsonDeserialize( builder = InvoicePaymentImp.Builder.class )
+public class InvoicePaymentImp implements InvoicePayment, Serializable {
+
+    private static final long serialVersionUID = 0xC42E4426E09BB7ADL;
+
+    protected BigDecimal amount;
+    protected DateTime createdDate;
+    protected Currency currency;
+    protected UUID id;
+    protected UUID invoiceId;
+    protected Boolean isSuccess;
+    protected UUID linkedInvoicePaymentId;
+    protected String paymentCookieId;
+    protected DateTime paymentDate;
+    protected UUID paymentId;
+    protected Currency processedCurrency;
+    protected InvoicePaymentType type;
+    protected DateTime updatedDate;
+
+    public InvoicePaymentImp(final InvoicePaymentImp that) {
+        this.amount = that.amount;
+        this.createdDate = that.createdDate;
+        this.currency = that.currency;
+        this.id = that.id;
+        this.invoiceId = that.invoiceId;
+        this.isSuccess = that.isSuccess;
+        this.linkedInvoicePaymentId = that.linkedInvoicePaymentId;
+        this.paymentCookieId = that.paymentCookieId;
+        this.paymentDate = that.paymentDate;
+        this.paymentId = that.paymentId;
+        this.processedCurrency = that.processedCurrency;
+        this.type = that.type;
+        this.updatedDate = that.updatedDate;
+    }
+    protected InvoicePaymentImp(final InvoicePaymentImp.Builder<?> builder) {
+        this.amount = builder.amount;
+        this.createdDate = builder.createdDate;
+        this.currency = builder.currency;
+        this.id = builder.id;
+        this.invoiceId = builder.invoiceId;
+        this.isSuccess = builder.isSuccess;
+        this.linkedInvoicePaymentId = builder.linkedInvoicePaymentId;
+        this.paymentCookieId = builder.paymentCookieId;
+        this.paymentDate = builder.paymentDate;
+        this.paymentId = builder.paymentId;
+        this.processedCurrency = builder.processedCurrency;
+        this.type = builder.type;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected InvoicePaymentImp() { }
+    @Override
+    public BigDecimal getAmount() {
+        return this.amount;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public UUID getInvoiceId() {
+        return this.invoiceId;
+    }
+    @Override
+    @JsonGetter("isSuccess")
+    public Boolean isSuccess() {
+        return this.isSuccess;
+    }
+    @Override
+    public UUID getLinkedInvoicePaymentId() {
+        return this.linkedInvoicePaymentId;
+    }
+    @Override
+    public String getPaymentCookieId() {
+        return this.paymentCookieId;
+    }
+    @Override
+    public DateTime getPaymentDate() {
+        return this.paymentDate;
+    }
+    @Override
+    public UUID getPaymentId() {
+        return this.paymentId;
+    }
+    @Override
+    public Currency getProcessedCurrency() {
+        return this.processedCurrency;
+    }
+    @Override
+    public InvoicePaymentType getType() {
+        return this.type;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoicePaymentImp that = (InvoicePaymentImp) o;
+        if( ( this.amount != null ) ? ( 0 != this.amount.compareTo(that.amount) ) : ( that.amount != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceId, that.invoiceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isSuccess, that.isSuccess) ) {
+            return false;
+        }
+        if( !Objects.equals(this.linkedInvoicePaymentId, that.linkedInvoicePaymentId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentCookieId, that.paymentCookieId) ) {
+            return false;
+        }
+        if( ( this.paymentDate != null ) ? ( 0 != this.paymentDate.compareTo(that.paymentDate) ) : ( that.paymentDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentId, that.paymentId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.processedCurrency, that.processedCurrency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.type, that.type) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceId);
+        result = ( 31 * result ) + Objects.hashCode(this.isSuccess);
+        result = ( 31 * result ) + Objects.hashCode(this.linkedInvoicePaymentId);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentCookieId);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentDate);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentId);
+        result = ( 31 * result ) + Objects.hashCode(this.processedCurrency);
+        result = ( 31 * result ) + Objects.hashCode(this.type);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("invoiceId=").append(this.invoiceId);
+        sb.append(", ");
+        sb.append("isSuccess=").append(this.isSuccess);
+        sb.append(", ");
+        sb.append("linkedInvoicePaymentId=").append(this.linkedInvoicePaymentId);
+        sb.append(", ");
+        sb.append("paymentCookieId=");
+        if( this.paymentCookieId == null ) {
+            sb.append(this.paymentCookieId);
+        }else{
+            sb.append("'").append(this.paymentCookieId).append("'");
+        }
+        sb.append(", ");
+        sb.append("paymentDate=").append(this.paymentDate);
+        sb.append(", ");
+        sb.append("paymentId=").append(this.paymentId);
+        sb.append(", ");
+        sb.append("processedCurrency=").append(this.processedCurrency);
+        sb.append(", ");
+        sb.append("type=").append(this.type);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoicePaymentImp.Builder<T>> {
+
+        protected BigDecimal amount;
+        protected DateTime createdDate;
+        protected Currency currency;
+        protected UUID id;
+        protected UUID invoiceId;
+        protected Boolean isSuccess;
+        protected UUID linkedInvoicePaymentId;
+        protected String paymentCookieId;
+        protected DateTime paymentDate;
+        protected UUID paymentId;
+        protected Currency processedCurrency;
+        protected InvoicePaymentType type;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.amount = that.amount;
+            this.createdDate = that.createdDate;
+            this.currency = that.currency;
+            this.id = that.id;
+            this.invoiceId = that.invoiceId;
+            this.isSuccess = that.isSuccess;
+            this.linkedInvoicePaymentId = that.linkedInvoicePaymentId;
+            this.paymentCookieId = that.paymentCookieId;
+            this.paymentDate = that.paymentDate;
+            this.paymentId = that.paymentId;
+            this.processedCurrency = that.processedCurrency;
+            this.type = that.type;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAmount(final BigDecimal amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withInvoiceId(final UUID invoiceId) {
+            this.invoiceId = invoiceId;
+            return (T) this;
+        }
+        public T withIsSuccess(final Boolean isSuccess) {
+            this.isSuccess = isSuccess;
+            return (T) this;
+        }
+        public T withLinkedInvoicePaymentId(final UUID linkedInvoicePaymentId) {
+            this.linkedInvoicePaymentId = linkedInvoicePaymentId;
+            return (T) this;
+        }
+        public T withPaymentCookieId(final String paymentCookieId) {
+            this.paymentCookieId = paymentCookieId;
+            return (T) this;
+        }
+        public T withPaymentDate(final DateTime paymentDate) {
+            this.paymentDate = paymentDate;
+            return (T) this;
+        }
+        public T withPaymentId(final UUID paymentId) {
+            this.paymentId = paymentId;
+            return (T) this;
+        }
+        public T withProcessedCurrency(final Currency processedCurrency) {
+            this.processedCurrency = processedCurrency;
+            return (T) this;
+        }
+        public T withType(final InvoicePaymentType type) {
+            this.type = type;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final InvoicePayment that) {
+            this.amount = that.getAmount();
+            this.createdDate = that.getCreatedDate();
+            this.currency = that.getCurrency();
+            this.id = that.getId();
+            this.invoiceId = that.getInvoiceId();
+            this.isSuccess = that.isSuccess();
+            this.linkedInvoicePaymentId = that.getLinkedInvoicePaymentId();
+            this.paymentCookieId = that.getPaymentCookieId();
+            this.paymentDate = that.getPaymentDate();
+            this.paymentId = that.getPaymentId();
+            this.processedCurrency = that.getProcessedCurrency();
+            this.type = that.getType();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoicePaymentImp build() {
+            return new InvoicePaymentImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceUserApiImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceUserApiImp.java
@@ -1,0 +1,230 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.account.api.AccountApiException;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.DryRunArguments;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceApiException;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoiceUserApi;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.api.AuditLevel;
+import org.killbill.billing.util.api.TagApiException;
+import org.killbill.billing.util.audit.AuditLogWithHistory;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.entity.Pagination;
+
+@JsonDeserialize( builder = InvoiceUserApiImp.Builder.class )
+public class InvoiceUserApiImp implements InvoiceUserApi, Serializable {
+
+    private static final long serialVersionUID = 0x43B28676FD363526L;
+
+
+    public InvoiceUserApiImp(final InvoiceUserApiImp that) {
+    }
+    protected InvoiceUserApiImp(final InvoiceUserApiImp.Builder<?> builder) {
+    }
+    protected InvoiceUserApiImp() { }
+    @Override
+    public void transferChildCreditToParent(final UUID childAccountId, final CallContext context) {
+        throw new UnsupportedOperationException("transferChildCreditToParent(java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<InvoiceItem> insertExternalCharges(final UUID accountId, final LocalDate effectiveDate, final Iterable<InvoiceItem> charges, final boolean autoCommit, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("insertExternalCharges(java.util.UUID, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.invoice.api.InvoiceItem>, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public String getInvoiceAsHTML(final UUID invoiceId, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoiceAsHTML(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Invoice> searchInvoices(final String searchKey, final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("searchInvoices(java.lang.String, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Invoice getInvoiceByPayment(final UUID paymentId, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoiceByPayment(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<Invoice> getInvoicesByAccount(final UUID accountId, final boolean includesMigrated, final boolean includeVoidedInvoices, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicesByAccount(java.util.UUID, boolean, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public UUID createMigrationInvoice(final UUID accountId, final LocalDate invoiceDate, final Iterable<InvoiceItem> items, final CallContext context) {
+        throw new UnsupportedOperationException("createMigrationInvoice(java.util.UUID, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.invoice.api.InvoiceItem>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public BigDecimal getAccountCBA(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccountCBA(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<InvoiceItem> getInvoiceItemsByParentInvoice(final UUID parentInvoiceId, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoiceItemsByParentInvoice(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Invoice triggerDryRunInvoiceGeneration(final UUID accountId, final LocalDate targetDate, final DryRunArguments dryRunArguments, final CallContext context) {
+        throw new UnsupportedOperationException("triggerDryRunInvoiceGeneration(java.util.UUID, org.joda.time.LocalDate, org.killbill.billing.invoice.api.DryRunArguments, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Invoice triggerInvoiceGeneration(final UUID accountId, final LocalDate targetDate, final CallContext context) {
+        throw new UnsupportedOperationException("triggerInvoiceGeneration(java.util.UUID, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getInvoicePaymentAuditLogsWithHistoryForId(final UUID invoicePaymentId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicePaymentAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void deleteCBA(final UUID accountId, final UUID invoiceId, final UUID invoiceItemId, final CallContext context) {
+        throw new UnsupportedOperationException("deleteCBA(java.util.UUID, java.util.UUID, java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Invoice getInvoiceByInvoiceItem(final UUID invoiceItemId, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoiceByInvoiceItem(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void consumeExistingCBAOnAccountWithUnpaidInvoices(final UUID accountId, final CallContext context) {
+        throw new UnsupportedOperationException("consumeExistingCBAOnAccountWithUnpaidInvoices(java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public InvoiceItem insertInvoiceItemAdjustment(final UUID accountId, final UUID invoiceId, final UUID invoiceItemId, final LocalDate effectiveDate, final BigDecimal amount, final Currency currency, final String description, final String itemDetails, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("insertInvoiceItemAdjustment(java.util.UUID, java.util.UUID, java.util.UUID, org.joda.time.LocalDate, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public InvoiceItem getExternalChargeById(final UUID externalChargeId, final TenantContext context) {
+        throw new UnsupportedOperationException("getExternalChargeById(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Invoice getInvoiceByNumber(final Integer number, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoiceByNumber(java.lang.Integer, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Invoice> getInvoices(final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoices(java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<InvoiceItem> insertCredits(final UUID accountId, final LocalDate effectiveDate, final Iterable<InvoiceItem> creditItems, final boolean autoCommit, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("insertCredits(java.util.UUID, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.invoice.api.InvoiceItem>, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public InvoiceItem getCreditById(final UUID creditId, final TenantContext context) {
+        throw new UnsupportedOperationException("getCreditById(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public InvoiceItem insertInvoiceItemAdjustment(final UUID accountId, final UUID invoiceId, final UUID invoiceItemId, final LocalDate effectiveDate, final String description, final String itemDetails, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("insertInvoiceItemAdjustment(java.util.UUID, java.util.UUID, java.util.UUID, org.joda.time.LocalDate, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Invoice getInvoice(final UUID invoiceId, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoice(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void voidInvoice(final UUID invoiceId, final CallContext context) {
+        throw new UnsupportedOperationException("voidInvoice(java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getInvoiceAuditLogsWithHistoryForId(final UUID invoiceId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoiceAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<Invoice> getInvoicesByAccount(final UUID accountId, final LocalDate fromDate, final LocalDate upToDate, final boolean includeVoidedInvoices, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicesByAccount(java.util.UUID, org.joda.time.LocalDate, org.joda.time.LocalDate, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void tagInvoiceAsWrittenOff(final UUID invoiceId, final CallContext context) {
+        throw new UnsupportedOperationException("tagInvoiceAsWrittenOff(java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<InvoiceItem> insertTaxItems(final UUID accountId, final LocalDate effectiveDate, final Iterable<InvoiceItem> taxes, final boolean autoCommit, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("insertTaxItems(java.util.UUID, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.invoice.api.InvoiceItem>, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getInvoiceItemAuditLogsWithHistoryForId(final UUID invoiceItemId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoiceItemAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void tagInvoiceAsNotWrittenOff(final UUID invoiceId, final CallContext context) {
+        throw new UnsupportedOperationException("tagInvoiceAsNotWrittenOff(java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public BigDecimal getAccountBalance(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccountBalance(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void commitInvoice(final UUID invoiceId, final CallContext context) {
+        throw new UnsupportedOperationException("commitInvoice(java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Collection<Invoice> getUnpaidInvoicesByAccountId(final UUID accountId, final LocalDate fromDate, final LocalDate upToDate, final TenantContext context) {
+        throw new UnsupportedOperationException("getUnpaidInvoicesByAccountId(java.util.UUID, org.joda.time.LocalDate, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoiceUserApiImp that = (InvoiceUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoiceUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final InvoiceUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoiceUserApiImp build() {
+            return new InvoiceUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.invoice.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/Resolver.java
@@ -1,0 +1,39 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.invoice.api.DryRunArguments;
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.InvoiceCreationEvent;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoiceParentChild;
+import org.killbill.billing.invoice.api.InvoicePayment;
+import org.killbill.billing.invoice.api.InvoiceUserApi;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(DryRunArguments.class, DryRunArgumentsImp.class);
+        this.addMapping(InvoiceCreationEvent.class, InvoiceCreationEventImp.class);
+        this.addMapping(Invoice.class, InvoiceImp.class);
+        this.addMapping(InvoiceItem.class, InvoiceItemImp.class);
+        this.addMapping(InvoiceParentChild.class, InvoiceParentChildImp.class);
+        this.addMapping(InvoicePayment.class, InvoicePaymentImp.class);
+        this.addMapping(InvoiceUserApi.class, InvoiceUserApiImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/formatters/boilerplate/InvoiceFormatterImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/formatters/boilerplate/InvoiceFormatterImp.java
@@ -1,0 +1,739 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.formatters.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.InvoiceItem;
+import org.killbill.billing.invoice.api.InvoicePayment;
+import org.killbill.billing.invoice.api.InvoiceStatus;
+import org.killbill.billing.invoice.api.formatters.InvoiceFormatter;
+
+@JsonDeserialize( builder = InvoiceFormatterImp.Builder.class )
+public class InvoiceFormatterImp implements InvoiceFormatter, Serializable {
+
+    private static final long serialVersionUID = 0x1AE703146018525BL;
+
+    protected UUID accountId;
+    protected BigDecimal balance;
+    protected BigDecimal chargedAmount;
+    protected DateTime createdDate;
+    protected BigDecimal creditedAmount;
+    protected Currency currency;
+    protected String formattedBalance;
+    protected String formattedChargedAmount;
+    protected String formattedInvoiceDate;
+    protected String formattedPaidAmount;
+    protected UUID id;
+    protected LocalDate invoiceDate;
+    protected List<InvoiceItem> invoiceItems;
+    protected Integer invoiceNumber;
+    protected boolean isMigrationInvoice;
+    protected boolean isParentInvoice;
+    protected int numberOfItems;
+    protected int numberOfPayments;
+    protected BigDecimal originalChargedAmount;
+    protected BigDecimal paidAmount;
+    protected UUID parentAccountId;
+    protected UUID parentInvoiceId;
+    protected List<InvoicePayment> payments;
+    protected Currency processedCurrency;
+    protected String processedPaymentRate;
+    protected BigDecimal refundedAmount;
+    protected InvoiceStatus status;
+    protected LocalDate targetDate;
+    protected List<String> trackingIds;
+    protected DateTime updatedDate;
+
+    public InvoiceFormatterImp(final InvoiceFormatterImp that) {
+        this.accountId = that.accountId;
+        this.balance = that.balance;
+        this.chargedAmount = that.chargedAmount;
+        this.createdDate = that.createdDate;
+        this.creditedAmount = that.creditedAmount;
+        this.currency = that.currency;
+        this.formattedBalance = that.formattedBalance;
+        this.formattedChargedAmount = that.formattedChargedAmount;
+        this.formattedInvoiceDate = that.formattedInvoiceDate;
+        this.formattedPaidAmount = that.formattedPaidAmount;
+        this.id = that.id;
+        this.invoiceDate = that.invoiceDate;
+        this.invoiceItems = that.invoiceItems;
+        this.invoiceNumber = that.invoiceNumber;
+        this.isMigrationInvoice = that.isMigrationInvoice;
+        this.isParentInvoice = that.isParentInvoice;
+        this.numberOfItems = that.numberOfItems;
+        this.numberOfPayments = that.numberOfPayments;
+        this.originalChargedAmount = that.originalChargedAmount;
+        this.paidAmount = that.paidAmount;
+        this.parentAccountId = that.parentAccountId;
+        this.parentInvoiceId = that.parentInvoiceId;
+        this.payments = that.payments;
+        this.processedCurrency = that.processedCurrency;
+        this.processedPaymentRate = that.processedPaymentRate;
+        this.refundedAmount = that.refundedAmount;
+        this.status = that.status;
+        this.targetDate = that.targetDate;
+        this.trackingIds = that.trackingIds;
+        this.updatedDate = that.updatedDate;
+    }
+    protected InvoiceFormatterImp(final InvoiceFormatterImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.balance = builder.balance;
+        this.chargedAmount = builder.chargedAmount;
+        this.createdDate = builder.createdDate;
+        this.creditedAmount = builder.creditedAmount;
+        this.currency = builder.currency;
+        this.formattedBalance = builder.formattedBalance;
+        this.formattedChargedAmount = builder.formattedChargedAmount;
+        this.formattedInvoiceDate = builder.formattedInvoiceDate;
+        this.formattedPaidAmount = builder.formattedPaidAmount;
+        this.id = builder.id;
+        this.invoiceDate = builder.invoiceDate;
+        this.invoiceItems = builder.invoiceItems;
+        this.invoiceNumber = builder.invoiceNumber;
+        this.isMigrationInvoice = builder.isMigrationInvoice;
+        this.isParentInvoice = builder.isParentInvoice;
+        this.numberOfItems = builder.numberOfItems;
+        this.numberOfPayments = builder.numberOfPayments;
+        this.originalChargedAmount = builder.originalChargedAmount;
+        this.paidAmount = builder.paidAmount;
+        this.parentAccountId = builder.parentAccountId;
+        this.parentInvoiceId = builder.parentInvoiceId;
+        this.payments = builder.payments;
+        this.processedCurrency = builder.processedCurrency;
+        this.processedPaymentRate = builder.processedPaymentRate;
+        this.refundedAmount = builder.refundedAmount;
+        this.status = builder.status;
+        this.targetDate = builder.targetDate;
+        this.trackingIds = builder.trackingIds;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected InvoiceFormatterImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public BigDecimal getBalance() {
+        return this.balance;
+    }
+    @Override
+    public BigDecimal getChargedAmount() {
+        return this.chargedAmount;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public BigDecimal getCreditedAmount() {
+        return this.creditedAmount;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public String getFormattedBalance() {
+        return this.formattedBalance;
+    }
+    @Override
+    public String getFormattedChargedAmount() {
+        return this.formattedChargedAmount;
+    }
+    @Override
+    public String getFormattedInvoiceDate() {
+        return this.formattedInvoiceDate;
+    }
+    @Override
+    public String getFormattedPaidAmount() {
+        return this.formattedPaidAmount;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public LocalDate getInvoiceDate() {
+        return this.invoiceDate;
+    }
+    @Override
+    public List<InvoiceItem> getInvoiceItems() {
+        return this.invoiceItems;
+    }
+    @Override
+    public Integer getInvoiceNumber() {
+        return this.invoiceNumber;
+    }
+    @Override
+    @JsonGetter("isMigrationInvoice")
+    public boolean isMigrationInvoice() {
+        return this.isMigrationInvoice;
+    }
+    @Override
+    @JsonGetter("isParentInvoice")
+    public boolean isParentInvoice() {
+        return this.isParentInvoice;
+    }
+    @Override
+    public int getNumberOfItems() {
+        return this.numberOfItems;
+    }
+    @Override
+    public int getNumberOfPayments() {
+        return this.numberOfPayments;
+    }
+    @Override
+    public BigDecimal getOriginalChargedAmount() {
+        return this.originalChargedAmount;
+    }
+    @Override
+    public BigDecimal getPaidAmount() {
+        return this.paidAmount;
+    }
+    @Override
+    public UUID getParentAccountId() {
+        return this.parentAccountId;
+    }
+    @Override
+    public UUID getParentInvoiceId() {
+        return this.parentInvoiceId;
+    }
+    @Override
+    public List<InvoicePayment> getPayments() {
+        return this.payments;
+    }
+    @Override
+    public Currency getProcessedCurrency() {
+        return this.processedCurrency;
+    }
+    @Override
+    public String getProcessedPaymentRate() {
+        return this.processedPaymentRate;
+    }
+    @Override
+    public BigDecimal getRefundedAmount() {
+        return this.refundedAmount;
+    }
+    @Override
+    public InvoiceStatus getStatus() {
+        return this.status;
+    }
+    @Override
+    public LocalDate getTargetDate() {
+        return this.targetDate;
+    }
+    @Override
+    public List<String> getTrackingIds() {
+        return this.trackingIds;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean addInvoiceItem(final InvoiceItem item) {
+        throw new UnsupportedOperationException("addInvoiceItem(org.killbill.billing.invoice.api.InvoiceItem) must be implemented.");
+    }
+    @Override
+    public boolean addInvoiceItems(final Collection<InvoiceItem> items) {
+        throw new UnsupportedOperationException("addInvoiceItems(java.util.Collection<org.killbill.billing.invoice.api.InvoiceItem>) must be implemented.");
+    }
+    @Override
+    public boolean addPayment(final InvoicePayment payment) {
+        throw new UnsupportedOperationException("addPayment(org.killbill.billing.invoice.api.InvoicePayment) must be implemented.");
+    }
+    @Override
+    public boolean addTrackingIds(final Collection<String> trackingIds) {
+        throw new UnsupportedOperationException("addTrackingIds(java.util.Collection<java.lang.String>) must be implemented.");
+    }
+    @Override
+    public <T extends InvoiceItem> List<InvoiceItem> getInvoiceItems(final Class<T> clazz) {
+        throw new UnsupportedOperationException("getInvoiceItems(java.lang.Class<java.lang.Object>) must be implemented.");
+    }
+    @Override
+    public boolean addPayments(final Collection<InvoicePayment> payments) {
+        throw new UnsupportedOperationException("addPayments(java.util.Collection<org.killbill.billing.invoice.api.InvoicePayment>) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoiceFormatterImp that = (InvoiceFormatterImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.balance != null ) ? ( 0 != this.balance.compareTo(that.balance) ) : ( that.balance != null ) ) {
+            return false;
+        }
+        if( ( this.chargedAmount != null ) ? ( 0 != this.chargedAmount.compareTo(that.chargedAmount) ) : ( that.chargedAmount != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( ( this.creditedAmount != null ) ? ( 0 != this.creditedAmount.compareTo(that.creditedAmount) ) : ( that.creditedAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formattedBalance, that.formattedBalance) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formattedChargedAmount, that.formattedChargedAmount) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formattedInvoiceDate, that.formattedInvoiceDate) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formattedPaidAmount, that.formattedPaidAmount) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( ( this.invoiceDate != null ) ? ( 0 != this.invoiceDate.compareTo(that.invoiceDate) ) : ( that.invoiceDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceItems, that.invoiceItems) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceNumber, that.invoiceNumber) ) {
+            return false;
+        }
+        if( this.isMigrationInvoice != that.isMigrationInvoice ) {
+            return false;
+        }
+        if( this.isParentInvoice != that.isParentInvoice ) {
+            return false;
+        }
+        if( this.numberOfItems != that.numberOfItems ) {
+            return false;
+        }
+        if( this.numberOfPayments != that.numberOfPayments ) {
+            return false;
+        }
+        if( ( this.originalChargedAmount != null ) ? ( 0 != this.originalChargedAmount.compareTo(that.originalChargedAmount) ) : ( that.originalChargedAmount != null ) ) {
+            return false;
+        }
+        if( ( this.paidAmount != null ) ? ( 0 != this.paidAmount.compareTo(that.paidAmount) ) : ( that.paidAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.parentAccountId, that.parentAccountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.parentInvoiceId, that.parentInvoiceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.payments, that.payments) ) {
+            return false;
+        }
+        if( !Objects.equals(this.processedCurrency, that.processedCurrency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.processedPaymentRate, that.processedPaymentRate) ) {
+            return false;
+        }
+        if( ( this.refundedAmount != null ) ? ( 0 != this.refundedAmount.compareTo(that.refundedAmount) ) : ( that.refundedAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.status, that.status) ) {
+            return false;
+        }
+        if( ( this.targetDate != null ) ? ( 0 != this.targetDate.compareTo(that.targetDate) ) : ( that.targetDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.trackingIds, that.trackingIds) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.balance);
+        result = ( 31 * result ) + Objects.hashCode(this.chargedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.creditedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.formattedBalance);
+        result = ( 31 * result ) + Objects.hashCode(this.formattedChargedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.formattedInvoiceDate);
+        result = ( 31 * result ) + Objects.hashCode(this.formattedPaidAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceDate);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceItems);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceNumber);
+        result = ( 31 * result ) + Objects.hashCode(this.isMigrationInvoice);
+        result = ( 31 * result ) + Objects.hashCode(this.isParentInvoice);
+        result = ( 31 * result ) + Objects.hashCode(this.numberOfItems);
+        result = ( 31 * result ) + Objects.hashCode(this.numberOfPayments);
+        result = ( 31 * result ) + Objects.hashCode(this.originalChargedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.paidAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.parentAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.parentInvoiceId);
+        result = ( 31 * result ) + Objects.hashCode(this.payments);
+        result = ( 31 * result ) + Objects.hashCode(this.processedCurrency);
+        result = ( 31 * result ) + Objects.hashCode(this.processedPaymentRate);
+        result = ( 31 * result ) + Objects.hashCode(this.refundedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.status);
+        result = ( 31 * result ) + Objects.hashCode(this.targetDate);
+        result = ( 31 * result ) + Objects.hashCode(this.trackingIds);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("balance=").append(this.balance);
+        sb.append(", ");
+        sb.append("chargedAmount=").append(this.chargedAmount);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("creditedAmount=").append(this.creditedAmount);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("formattedBalance=");
+        if( this.formattedBalance == null ) {
+            sb.append(this.formattedBalance);
+        }else{
+            sb.append("'").append(this.formattedBalance).append("'");
+        }
+        sb.append(", ");
+        sb.append("formattedChargedAmount=");
+        if( this.formattedChargedAmount == null ) {
+            sb.append(this.formattedChargedAmount);
+        }else{
+            sb.append("'").append(this.formattedChargedAmount).append("'");
+        }
+        sb.append(", ");
+        sb.append("formattedInvoiceDate=");
+        if( this.formattedInvoiceDate == null ) {
+            sb.append(this.formattedInvoiceDate);
+        }else{
+            sb.append("'").append(this.formattedInvoiceDate).append("'");
+        }
+        sb.append(", ");
+        sb.append("formattedPaidAmount=");
+        if( this.formattedPaidAmount == null ) {
+            sb.append(this.formattedPaidAmount);
+        }else{
+            sb.append("'").append(this.formattedPaidAmount).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("invoiceDate=").append(this.invoiceDate);
+        sb.append(", ");
+        sb.append("invoiceItems=").append(this.invoiceItems);
+        sb.append(", ");
+        sb.append("invoiceNumber=").append(this.invoiceNumber);
+        sb.append(", ");
+        sb.append("isMigrationInvoice=").append(this.isMigrationInvoice);
+        sb.append(", ");
+        sb.append("isParentInvoice=").append(this.isParentInvoice);
+        sb.append(", ");
+        sb.append("numberOfItems=").append(this.numberOfItems);
+        sb.append(", ");
+        sb.append("numberOfPayments=").append(this.numberOfPayments);
+        sb.append(", ");
+        sb.append("originalChargedAmount=").append(this.originalChargedAmount);
+        sb.append(", ");
+        sb.append("paidAmount=").append(this.paidAmount);
+        sb.append(", ");
+        sb.append("parentAccountId=").append(this.parentAccountId);
+        sb.append(", ");
+        sb.append("parentInvoiceId=").append(this.parentInvoiceId);
+        sb.append(", ");
+        sb.append("payments=").append(this.payments);
+        sb.append(", ");
+        sb.append("processedCurrency=").append(this.processedCurrency);
+        sb.append(", ");
+        sb.append("processedPaymentRate=");
+        if( this.processedPaymentRate == null ) {
+            sb.append(this.processedPaymentRate);
+        }else{
+            sb.append("'").append(this.processedPaymentRate).append("'");
+        }
+        sb.append(", ");
+        sb.append("refundedAmount=").append(this.refundedAmount);
+        sb.append(", ");
+        sb.append("status=").append(this.status);
+        sb.append(", ");
+        sb.append("targetDate=").append(this.targetDate);
+        sb.append(", ");
+        sb.append("trackingIds=").append(this.trackingIds);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoiceFormatterImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected BigDecimal balance;
+        protected BigDecimal chargedAmount;
+        protected DateTime createdDate;
+        protected BigDecimal creditedAmount;
+        protected Currency currency;
+        protected String formattedBalance;
+        protected String formattedChargedAmount;
+        protected String formattedInvoiceDate;
+        protected String formattedPaidAmount;
+        protected UUID id;
+        protected LocalDate invoiceDate;
+        protected List<InvoiceItem> invoiceItems;
+        protected Integer invoiceNumber;
+        protected boolean isMigrationInvoice;
+        protected boolean isParentInvoice;
+        protected int numberOfItems;
+        protected int numberOfPayments;
+        protected BigDecimal originalChargedAmount;
+        protected BigDecimal paidAmount;
+        protected UUID parentAccountId;
+        protected UUID parentInvoiceId;
+        protected List<InvoicePayment> payments;
+        protected Currency processedCurrency;
+        protected String processedPaymentRate;
+        protected BigDecimal refundedAmount;
+        protected InvoiceStatus status;
+        protected LocalDate targetDate;
+        protected List<String> trackingIds;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.balance = that.balance;
+            this.chargedAmount = that.chargedAmount;
+            this.createdDate = that.createdDate;
+            this.creditedAmount = that.creditedAmount;
+            this.currency = that.currency;
+            this.formattedBalance = that.formattedBalance;
+            this.formattedChargedAmount = that.formattedChargedAmount;
+            this.formattedInvoiceDate = that.formattedInvoiceDate;
+            this.formattedPaidAmount = that.formattedPaidAmount;
+            this.id = that.id;
+            this.invoiceDate = that.invoiceDate;
+            this.invoiceItems = that.invoiceItems;
+            this.invoiceNumber = that.invoiceNumber;
+            this.isMigrationInvoice = that.isMigrationInvoice;
+            this.isParentInvoice = that.isParentInvoice;
+            this.numberOfItems = that.numberOfItems;
+            this.numberOfPayments = that.numberOfPayments;
+            this.originalChargedAmount = that.originalChargedAmount;
+            this.paidAmount = that.paidAmount;
+            this.parentAccountId = that.parentAccountId;
+            this.parentInvoiceId = that.parentInvoiceId;
+            this.payments = that.payments;
+            this.processedCurrency = that.processedCurrency;
+            this.processedPaymentRate = that.processedPaymentRate;
+            this.refundedAmount = that.refundedAmount;
+            this.status = that.status;
+            this.targetDate = that.targetDate;
+            this.trackingIds = that.trackingIds;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withBalance(final BigDecimal balance) {
+            this.balance = balance;
+            return (T) this;
+        }
+        public T withChargedAmount(final BigDecimal chargedAmount) {
+            this.chargedAmount = chargedAmount;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCreditedAmount(final BigDecimal creditedAmount) {
+            this.creditedAmount = creditedAmount;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withFormattedBalance(final String formattedBalance) {
+            this.formattedBalance = formattedBalance;
+            return (T) this;
+        }
+        public T withFormattedChargedAmount(final String formattedChargedAmount) {
+            this.formattedChargedAmount = formattedChargedAmount;
+            return (T) this;
+        }
+        public T withFormattedInvoiceDate(final String formattedInvoiceDate) {
+            this.formattedInvoiceDate = formattedInvoiceDate;
+            return (T) this;
+        }
+        public T withFormattedPaidAmount(final String formattedPaidAmount) {
+            this.formattedPaidAmount = formattedPaidAmount;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withInvoiceDate(final LocalDate invoiceDate) {
+            this.invoiceDate = invoiceDate;
+            return (T) this;
+        }
+        public T withInvoiceItems(final List<InvoiceItem> invoiceItems) {
+            this.invoiceItems = invoiceItems;
+            return (T) this;
+        }
+        public T withInvoiceNumber(final Integer invoiceNumber) {
+            this.invoiceNumber = invoiceNumber;
+            return (T) this;
+        }
+        public T withIsMigrationInvoice(final boolean isMigrationInvoice) {
+            this.isMigrationInvoice = isMigrationInvoice;
+            return (T) this;
+        }
+        public T withIsParentInvoice(final boolean isParentInvoice) {
+            this.isParentInvoice = isParentInvoice;
+            return (T) this;
+        }
+        public T withNumberOfItems(final int numberOfItems) {
+            this.numberOfItems = numberOfItems;
+            return (T) this;
+        }
+        public T withNumberOfPayments(final int numberOfPayments) {
+            this.numberOfPayments = numberOfPayments;
+            return (T) this;
+        }
+        public T withOriginalChargedAmount(final BigDecimal originalChargedAmount) {
+            this.originalChargedAmount = originalChargedAmount;
+            return (T) this;
+        }
+        public T withPaidAmount(final BigDecimal paidAmount) {
+            this.paidAmount = paidAmount;
+            return (T) this;
+        }
+        public T withParentAccountId(final UUID parentAccountId) {
+            this.parentAccountId = parentAccountId;
+            return (T) this;
+        }
+        public T withParentInvoiceId(final UUID parentInvoiceId) {
+            this.parentInvoiceId = parentInvoiceId;
+            return (T) this;
+        }
+        public T withPayments(final List<InvoicePayment> payments) {
+            this.payments = payments;
+            return (T) this;
+        }
+        public T withProcessedCurrency(final Currency processedCurrency) {
+            this.processedCurrency = processedCurrency;
+            return (T) this;
+        }
+        public T withProcessedPaymentRate(final String processedPaymentRate) {
+            this.processedPaymentRate = processedPaymentRate;
+            return (T) this;
+        }
+        public T withRefundedAmount(final BigDecimal refundedAmount) {
+            this.refundedAmount = refundedAmount;
+            return (T) this;
+        }
+        public T withStatus(final InvoiceStatus status) {
+            this.status = status;
+            return (T) this;
+        }
+        public T withTargetDate(final LocalDate targetDate) {
+            this.targetDate = targetDate;
+            return (T) this;
+        }
+        public T withTrackingIds(final List<String> trackingIds) {
+            this.trackingIds = trackingIds;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final InvoiceFormatter that) {
+            this.accountId = that.getAccountId();
+            this.balance = that.getBalance();
+            this.chargedAmount = that.getChargedAmount();
+            this.createdDate = that.getCreatedDate();
+            this.creditedAmount = that.getCreditedAmount();
+            this.currency = that.getCurrency();
+            this.formattedBalance = that.getFormattedBalance();
+            this.formattedChargedAmount = that.getFormattedChargedAmount();
+            this.formattedInvoiceDate = that.getFormattedInvoiceDate();
+            this.formattedPaidAmount = that.getFormattedPaidAmount();
+            this.id = that.getId();
+            this.invoiceDate = that.getInvoiceDate();
+            this.invoiceItems = that.getInvoiceItems();
+            this.invoiceNumber = that.getInvoiceNumber();
+            this.isMigrationInvoice = that.isMigrationInvoice();
+            this.isParentInvoice = that.isParentInvoice();
+            this.numberOfItems = that.getNumberOfItems();
+            this.numberOfPayments = that.getNumberOfPayments();
+            this.originalChargedAmount = that.getOriginalChargedAmount();
+            this.paidAmount = that.getPaidAmount();
+            this.parentAccountId = that.getParentAccountId();
+            this.parentInvoiceId = that.getParentInvoiceId();
+            this.payments = that.getPayments();
+            this.processedCurrency = that.getProcessedCurrency();
+            this.processedPaymentRate = that.getProcessedPaymentRate();
+            this.refundedAmount = that.getRefundedAmount();
+            this.status = that.getStatus();
+            this.targetDate = that.getTargetDate();
+            this.trackingIds = that.getTrackingIds();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoiceFormatterImp build() {
+            return new InvoiceFormatterImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/formatters/boilerplate/InvoiceItemFormatterImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/formatters/boilerplate/InvoiceItemFormatterImp.java
@@ -1,0 +1,753 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.formatters.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.invoice.api.formatters.InvoiceItemFormatter;
+
+@JsonDeserialize( builder = InvoiceItemFormatterImp.Builder.class )
+public class InvoiceItemFormatterImp implements InvoiceItemFormatter, Serializable {
+
+    private static final long serialVersionUID = 0x27111BE21BB71CDCL;
+
+    protected UUID accountId;
+    protected BigDecimal amount;
+    protected UUID bundleId;
+    protected DateTime catalogEffectiveDate;
+    protected UUID childAccountId;
+    protected DateTime createdDate;
+    protected Currency currency;
+    protected String description;
+    protected LocalDate endDate;
+    protected String formattedAmount;
+    protected String formattedEndDate;
+    protected String formattedStartDate;
+    protected UUID id;
+    protected UUID invoiceId;
+    protected InvoiceItemType invoiceItemType;
+    protected String itemDetails;
+    protected UUID linkedItemId;
+    protected String phaseName;
+    protected String planName;
+    protected String prettyPhaseName;
+    protected String prettyPlanName;
+    protected String prettyProductName;
+    protected String prettyUsageName;
+    protected String productName;
+    protected Integer quantity;
+    protected BigDecimal rate;
+    protected LocalDate startDate;
+    protected UUID subscriptionId;
+    protected DateTime updatedDate;
+    protected String usageName;
+
+    public InvoiceItemFormatterImp(final InvoiceItemFormatterImp that) {
+        this.accountId = that.accountId;
+        this.amount = that.amount;
+        this.bundleId = that.bundleId;
+        this.catalogEffectiveDate = that.catalogEffectiveDate;
+        this.childAccountId = that.childAccountId;
+        this.createdDate = that.createdDate;
+        this.currency = that.currency;
+        this.description = that.description;
+        this.endDate = that.endDate;
+        this.formattedAmount = that.formattedAmount;
+        this.formattedEndDate = that.formattedEndDate;
+        this.formattedStartDate = that.formattedStartDate;
+        this.id = that.id;
+        this.invoiceId = that.invoiceId;
+        this.invoiceItemType = that.invoiceItemType;
+        this.itemDetails = that.itemDetails;
+        this.linkedItemId = that.linkedItemId;
+        this.phaseName = that.phaseName;
+        this.planName = that.planName;
+        this.prettyPhaseName = that.prettyPhaseName;
+        this.prettyPlanName = that.prettyPlanName;
+        this.prettyProductName = that.prettyProductName;
+        this.prettyUsageName = that.prettyUsageName;
+        this.productName = that.productName;
+        this.quantity = that.quantity;
+        this.rate = that.rate;
+        this.startDate = that.startDate;
+        this.subscriptionId = that.subscriptionId;
+        this.updatedDate = that.updatedDate;
+        this.usageName = that.usageName;
+    }
+    protected InvoiceItemFormatterImp(final InvoiceItemFormatterImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.amount = builder.amount;
+        this.bundleId = builder.bundleId;
+        this.catalogEffectiveDate = builder.catalogEffectiveDate;
+        this.childAccountId = builder.childAccountId;
+        this.createdDate = builder.createdDate;
+        this.currency = builder.currency;
+        this.description = builder.description;
+        this.endDate = builder.endDate;
+        this.formattedAmount = builder.formattedAmount;
+        this.formattedEndDate = builder.formattedEndDate;
+        this.formattedStartDate = builder.formattedStartDate;
+        this.id = builder.id;
+        this.invoiceId = builder.invoiceId;
+        this.invoiceItemType = builder.invoiceItemType;
+        this.itemDetails = builder.itemDetails;
+        this.linkedItemId = builder.linkedItemId;
+        this.phaseName = builder.phaseName;
+        this.planName = builder.planName;
+        this.prettyPhaseName = builder.prettyPhaseName;
+        this.prettyPlanName = builder.prettyPlanName;
+        this.prettyProductName = builder.prettyProductName;
+        this.prettyUsageName = builder.prettyUsageName;
+        this.productName = builder.productName;
+        this.quantity = builder.quantity;
+        this.rate = builder.rate;
+        this.startDate = builder.startDate;
+        this.subscriptionId = builder.subscriptionId;
+        this.updatedDate = builder.updatedDate;
+        this.usageName = builder.usageName;
+    }
+    protected InvoiceItemFormatterImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public BigDecimal getAmount() {
+        return this.amount;
+    }
+    @Override
+    public UUID getBundleId() {
+        return this.bundleId;
+    }
+    @Override
+    public DateTime getCatalogEffectiveDate() {
+        return this.catalogEffectiveDate;
+    }
+    @Override
+    public UUID getChildAccountId() {
+        return this.childAccountId;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+    @Override
+    public LocalDate getEndDate() {
+        return this.endDate;
+    }
+    @Override
+    public String getFormattedAmount() {
+        return this.formattedAmount;
+    }
+    @Override
+    public String getFormattedEndDate() {
+        return this.formattedEndDate;
+    }
+    @Override
+    public String getFormattedStartDate() {
+        return this.formattedStartDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public UUID getInvoiceId() {
+        return this.invoiceId;
+    }
+    @Override
+    public InvoiceItemType getInvoiceItemType() {
+        return this.invoiceItemType;
+    }
+    @Override
+    public String getItemDetails() {
+        return this.itemDetails;
+    }
+    @Override
+    public UUID getLinkedItemId() {
+        return this.linkedItemId;
+    }
+    @Override
+    public String getPhaseName() {
+        return this.phaseName;
+    }
+    @Override
+    public String getPlanName() {
+        return this.planName;
+    }
+    @Override
+    public String getPrettyPhaseName() {
+        return this.prettyPhaseName;
+    }
+    @Override
+    public String getPrettyPlanName() {
+        return this.prettyPlanName;
+    }
+    @Override
+    public String getPrettyProductName() {
+        return this.prettyProductName;
+    }
+    @Override
+    public String getPrettyUsageName() {
+        return this.prettyUsageName;
+    }
+    @Override
+    public String getProductName() {
+        return this.productName;
+    }
+    @Override
+    public Integer getQuantity() {
+        return this.quantity;
+    }
+    @Override
+    public BigDecimal getRate() {
+        return this.rate;
+    }
+    @Override
+    public LocalDate getStartDate() {
+        return this.startDate;
+    }
+    @Override
+    public UUID getSubscriptionId() {
+        return this.subscriptionId;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public String getUsageName() {
+        return this.usageName;
+    }
+    @Override
+    public boolean matches(final Object other) {
+        throw new UnsupportedOperationException("matches(java.lang.Object) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoiceItemFormatterImp that = (InvoiceItemFormatterImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.amount != null ) ? ( 0 != this.amount.compareTo(that.amount) ) : ( that.amount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.bundleId, that.bundleId) ) {
+            return false;
+        }
+        if( ( this.catalogEffectiveDate != null ) ? ( 0 != this.catalogEffectiveDate.compareTo(that.catalogEffectiveDate) ) : ( that.catalogEffectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.childAccountId, that.childAccountId) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.description, that.description) ) {
+            return false;
+        }
+        if( ( this.endDate != null ) ? ( 0 != this.endDate.compareTo(that.endDate) ) : ( that.endDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formattedAmount, that.formattedAmount) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formattedEndDate, that.formattedEndDate) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formattedStartDate, that.formattedStartDate) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceId, that.invoiceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceItemType, that.invoiceItemType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.itemDetails, that.itemDetails) ) {
+            return false;
+        }
+        if( !Objects.equals(this.linkedItemId, that.linkedItemId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.phaseName, that.phaseName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.planName, that.planName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyPhaseName, that.prettyPhaseName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyPlanName, that.prettyPlanName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyProductName, that.prettyProductName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.prettyUsageName, that.prettyUsageName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.productName, that.productName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.quantity, that.quantity) ) {
+            return false;
+        }
+        if( ( this.rate != null ) ? ( 0 != this.rate.compareTo(that.rate) ) : ( that.rate != null ) ) {
+            return false;
+        }
+        if( ( this.startDate != null ) ? ( 0 != this.startDate.compareTo(that.startDate) ) : ( that.startDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionId, that.subscriptionId) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.usageName, that.usageName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.bundleId);
+        result = ( 31 * result ) + Objects.hashCode(this.catalogEffectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.childAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.description);
+        result = ( 31 * result ) + Objects.hashCode(this.endDate);
+        result = ( 31 * result ) + Objects.hashCode(this.formattedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.formattedEndDate);
+        result = ( 31 * result ) + Objects.hashCode(this.formattedStartDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceId);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceItemType);
+        result = ( 31 * result ) + Objects.hashCode(this.itemDetails);
+        result = ( 31 * result ) + Objects.hashCode(this.linkedItemId);
+        result = ( 31 * result ) + Objects.hashCode(this.phaseName);
+        result = ( 31 * result ) + Objects.hashCode(this.planName);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyPhaseName);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyPlanName);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyProductName);
+        result = ( 31 * result ) + Objects.hashCode(this.prettyUsageName);
+        result = ( 31 * result ) + Objects.hashCode(this.productName);
+        result = ( 31 * result ) + Objects.hashCode(this.quantity);
+        result = ( 31 * result ) + Objects.hashCode(this.rate);
+        result = ( 31 * result ) + Objects.hashCode(this.startDate);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionId);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.usageName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("bundleId=").append(this.bundleId);
+        sb.append(", ");
+        sb.append("catalogEffectiveDate=").append(this.catalogEffectiveDate);
+        sb.append(", ");
+        sb.append("childAccountId=").append(this.childAccountId);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("description=");
+        if( this.description == null ) {
+            sb.append(this.description);
+        }else{
+            sb.append("'").append(this.description).append("'");
+        }
+        sb.append(", ");
+        sb.append("endDate=").append(this.endDate);
+        sb.append(", ");
+        sb.append("formattedAmount=");
+        if( this.formattedAmount == null ) {
+            sb.append(this.formattedAmount);
+        }else{
+            sb.append("'").append(this.formattedAmount).append("'");
+        }
+        sb.append(", ");
+        sb.append("formattedEndDate=");
+        if( this.formattedEndDate == null ) {
+            sb.append(this.formattedEndDate);
+        }else{
+            sb.append("'").append(this.formattedEndDate).append("'");
+        }
+        sb.append(", ");
+        sb.append("formattedStartDate=");
+        if( this.formattedStartDate == null ) {
+            sb.append(this.formattedStartDate);
+        }else{
+            sb.append("'").append(this.formattedStartDate).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("invoiceId=").append(this.invoiceId);
+        sb.append(", ");
+        sb.append("invoiceItemType=").append(this.invoiceItemType);
+        sb.append(", ");
+        sb.append("itemDetails=");
+        if( this.itemDetails == null ) {
+            sb.append(this.itemDetails);
+        }else{
+            sb.append("'").append(this.itemDetails).append("'");
+        }
+        sb.append(", ");
+        sb.append("linkedItemId=").append(this.linkedItemId);
+        sb.append(", ");
+        sb.append("phaseName=");
+        if( this.phaseName == null ) {
+            sb.append(this.phaseName);
+        }else{
+            sb.append("'").append(this.phaseName).append("'");
+        }
+        sb.append(", ");
+        sb.append("planName=");
+        if( this.planName == null ) {
+            sb.append(this.planName);
+        }else{
+            sb.append("'").append(this.planName).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyPhaseName=");
+        if( this.prettyPhaseName == null ) {
+            sb.append(this.prettyPhaseName);
+        }else{
+            sb.append("'").append(this.prettyPhaseName).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyPlanName=");
+        if( this.prettyPlanName == null ) {
+            sb.append(this.prettyPlanName);
+        }else{
+            sb.append("'").append(this.prettyPlanName).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyProductName=");
+        if( this.prettyProductName == null ) {
+            sb.append(this.prettyProductName);
+        }else{
+            sb.append("'").append(this.prettyProductName).append("'");
+        }
+        sb.append(", ");
+        sb.append("prettyUsageName=");
+        if( this.prettyUsageName == null ) {
+            sb.append(this.prettyUsageName);
+        }else{
+            sb.append("'").append(this.prettyUsageName).append("'");
+        }
+        sb.append(", ");
+        sb.append("productName=");
+        if( this.productName == null ) {
+            sb.append(this.productName);
+        }else{
+            sb.append("'").append(this.productName).append("'");
+        }
+        sb.append(", ");
+        sb.append("quantity=").append(this.quantity);
+        sb.append(", ");
+        sb.append("rate=").append(this.rate);
+        sb.append(", ");
+        sb.append("startDate=").append(this.startDate);
+        sb.append(", ");
+        sb.append("subscriptionId=").append(this.subscriptionId);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("usageName=");
+        if( this.usageName == null ) {
+            sb.append(this.usageName);
+        }else{
+            sb.append("'").append(this.usageName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoiceItemFormatterImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected BigDecimal amount;
+        protected UUID bundleId;
+        protected DateTime catalogEffectiveDate;
+        protected UUID childAccountId;
+        protected DateTime createdDate;
+        protected Currency currency;
+        protected String description;
+        protected LocalDate endDate;
+        protected String formattedAmount;
+        protected String formattedEndDate;
+        protected String formattedStartDate;
+        protected UUID id;
+        protected UUID invoiceId;
+        protected InvoiceItemType invoiceItemType;
+        protected String itemDetails;
+        protected UUID linkedItemId;
+        protected String phaseName;
+        protected String planName;
+        protected String prettyPhaseName;
+        protected String prettyPlanName;
+        protected String prettyProductName;
+        protected String prettyUsageName;
+        protected String productName;
+        protected Integer quantity;
+        protected BigDecimal rate;
+        protected LocalDate startDate;
+        protected UUID subscriptionId;
+        protected DateTime updatedDate;
+        protected String usageName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.amount = that.amount;
+            this.bundleId = that.bundleId;
+            this.catalogEffectiveDate = that.catalogEffectiveDate;
+            this.childAccountId = that.childAccountId;
+            this.createdDate = that.createdDate;
+            this.currency = that.currency;
+            this.description = that.description;
+            this.endDate = that.endDate;
+            this.formattedAmount = that.formattedAmount;
+            this.formattedEndDate = that.formattedEndDate;
+            this.formattedStartDate = that.formattedStartDate;
+            this.id = that.id;
+            this.invoiceId = that.invoiceId;
+            this.invoiceItemType = that.invoiceItemType;
+            this.itemDetails = that.itemDetails;
+            this.linkedItemId = that.linkedItemId;
+            this.phaseName = that.phaseName;
+            this.planName = that.planName;
+            this.prettyPhaseName = that.prettyPhaseName;
+            this.prettyPlanName = that.prettyPlanName;
+            this.prettyProductName = that.prettyProductName;
+            this.prettyUsageName = that.prettyUsageName;
+            this.productName = that.productName;
+            this.quantity = that.quantity;
+            this.rate = that.rate;
+            this.startDate = that.startDate;
+            this.subscriptionId = that.subscriptionId;
+            this.updatedDate = that.updatedDate;
+            this.usageName = that.usageName;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withAmount(final BigDecimal amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withBundleId(final UUID bundleId) {
+            this.bundleId = bundleId;
+            return (T) this;
+        }
+        public T withCatalogEffectiveDate(final DateTime catalogEffectiveDate) {
+            this.catalogEffectiveDate = catalogEffectiveDate;
+            return (T) this;
+        }
+        public T withChildAccountId(final UUID childAccountId) {
+            this.childAccountId = childAccountId;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withDescription(final String description) {
+            this.description = description;
+            return (T) this;
+        }
+        public T withEndDate(final LocalDate endDate) {
+            this.endDate = endDate;
+            return (T) this;
+        }
+        public T withFormattedAmount(final String formattedAmount) {
+            this.formattedAmount = formattedAmount;
+            return (T) this;
+        }
+        public T withFormattedEndDate(final String formattedEndDate) {
+            this.formattedEndDate = formattedEndDate;
+            return (T) this;
+        }
+        public T withFormattedStartDate(final String formattedStartDate) {
+            this.formattedStartDate = formattedStartDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withInvoiceId(final UUID invoiceId) {
+            this.invoiceId = invoiceId;
+            return (T) this;
+        }
+        public T withInvoiceItemType(final InvoiceItemType invoiceItemType) {
+            this.invoiceItemType = invoiceItemType;
+            return (T) this;
+        }
+        public T withItemDetails(final String itemDetails) {
+            this.itemDetails = itemDetails;
+            return (T) this;
+        }
+        public T withLinkedItemId(final UUID linkedItemId) {
+            this.linkedItemId = linkedItemId;
+            return (T) this;
+        }
+        public T withPhaseName(final String phaseName) {
+            this.phaseName = phaseName;
+            return (T) this;
+        }
+        public T withPlanName(final String planName) {
+            this.planName = planName;
+            return (T) this;
+        }
+        public T withPrettyPhaseName(final String prettyPhaseName) {
+            this.prettyPhaseName = prettyPhaseName;
+            return (T) this;
+        }
+        public T withPrettyPlanName(final String prettyPlanName) {
+            this.prettyPlanName = prettyPlanName;
+            return (T) this;
+        }
+        public T withPrettyProductName(final String prettyProductName) {
+            this.prettyProductName = prettyProductName;
+            return (T) this;
+        }
+        public T withPrettyUsageName(final String prettyUsageName) {
+            this.prettyUsageName = prettyUsageName;
+            return (T) this;
+        }
+        public T withProductName(final String productName) {
+            this.productName = productName;
+            return (T) this;
+        }
+        public T withQuantity(final Integer quantity) {
+            this.quantity = quantity;
+            return (T) this;
+        }
+        public T withRate(final BigDecimal rate) {
+            this.rate = rate;
+            return (T) this;
+        }
+        public T withStartDate(final LocalDate startDate) {
+            this.startDate = startDate;
+            return (T) this;
+        }
+        public T withSubscriptionId(final UUID subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T withUsageName(final String usageName) {
+            this.usageName = usageName;
+            return (T) this;
+        }
+        public T source(final InvoiceItemFormatter that) {
+            this.accountId = that.getAccountId();
+            this.amount = that.getAmount();
+            this.bundleId = that.getBundleId();
+            this.catalogEffectiveDate = that.getCatalogEffectiveDate();
+            this.childAccountId = that.getChildAccountId();
+            this.createdDate = that.getCreatedDate();
+            this.currency = that.getCurrency();
+            this.description = that.getDescription();
+            this.endDate = that.getEndDate();
+            this.formattedAmount = that.getFormattedAmount();
+            this.formattedEndDate = that.getFormattedEndDate();
+            this.formattedStartDate = that.getFormattedStartDate();
+            this.id = that.getId();
+            this.invoiceId = that.getInvoiceId();
+            this.invoiceItemType = that.getInvoiceItemType();
+            this.itemDetails = that.getItemDetails();
+            this.linkedItemId = that.getLinkedItemId();
+            this.phaseName = that.getPhaseName();
+            this.planName = that.getPlanName();
+            this.prettyPhaseName = that.getPrettyPhaseName();
+            this.prettyPlanName = that.getPrettyPlanName();
+            this.prettyProductName = that.getPrettyProductName();
+            this.prettyUsageName = that.getPrettyUsageName();
+            this.productName = that.getProductName();
+            this.quantity = that.getQuantity();
+            this.rate = that.getRate();
+            this.startDate = that.getStartDate();
+            this.subscriptionId = that.getSubscriptionId();
+            this.updatedDate = that.getUpdatedDate();
+            this.usageName = that.getUsageName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoiceItemFormatterImp build() {
+            return new InvoiceItemFormatterImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/formatters/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/invoice/api/formatters/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.formatters.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.invoice.api.formatters.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/invoice/api/formatters/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/invoice/api/formatters/boilerplate/Resolver.java
@@ -1,0 +1,29 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.invoice.api.formatters.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.invoice.api.formatters.InvoiceFormatter;
+import org.killbill.billing.invoice.api.formatters.InvoiceItemFormatter;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(InvoiceFormatter.class, InvoiceFormatterImp.class);
+        this.addMapping(InvoiceItemFormatter.class, InvoiceItemFormatterImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/boilerplate/HealthcheckImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/boilerplate/HealthcheckImp.java
@@ -1,0 +1,85 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.Healthcheck;
+import org.killbill.billing.tenant.api.Tenant;
+
+@JsonDeserialize( builder = HealthcheckImp.Builder.class )
+public class HealthcheckImp implements Healthcheck, Serializable {
+
+    private static final long serialVersionUID = 0xE655C4248CAE949FL;
+
+
+    public HealthcheckImp(final HealthcheckImp that) {
+    }
+    protected HealthcheckImp(final HealthcheckImp.Builder<?> builder) {
+    }
+    protected HealthcheckImp() { }
+    @Override
+    public Healthcheck.HealthStatus getHealthStatus(final Tenant tenant, final Map properties) {
+        throw new UnsupportedOperationException("getHealthStatus(org.killbill.billing.tenant.api.Tenant, java.util.Map) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final HealthcheckImp that = (HealthcheckImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends HealthcheckImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final Healthcheck that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public HealthcheckImp build() {
+            return new HealthcheckImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/osgi/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.osgi.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/boilerplate/OSGIKillbillImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/boilerplate/OSGIKillbillImp.java
@@ -1,0 +1,519 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.account.api.AccountUserApi;
+import org.killbill.billing.catalog.api.CatalogUserApi;
+import org.killbill.billing.currency.api.CurrencyConversionApi;
+import org.killbill.billing.entitlement.api.EntitlementApi;
+import org.killbill.billing.entitlement.api.SubscriptionApi;
+import org.killbill.billing.invoice.api.InvoiceUserApi;
+import org.killbill.billing.osgi.api.OSGIKillbill;
+import org.killbill.billing.osgi.api.PluginsInfoApi;
+import org.killbill.billing.osgi.api.config.PluginConfigServiceApi;
+import org.killbill.billing.overdue.api.OverdueApi;
+import org.killbill.billing.payment.api.AdminPaymentApi;
+import org.killbill.billing.payment.api.InvoicePaymentApi;
+import org.killbill.billing.payment.api.PaymentApi;
+import org.killbill.billing.security.api.SecurityApi;
+import org.killbill.billing.tenant.api.TenantUserApi;
+import org.killbill.billing.usage.api.UsageUserApi;
+import org.killbill.billing.util.api.AuditUserApi;
+import org.killbill.billing.util.api.CustomFieldUserApi;
+import org.killbill.billing.util.api.ExportUserApi;
+import org.killbill.billing.util.api.RecordIdApi;
+import org.killbill.billing.util.api.TagUserApi;
+import org.killbill.billing.util.nodes.KillbillNodesApi;
+
+@JsonDeserialize( builder = OSGIKillbillImp.Builder.class )
+public class OSGIKillbillImp implements OSGIKillbill, Serializable {
+
+    private static final long serialVersionUID = 0x95EB15ABC31DA206L;
+
+    protected AccountUserApi accountUserApi;
+    protected AdminPaymentApi adminPaymentApi;
+    protected AuditUserApi auditUserApi;
+    protected CatalogUserApi catalogUserApi;
+    protected CurrencyConversionApi currencyConversionApi;
+    protected CustomFieldUserApi customFieldUserApi;
+    protected EntitlementApi entitlementApi;
+    protected ExportUserApi exportUserApi;
+    protected InvoicePaymentApi invoicePaymentApi;
+    protected InvoiceUserApi invoiceUserApi;
+    protected KillbillNodesApi killbillNodesApi;
+    protected OverdueApi overdueApi;
+    protected PaymentApi paymentApi;
+    protected PluginConfigServiceApi pluginConfigServiceApi;
+    protected PluginsInfoApi pluginsInfoApi;
+    protected RecordIdApi recordIdApi;
+    protected SecurityApi securityApi;
+    protected SubscriptionApi subscriptionApi;
+    protected TagUserApi tagUserApi;
+    protected TenantUserApi tenantUserApi;
+    protected UsageUserApi usageUserApi;
+
+    public OSGIKillbillImp(final OSGIKillbillImp that) {
+        this.accountUserApi = that.accountUserApi;
+        this.adminPaymentApi = that.adminPaymentApi;
+        this.auditUserApi = that.auditUserApi;
+        this.catalogUserApi = that.catalogUserApi;
+        this.currencyConversionApi = that.currencyConversionApi;
+        this.customFieldUserApi = that.customFieldUserApi;
+        this.entitlementApi = that.entitlementApi;
+        this.exportUserApi = that.exportUserApi;
+        this.invoicePaymentApi = that.invoicePaymentApi;
+        this.invoiceUserApi = that.invoiceUserApi;
+        this.killbillNodesApi = that.killbillNodesApi;
+        this.overdueApi = that.overdueApi;
+        this.paymentApi = that.paymentApi;
+        this.pluginConfigServiceApi = that.pluginConfigServiceApi;
+        this.pluginsInfoApi = that.pluginsInfoApi;
+        this.recordIdApi = that.recordIdApi;
+        this.securityApi = that.securityApi;
+        this.subscriptionApi = that.subscriptionApi;
+        this.tagUserApi = that.tagUserApi;
+        this.tenantUserApi = that.tenantUserApi;
+        this.usageUserApi = that.usageUserApi;
+    }
+    protected OSGIKillbillImp(final OSGIKillbillImp.Builder<?> builder) {
+        this.accountUserApi = builder.accountUserApi;
+        this.adminPaymentApi = builder.adminPaymentApi;
+        this.auditUserApi = builder.auditUserApi;
+        this.catalogUserApi = builder.catalogUserApi;
+        this.currencyConversionApi = builder.currencyConversionApi;
+        this.customFieldUserApi = builder.customFieldUserApi;
+        this.entitlementApi = builder.entitlementApi;
+        this.exportUserApi = builder.exportUserApi;
+        this.invoicePaymentApi = builder.invoicePaymentApi;
+        this.invoiceUserApi = builder.invoiceUserApi;
+        this.killbillNodesApi = builder.killbillNodesApi;
+        this.overdueApi = builder.overdueApi;
+        this.paymentApi = builder.paymentApi;
+        this.pluginConfigServiceApi = builder.pluginConfigServiceApi;
+        this.pluginsInfoApi = builder.pluginsInfoApi;
+        this.recordIdApi = builder.recordIdApi;
+        this.securityApi = builder.securityApi;
+        this.subscriptionApi = builder.subscriptionApi;
+        this.tagUserApi = builder.tagUserApi;
+        this.tenantUserApi = builder.tenantUserApi;
+        this.usageUserApi = builder.usageUserApi;
+    }
+    protected OSGIKillbillImp() { }
+    @Override
+    public AccountUserApi getAccountUserApi() {
+        return this.accountUserApi;
+    }
+    @Override
+    public AdminPaymentApi getAdminPaymentApi() {
+        return this.adminPaymentApi;
+    }
+    @Override
+    public AuditUserApi getAuditUserApi() {
+        return this.auditUserApi;
+    }
+    @Override
+    public CatalogUserApi getCatalogUserApi() {
+        return this.catalogUserApi;
+    }
+    @Override
+    public CurrencyConversionApi getCurrencyConversionApi() {
+        return this.currencyConversionApi;
+    }
+    @Override
+    public CustomFieldUserApi getCustomFieldUserApi() {
+        return this.customFieldUserApi;
+    }
+    @Override
+    public EntitlementApi getEntitlementApi() {
+        return this.entitlementApi;
+    }
+    @Override
+    public ExportUserApi getExportUserApi() {
+        return this.exportUserApi;
+    }
+    @Override
+    public InvoicePaymentApi getInvoicePaymentApi() {
+        return this.invoicePaymentApi;
+    }
+    @Override
+    public InvoiceUserApi getInvoiceUserApi() {
+        return this.invoiceUserApi;
+    }
+    @Override
+    public KillbillNodesApi getKillbillNodesApi() {
+        return this.killbillNodesApi;
+    }
+    @Override
+    public OverdueApi getOverdueApi() {
+        return this.overdueApi;
+    }
+    @Override
+    public PaymentApi getPaymentApi() {
+        return this.paymentApi;
+    }
+    @Override
+    public PluginConfigServiceApi getPluginConfigServiceApi() {
+        return this.pluginConfigServiceApi;
+    }
+    @Override
+    public PluginsInfoApi getPluginsInfoApi() {
+        return this.pluginsInfoApi;
+    }
+    @Override
+    public RecordIdApi getRecordIdApi() {
+        return this.recordIdApi;
+    }
+    @Override
+    public SecurityApi getSecurityApi() {
+        return this.securityApi;
+    }
+    @Override
+    public SubscriptionApi getSubscriptionApi() {
+        return this.subscriptionApi;
+    }
+    @Override
+    public TagUserApi getTagUserApi() {
+        return this.tagUserApi;
+    }
+    @Override
+    public TenantUserApi getTenantUserApi() {
+        return this.tenantUserApi;
+    }
+    @Override
+    public UsageUserApi getUsageUserApi() {
+        return this.usageUserApi;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final OSGIKillbillImp that = (OSGIKillbillImp) o;
+        if( !Objects.equals(this.accountUserApi, that.accountUserApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.adminPaymentApi, that.adminPaymentApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.auditUserApi, that.auditUserApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.catalogUserApi, that.catalogUserApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currencyConversionApi, that.currencyConversionApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.customFieldUserApi, that.customFieldUserApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.entitlementApi, that.entitlementApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.exportUserApi, that.exportUserApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoicePaymentApi, that.invoicePaymentApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.invoiceUserApi, that.invoiceUserApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.killbillNodesApi, that.killbillNodesApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.overdueApi, that.overdueApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentApi, that.paymentApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginConfigServiceApi, that.pluginConfigServiceApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginsInfoApi, that.pluginsInfoApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.recordIdApi, that.recordIdApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.securityApi, that.securityApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionApi, that.subscriptionApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tagUserApi, that.tagUserApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tenantUserApi, that.tenantUserApi) ) {
+            return false;
+        }
+        if( !Objects.equals(this.usageUserApi, that.usageUserApi) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountUserApi);
+        result = ( 31 * result ) + Objects.hashCode(this.adminPaymentApi);
+        result = ( 31 * result ) + Objects.hashCode(this.auditUserApi);
+        result = ( 31 * result ) + Objects.hashCode(this.catalogUserApi);
+        result = ( 31 * result ) + Objects.hashCode(this.currencyConversionApi);
+        result = ( 31 * result ) + Objects.hashCode(this.customFieldUserApi);
+        result = ( 31 * result ) + Objects.hashCode(this.entitlementApi);
+        result = ( 31 * result ) + Objects.hashCode(this.exportUserApi);
+        result = ( 31 * result ) + Objects.hashCode(this.invoicePaymentApi);
+        result = ( 31 * result ) + Objects.hashCode(this.invoiceUserApi);
+        result = ( 31 * result ) + Objects.hashCode(this.killbillNodesApi);
+        result = ( 31 * result ) + Objects.hashCode(this.overdueApi);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentApi);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginConfigServiceApi);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginsInfoApi);
+        result = ( 31 * result ) + Objects.hashCode(this.recordIdApi);
+        result = ( 31 * result ) + Objects.hashCode(this.securityApi);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionApi);
+        result = ( 31 * result ) + Objects.hashCode(this.tagUserApi);
+        result = ( 31 * result ) + Objects.hashCode(this.tenantUserApi);
+        result = ( 31 * result ) + Objects.hashCode(this.usageUserApi);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountUserApi=").append(this.accountUserApi);
+        sb.append(", ");
+        sb.append("adminPaymentApi=").append(this.adminPaymentApi);
+        sb.append(", ");
+        sb.append("auditUserApi=").append(this.auditUserApi);
+        sb.append(", ");
+        sb.append("catalogUserApi=").append(this.catalogUserApi);
+        sb.append(", ");
+        sb.append("currencyConversionApi=").append(this.currencyConversionApi);
+        sb.append(", ");
+        sb.append("customFieldUserApi=").append(this.customFieldUserApi);
+        sb.append(", ");
+        sb.append("entitlementApi=").append(this.entitlementApi);
+        sb.append(", ");
+        sb.append("exportUserApi=").append(this.exportUserApi);
+        sb.append(", ");
+        sb.append("invoicePaymentApi=").append(this.invoicePaymentApi);
+        sb.append(", ");
+        sb.append("invoiceUserApi=").append(this.invoiceUserApi);
+        sb.append(", ");
+        sb.append("killbillNodesApi=").append(this.killbillNodesApi);
+        sb.append(", ");
+        sb.append("overdueApi=").append(this.overdueApi);
+        sb.append(", ");
+        sb.append("paymentApi=").append(this.paymentApi);
+        sb.append(", ");
+        sb.append("pluginConfigServiceApi=").append(this.pluginConfigServiceApi);
+        sb.append(", ");
+        sb.append("pluginsInfoApi=").append(this.pluginsInfoApi);
+        sb.append(", ");
+        sb.append("recordIdApi=").append(this.recordIdApi);
+        sb.append(", ");
+        sb.append("securityApi=").append(this.securityApi);
+        sb.append(", ");
+        sb.append("subscriptionApi=").append(this.subscriptionApi);
+        sb.append(", ");
+        sb.append("tagUserApi=").append(this.tagUserApi);
+        sb.append(", ");
+        sb.append("tenantUserApi=").append(this.tenantUserApi);
+        sb.append(", ");
+        sb.append("usageUserApi=").append(this.usageUserApi);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends OSGIKillbillImp.Builder<T>> {
+
+        protected AccountUserApi accountUserApi;
+        protected AdminPaymentApi adminPaymentApi;
+        protected AuditUserApi auditUserApi;
+        protected CatalogUserApi catalogUserApi;
+        protected CurrencyConversionApi currencyConversionApi;
+        protected CustomFieldUserApi customFieldUserApi;
+        protected EntitlementApi entitlementApi;
+        protected ExportUserApi exportUserApi;
+        protected InvoicePaymentApi invoicePaymentApi;
+        protected InvoiceUserApi invoiceUserApi;
+        protected KillbillNodesApi killbillNodesApi;
+        protected OverdueApi overdueApi;
+        protected PaymentApi paymentApi;
+        protected PluginConfigServiceApi pluginConfigServiceApi;
+        protected PluginsInfoApi pluginsInfoApi;
+        protected RecordIdApi recordIdApi;
+        protected SecurityApi securityApi;
+        protected SubscriptionApi subscriptionApi;
+        protected TagUserApi tagUserApi;
+        protected TenantUserApi tenantUserApi;
+        protected UsageUserApi usageUserApi;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountUserApi = that.accountUserApi;
+            this.adminPaymentApi = that.adminPaymentApi;
+            this.auditUserApi = that.auditUserApi;
+            this.catalogUserApi = that.catalogUserApi;
+            this.currencyConversionApi = that.currencyConversionApi;
+            this.customFieldUserApi = that.customFieldUserApi;
+            this.entitlementApi = that.entitlementApi;
+            this.exportUserApi = that.exportUserApi;
+            this.invoicePaymentApi = that.invoicePaymentApi;
+            this.invoiceUserApi = that.invoiceUserApi;
+            this.killbillNodesApi = that.killbillNodesApi;
+            this.overdueApi = that.overdueApi;
+            this.paymentApi = that.paymentApi;
+            this.pluginConfigServiceApi = that.pluginConfigServiceApi;
+            this.pluginsInfoApi = that.pluginsInfoApi;
+            this.recordIdApi = that.recordIdApi;
+            this.securityApi = that.securityApi;
+            this.subscriptionApi = that.subscriptionApi;
+            this.tagUserApi = that.tagUserApi;
+            this.tenantUserApi = that.tenantUserApi;
+            this.usageUserApi = that.usageUserApi;
+        }
+        public T withAccountUserApi(final AccountUserApi accountUserApi) {
+            this.accountUserApi = accountUserApi;
+            return (T) this;
+        }
+        public T withAdminPaymentApi(final AdminPaymentApi adminPaymentApi) {
+            this.adminPaymentApi = adminPaymentApi;
+            return (T) this;
+        }
+        public T withAuditUserApi(final AuditUserApi auditUserApi) {
+            this.auditUserApi = auditUserApi;
+            return (T) this;
+        }
+        public T withCatalogUserApi(final CatalogUserApi catalogUserApi) {
+            this.catalogUserApi = catalogUserApi;
+            return (T) this;
+        }
+        public T withCurrencyConversionApi(final CurrencyConversionApi currencyConversionApi) {
+            this.currencyConversionApi = currencyConversionApi;
+            return (T) this;
+        }
+        public T withCustomFieldUserApi(final CustomFieldUserApi customFieldUserApi) {
+            this.customFieldUserApi = customFieldUserApi;
+            return (T) this;
+        }
+        public T withEntitlementApi(final EntitlementApi entitlementApi) {
+            this.entitlementApi = entitlementApi;
+            return (T) this;
+        }
+        public T withExportUserApi(final ExportUserApi exportUserApi) {
+            this.exportUserApi = exportUserApi;
+            return (T) this;
+        }
+        public T withInvoicePaymentApi(final InvoicePaymentApi invoicePaymentApi) {
+            this.invoicePaymentApi = invoicePaymentApi;
+            return (T) this;
+        }
+        public T withInvoiceUserApi(final InvoiceUserApi invoiceUserApi) {
+            this.invoiceUserApi = invoiceUserApi;
+            return (T) this;
+        }
+        public T withKillbillNodesApi(final KillbillNodesApi killbillNodesApi) {
+            this.killbillNodesApi = killbillNodesApi;
+            return (T) this;
+        }
+        public T withOverdueApi(final OverdueApi overdueApi) {
+            this.overdueApi = overdueApi;
+            return (T) this;
+        }
+        public T withPaymentApi(final PaymentApi paymentApi) {
+            this.paymentApi = paymentApi;
+            return (T) this;
+        }
+        public T withPluginConfigServiceApi(final PluginConfigServiceApi pluginConfigServiceApi) {
+            this.pluginConfigServiceApi = pluginConfigServiceApi;
+            return (T) this;
+        }
+        public T withPluginsInfoApi(final PluginsInfoApi pluginsInfoApi) {
+            this.pluginsInfoApi = pluginsInfoApi;
+            return (T) this;
+        }
+        public T withRecordIdApi(final RecordIdApi recordIdApi) {
+            this.recordIdApi = recordIdApi;
+            return (T) this;
+        }
+        public T withSecurityApi(final SecurityApi securityApi) {
+            this.securityApi = securityApi;
+            return (T) this;
+        }
+        public T withSubscriptionApi(final SubscriptionApi subscriptionApi) {
+            this.subscriptionApi = subscriptionApi;
+            return (T) this;
+        }
+        public T withTagUserApi(final TagUserApi tagUserApi) {
+            this.tagUserApi = tagUserApi;
+            return (T) this;
+        }
+        public T withTenantUserApi(final TenantUserApi tenantUserApi) {
+            this.tenantUserApi = tenantUserApi;
+            return (T) this;
+        }
+        public T withUsageUserApi(final UsageUserApi usageUserApi) {
+            this.usageUserApi = usageUserApi;
+            return (T) this;
+        }
+        public T source(final OSGIKillbill that) {
+            this.accountUserApi = that.getAccountUserApi();
+            this.adminPaymentApi = that.getAdminPaymentApi();
+            this.auditUserApi = that.getAuditUserApi();
+            this.catalogUserApi = that.getCatalogUserApi();
+            this.currencyConversionApi = that.getCurrencyConversionApi();
+            this.customFieldUserApi = that.getCustomFieldUserApi();
+            this.entitlementApi = that.getEntitlementApi();
+            this.exportUserApi = that.getExportUserApi();
+            this.invoicePaymentApi = that.getInvoicePaymentApi();
+            this.invoiceUserApi = that.getInvoiceUserApi();
+            this.killbillNodesApi = that.getKillbillNodesApi();
+            this.overdueApi = that.getOverdueApi();
+            this.paymentApi = that.getPaymentApi();
+            this.pluginConfigServiceApi = that.getPluginConfigServiceApi();
+            this.pluginsInfoApi = that.getPluginsInfoApi();
+            this.recordIdApi = that.getRecordIdApi();
+            this.securityApi = that.getSecurityApi();
+            this.subscriptionApi = that.getSubscriptionApi();
+            this.tagUserApi = that.getTagUserApi();
+            this.tenantUserApi = that.getTenantUserApi();
+            this.usageUserApi = that.getUsageUserApi();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public OSGIKillbillImp build() {
+            return new OSGIKillbillImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/boilerplate/OSGIPluginPropertiesImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/boilerplate/OSGIPluginPropertiesImp.java
@@ -1,0 +1,79 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.OSGIPluginProperties;
+
+@JsonDeserialize( builder = OSGIPluginPropertiesImp.Builder.class )
+public class OSGIPluginPropertiesImp implements OSGIPluginProperties, Serializable {
+
+    private static final long serialVersionUID = 0xBA59CD1E61252620L;
+
+
+    public OSGIPluginPropertiesImp(final OSGIPluginPropertiesImp that) {
+    }
+    protected OSGIPluginPropertiesImp(final OSGIPluginPropertiesImp.Builder<?> builder) {
+    }
+    protected OSGIPluginPropertiesImp() { }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final OSGIPluginPropertiesImp that = (OSGIPluginPropertiesImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends OSGIPluginPropertiesImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final OSGIPluginProperties that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public OSGIPluginPropertiesImp build() {
+            return new OSGIPluginPropertiesImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/boilerplate/PluginInfoImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/boilerplate/PluginInfoImp.java
@@ -1,0 +1,242 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import org.killbill.billing.osgi.api.PluginInfo;
+import org.killbill.billing.osgi.api.PluginServiceInfo;
+import org.killbill.billing.osgi.api.PluginState;
+
+@JsonDeserialize( builder = PluginInfoImp.Builder.class )
+public class PluginInfoImp implements PluginInfo, Serializable {
+
+    private static final long serialVersionUID = 0xB9029905DFA97950L;
+
+    protected String bundleSymbolicName;
+    protected boolean isSelectedForStart;
+    protected String pluginKey;
+    protected String pluginName;
+    protected PluginState pluginState;
+    protected Set<PluginServiceInfo> services;
+    protected String version;
+
+    public PluginInfoImp(final PluginInfoImp that) {
+        this.bundleSymbolicName = that.bundleSymbolicName;
+        this.isSelectedForStart = that.isSelectedForStart;
+        this.pluginKey = that.pluginKey;
+        this.pluginName = that.pluginName;
+        this.pluginState = that.pluginState;
+        this.services = that.services;
+        this.version = that.version;
+    }
+    protected PluginInfoImp(final PluginInfoImp.Builder<?> builder) {
+        this.bundleSymbolicName = builder.bundleSymbolicName;
+        this.isSelectedForStart = builder.isSelectedForStart;
+        this.pluginKey = builder.pluginKey;
+        this.pluginName = builder.pluginName;
+        this.pluginState = builder.pluginState;
+        this.services = builder.services;
+        this.version = builder.version;
+    }
+    protected PluginInfoImp() { }
+    @Override
+    public String getBundleSymbolicName() {
+        return this.bundleSymbolicName;
+    }
+    @Override
+    @JsonGetter("isSelectedForStart")
+    public boolean isSelectedForStart() {
+        return this.isSelectedForStart;
+    }
+    @Override
+    public String getPluginKey() {
+        return this.pluginKey;
+    }
+    @Override
+    public String getPluginName() {
+        return this.pluginName;
+    }
+    @Override
+    public PluginState getPluginState() {
+        return this.pluginState;
+    }
+    @Override
+    public Set<PluginServiceInfo> getServices() {
+        return this.services;
+    }
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PluginInfoImp that = (PluginInfoImp) o;
+        if( !Objects.equals(this.bundleSymbolicName, that.bundleSymbolicName) ) {
+            return false;
+        }
+        if( this.isSelectedForStart != that.isSelectedForStart ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginKey, that.pluginKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginName, that.pluginName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginState, that.pluginState) ) {
+            return false;
+        }
+        if( !Objects.equals(this.services, that.services) ) {
+            return false;
+        }
+        if( !Objects.equals(this.version, that.version) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.bundleSymbolicName);
+        result = ( 31 * result ) + Objects.hashCode(this.isSelectedForStart);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginKey);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginName);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginState);
+        result = ( 31 * result ) + Objects.hashCode(this.services);
+        result = ( 31 * result ) + Objects.hashCode(this.version);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("bundleSymbolicName=");
+        if( this.bundleSymbolicName == null ) {
+            sb.append(this.bundleSymbolicName);
+        }else{
+            sb.append("'").append(this.bundleSymbolicName).append("'");
+        }
+        sb.append(", ");
+        sb.append("isSelectedForStart=").append(this.isSelectedForStart);
+        sb.append(", ");
+        sb.append("pluginKey=");
+        if( this.pluginKey == null ) {
+            sb.append(this.pluginKey);
+        }else{
+            sb.append("'").append(this.pluginKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginName=");
+        if( this.pluginName == null ) {
+            sb.append(this.pluginName);
+        }else{
+            sb.append("'").append(this.pluginName).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginState=").append(this.pluginState);
+        sb.append(", ");
+        sb.append("services=").append(this.services);
+        sb.append(", ");
+        sb.append("version=");
+        if( this.version == null ) {
+            sb.append(this.version);
+        }else{
+            sb.append("'").append(this.version).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginInfoImp.Builder<T>> {
+
+        protected String bundleSymbolicName;
+        protected boolean isSelectedForStart;
+        protected String pluginKey;
+        protected String pluginName;
+        protected PluginState pluginState;
+        protected Set<PluginServiceInfo> services;
+        protected String version;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.bundleSymbolicName = that.bundleSymbolicName;
+            this.isSelectedForStart = that.isSelectedForStart;
+            this.pluginKey = that.pluginKey;
+            this.pluginName = that.pluginName;
+            this.pluginState = that.pluginState;
+            this.services = that.services;
+            this.version = that.version;
+        }
+        public T withBundleSymbolicName(final String bundleSymbolicName) {
+            this.bundleSymbolicName = bundleSymbolicName;
+            return (T) this;
+        }
+        public T withIsSelectedForStart(final boolean isSelectedForStart) {
+            this.isSelectedForStart = isSelectedForStart;
+            return (T) this;
+        }
+        public T withPluginKey(final String pluginKey) {
+            this.pluginKey = pluginKey;
+            return (T) this;
+        }
+        public T withPluginName(final String pluginName) {
+            this.pluginName = pluginName;
+            return (T) this;
+        }
+        public T withPluginState(final PluginState pluginState) {
+            this.pluginState = pluginState;
+            return (T) this;
+        }
+        public T withServices(final Set<PluginServiceInfo> services) {
+            this.services = services;
+            return (T) this;
+        }
+        public T withVersion(final String version) {
+            this.version = version;
+            return (T) this;
+        }
+        public T source(final PluginInfo that) {
+            this.bundleSymbolicName = that.getBundleSymbolicName();
+            this.isSelectedForStart = that.isSelectedForStart();
+            this.pluginKey = that.getPluginKey();
+            this.pluginName = that.getPluginName();
+            this.pluginState = that.getPluginState();
+            this.services = that.getServices();
+            this.version = that.getVersion();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PluginInfoImp build() {
+            return new PluginInfoImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/boilerplate/PluginServiceInfoImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/boilerplate/PluginServiceInfoImp.java
@@ -1,0 +1,128 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.PluginServiceInfo;
+
+@JsonDeserialize( builder = PluginServiceInfoImp.Builder.class )
+public class PluginServiceInfoImp implements PluginServiceInfo, Serializable {
+
+    private static final long serialVersionUID = 0x673FA98461167B1FL;
+
+    protected String registrationName;
+    protected String serviceTypeName;
+
+    public PluginServiceInfoImp(final PluginServiceInfoImp that) {
+        this.registrationName = that.registrationName;
+        this.serviceTypeName = that.serviceTypeName;
+    }
+    protected PluginServiceInfoImp(final PluginServiceInfoImp.Builder<?> builder) {
+        this.registrationName = builder.registrationName;
+        this.serviceTypeName = builder.serviceTypeName;
+    }
+    protected PluginServiceInfoImp() { }
+    @Override
+    public String getRegistrationName() {
+        return this.registrationName;
+    }
+    @Override
+    public String getServiceTypeName() {
+        return this.serviceTypeName;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PluginServiceInfoImp that = (PluginServiceInfoImp) o;
+        if( !Objects.equals(this.registrationName, that.registrationName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.serviceTypeName, that.serviceTypeName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.registrationName);
+        result = ( 31 * result ) + Objects.hashCode(this.serviceTypeName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("registrationName=");
+        if( this.registrationName == null ) {
+            sb.append(this.registrationName);
+        }else{
+            sb.append("'").append(this.registrationName).append("'");
+        }
+        sb.append(", ");
+        sb.append("serviceTypeName=");
+        if( this.serviceTypeName == null ) {
+            sb.append(this.serviceTypeName);
+        }else{
+            sb.append("'").append(this.serviceTypeName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginServiceInfoImp.Builder<T>> {
+
+        protected String registrationName;
+        protected String serviceTypeName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.registrationName = that.registrationName;
+            this.serviceTypeName = that.serviceTypeName;
+        }
+        public T withRegistrationName(final String registrationName) {
+            this.registrationName = registrationName;
+            return (T) this;
+        }
+        public T withServiceTypeName(final String serviceTypeName) {
+            this.serviceTypeName = serviceTypeName;
+            return (T) this;
+        }
+        public T source(final PluginServiceInfo that) {
+            this.registrationName = that.getRegistrationName();
+            this.serviceTypeName = that.getServiceTypeName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PluginServiceInfoImp build() {
+            return new PluginServiceInfoImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/boilerplate/PluginsInfoApiImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/boilerplate/PluginsInfoApiImp.java
@@ -1,0 +1,105 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.PluginInfo;
+import org.killbill.billing.osgi.api.PluginStateChange;
+import org.killbill.billing.osgi.api.PluginsInfoApi;
+import org.killbill.billing.osgi.api.config.PluginLanguage;
+
+@JsonDeserialize( builder = PluginsInfoApiImp.Builder.class )
+public class PluginsInfoApiImp implements PluginsInfoApi, Serializable {
+
+    private static final long serialVersionUID = 0xFF04D697E6CBEADEL;
+
+    protected Iterable<PluginInfo> pluginsInfo;
+
+    public PluginsInfoApiImp(final PluginsInfoApiImp that) {
+        this.pluginsInfo = that.pluginsInfo;
+    }
+    protected PluginsInfoApiImp(final PluginsInfoApiImp.Builder<?> builder) {
+        this.pluginsInfo = builder.pluginsInfo;
+    }
+    protected PluginsInfoApiImp() { }
+    @Override
+    public Iterable<PluginInfo> getPluginsInfo() {
+        return this.pluginsInfo;
+    }
+    @Override
+    public void notifyOfStateChanged(final PluginStateChange newState, final String pluginKey, final String pluginName, final String pluginVersion, final PluginLanguage pluginLanguage) {
+        throw new UnsupportedOperationException("notifyOfStateChanged(org.killbill.billing.osgi.api.PluginStateChange, java.lang.String, java.lang.String, java.lang.String, org.killbill.billing.osgi.api.config.PluginLanguage) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PluginsInfoApiImp that = (PluginsInfoApiImp) o;
+        if( !Objects.equals(this.pluginsInfo, that.pluginsInfo) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.pluginsInfo);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("pluginsInfo=").append(this.pluginsInfo);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginsInfoApiImp.Builder<T>> {
+
+        protected Iterable<PluginInfo> pluginsInfo;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.pluginsInfo = that.pluginsInfo;
+        }
+        public T withPluginsInfo(final Iterable<PluginInfo> pluginsInfo) {
+            this.pluginsInfo = pluginsInfo;
+            return (T) this;
+        }
+        public T source(final PluginsInfoApi that) {
+            this.pluginsInfo = that.getPluginsInfo();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PluginsInfoApiImp build() {
+            return new PluginsInfoApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/osgi/api/boilerplate/Resolver.java
@@ -1,0 +1,37 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.osgi.api.Healthcheck;
+import org.killbill.billing.osgi.api.OSGIKillbill;
+import org.killbill.billing.osgi.api.OSGIPluginProperties;
+import org.killbill.billing.osgi.api.PluginInfo;
+import org.killbill.billing.osgi.api.PluginServiceInfo;
+import org.killbill.billing.osgi.api.PluginsInfoApi;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(Healthcheck.class, HealthcheckImp.class);
+        this.addMapping(OSGIKillbill.class, OSGIKillbillImp.class);
+        this.addMapping(OSGIPluginProperties.class, OSGIPluginPropertiesImp.class);
+        this.addMapping(PluginInfo.class, PluginInfoImp.class);
+        this.addMapping(PluginServiceInfo.class, PluginServiceInfoImp.class);
+        this.addMapping(PluginsInfoApi.class, PluginsInfoApiImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.config.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.osgi.api.config.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/PluginConfigImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/PluginConfigImp.java
@@ -1,0 +1,287 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.config.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.File;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.config.PluginConfig;
+import org.killbill.billing.osgi.api.config.PluginLanguage;
+import org.killbill.billing.osgi.api.config.PluginType;
+
+@JsonDeserialize( builder = PluginConfigImp.Builder.class )
+public class PluginConfigImp implements PluginConfig, Serializable {
+
+    private static final long serialVersionUID = 0x3C97070067D45587L;
+
+    protected boolean isDisabled;
+    protected boolean isSelectedForStart;
+    protected String pluginKey;
+    protected PluginLanguage pluginLanguage;
+    protected String pluginName;
+    protected PluginType pluginType;
+    protected File pluginVersionRoot;
+    protected String pluginVersionnedName;
+    protected String version;
+
+    public PluginConfigImp(final PluginConfigImp that) {
+        this.isDisabled = that.isDisabled;
+        this.isSelectedForStart = that.isSelectedForStart;
+        this.pluginKey = that.pluginKey;
+        this.pluginLanguage = that.pluginLanguage;
+        this.pluginName = that.pluginName;
+        this.pluginType = that.pluginType;
+        this.pluginVersionRoot = that.pluginVersionRoot;
+        this.pluginVersionnedName = that.pluginVersionnedName;
+        this.version = that.version;
+    }
+    protected PluginConfigImp(final PluginConfigImp.Builder<?> builder) {
+        this.isDisabled = builder.isDisabled;
+        this.isSelectedForStart = builder.isSelectedForStart;
+        this.pluginKey = builder.pluginKey;
+        this.pluginLanguage = builder.pluginLanguage;
+        this.pluginName = builder.pluginName;
+        this.pluginType = builder.pluginType;
+        this.pluginVersionRoot = builder.pluginVersionRoot;
+        this.pluginVersionnedName = builder.pluginVersionnedName;
+        this.version = builder.version;
+    }
+    protected PluginConfigImp() { }
+    @Override
+    @JsonGetter("isDisabled")
+    public boolean isDisabled() {
+        return this.isDisabled;
+    }
+    @Override
+    @JsonGetter("isSelectedForStart")
+    public boolean isSelectedForStart() {
+        return this.isSelectedForStart;
+    }
+    @Override
+    public String getPluginKey() {
+        return this.pluginKey;
+    }
+    @Override
+    public PluginLanguage getPluginLanguage() {
+        return this.pluginLanguage;
+    }
+    @Override
+    public String getPluginName() {
+        return this.pluginName;
+    }
+    @Override
+    public PluginType getPluginType() {
+        return this.pluginType;
+    }
+    @Override
+    public File getPluginVersionRoot() {
+        return this.pluginVersionRoot;
+    }
+    @Override
+    public String getPluginVersionnedName() {
+        return this.pluginVersionnedName;
+    }
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+    @Override
+    public int compareTo(final PluginConfig a) {
+        throw new UnsupportedOperationException("compareTo(org.killbill.billing.osgi.api.config.PluginConfig) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PluginConfigImp that = (PluginConfigImp) o;
+        if( this.isDisabled != that.isDisabled ) {
+            return false;
+        }
+        if( this.isSelectedForStart != that.isSelectedForStart ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginKey, that.pluginKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginLanguage, that.pluginLanguage) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginName, that.pluginName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginType, that.pluginType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginVersionRoot, that.pluginVersionRoot) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginVersionnedName, that.pluginVersionnedName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.version, that.version) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.isDisabled);
+        result = ( 31 * result ) + Objects.hashCode(this.isSelectedForStart);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginKey);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginLanguage);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginName);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginType);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginVersionRoot);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginVersionnedName);
+        result = ( 31 * result ) + Objects.hashCode(this.version);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("isDisabled=").append(this.isDisabled);
+        sb.append(", ");
+        sb.append("isSelectedForStart=").append(this.isSelectedForStart);
+        sb.append(", ");
+        sb.append("pluginKey=");
+        if( this.pluginKey == null ) {
+            sb.append(this.pluginKey);
+        }else{
+            sb.append("'").append(this.pluginKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginLanguage=").append(this.pluginLanguage);
+        sb.append(", ");
+        sb.append("pluginName=");
+        if( this.pluginName == null ) {
+            sb.append(this.pluginName);
+        }else{
+            sb.append("'").append(this.pluginName).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginType=").append(this.pluginType);
+        sb.append(", ");
+        sb.append("pluginVersionRoot=").append(this.pluginVersionRoot);
+        sb.append(", ");
+        sb.append("pluginVersionnedName=");
+        if( this.pluginVersionnedName == null ) {
+            sb.append(this.pluginVersionnedName);
+        }else{
+            sb.append("'").append(this.pluginVersionnedName).append("'");
+        }
+        sb.append(", ");
+        sb.append("version=");
+        if( this.version == null ) {
+            sb.append(this.version);
+        }else{
+            sb.append("'").append(this.version).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginConfigImp.Builder<T>> {
+
+        protected boolean isDisabled;
+        protected boolean isSelectedForStart;
+        protected String pluginKey;
+        protected PluginLanguage pluginLanguage;
+        protected String pluginName;
+        protected PluginType pluginType;
+        protected File pluginVersionRoot;
+        protected String pluginVersionnedName;
+        protected String version;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.isDisabled = that.isDisabled;
+            this.isSelectedForStart = that.isSelectedForStart;
+            this.pluginKey = that.pluginKey;
+            this.pluginLanguage = that.pluginLanguage;
+            this.pluginName = that.pluginName;
+            this.pluginType = that.pluginType;
+            this.pluginVersionRoot = that.pluginVersionRoot;
+            this.pluginVersionnedName = that.pluginVersionnedName;
+            this.version = that.version;
+        }
+        public T withIsDisabled(final boolean isDisabled) {
+            this.isDisabled = isDisabled;
+            return (T) this;
+        }
+        public T withIsSelectedForStart(final boolean isSelectedForStart) {
+            this.isSelectedForStart = isSelectedForStart;
+            return (T) this;
+        }
+        public T withPluginKey(final String pluginKey) {
+            this.pluginKey = pluginKey;
+            return (T) this;
+        }
+        public T withPluginLanguage(final PluginLanguage pluginLanguage) {
+            this.pluginLanguage = pluginLanguage;
+            return (T) this;
+        }
+        public T withPluginName(final String pluginName) {
+            this.pluginName = pluginName;
+            return (T) this;
+        }
+        public T withPluginType(final PluginType pluginType) {
+            this.pluginType = pluginType;
+            return (T) this;
+        }
+        public T withPluginVersionRoot(final File pluginVersionRoot) {
+            this.pluginVersionRoot = pluginVersionRoot;
+            return (T) this;
+        }
+        public T withPluginVersionnedName(final String pluginVersionnedName) {
+            this.pluginVersionnedName = pluginVersionnedName;
+            return (T) this;
+        }
+        public T withVersion(final String version) {
+            this.version = version;
+            return (T) this;
+        }
+        public T source(final PluginConfig that) {
+            this.isDisabled = that.isDisabled();
+            this.isSelectedForStart = that.isSelectedForStart();
+            this.pluginKey = that.getPluginKey();
+            this.pluginLanguage = that.getPluginLanguage();
+            this.pluginName = that.getPluginName();
+            this.pluginType = that.getPluginType();
+            this.pluginVersionRoot = that.getPluginVersionRoot();
+            this.pluginVersionnedName = that.getPluginVersionnedName();
+            this.version = that.getVersion();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PluginConfigImp build() {
+            return new PluginConfigImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/PluginConfigServiceApiImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/PluginConfigServiceApiImp.java
@@ -1,0 +1,89 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.config.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.config.PluginConfigServiceApi;
+import org.killbill.billing.osgi.api.config.PluginJavaConfig;
+import org.killbill.billing.osgi.api.config.PluginRubyConfig;
+
+@JsonDeserialize( builder = PluginConfigServiceApiImp.Builder.class )
+public class PluginConfigServiceApiImp implements PluginConfigServiceApi, Serializable {
+
+    private static final long serialVersionUID = 0x7FA95CF314C588A6L;
+
+
+    public PluginConfigServiceApiImp(final PluginConfigServiceApiImp that) {
+    }
+    protected PluginConfigServiceApiImp(final PluginConfigServiceApiImp.Builder<?> builder) {
+    }
+    protected PluginConfigServiceApiImp() { }
+    @Override
+    public PluginJavaConfig getPluginJavaConfig(final long bundleId) {
+        throw new UnsupportedOperationException("getPluginJavaConfig(long) must be implemented.");
+    }
+    @Override
+    public PluginRubyConfig getPluginRubyConfig(final long bundleId) {
+        throw new UnsupportedOperationException("getPluginRubyConfig(long) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PluginConfigServiceApiImp that = (PluginConfigServiceApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginConfigServiceApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final PluginConfigServiceApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PluginConfigServiceApiImp build() {
+            return new PluginConfigServiceApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/PluginJavaConfigImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/PluginJavaConfigImp.java
@@ -1,0 +1,313 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.config.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.File;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.config.PluginConfig;
+import org.killbill.billing.osgi.api.config.PluginJavaConfig;
+import org.killbill.billing.osgi.api.config.PluginLanguage;
+import org.killbill.billing.osgi.api.config.PluginType;
+
+@JsonDeserialize( builder = PluginJavaConfigImp.Builder.class )
+public class PluginJavaConfigImp implements PluginJavaConfig, Serializable {
+
+    private static final long serialVersionUID = 0xBEB2603DF892B0A4L;
+
+    protected String bundleJarPath;
+    protected boolean isDisabled;
+    protected boolean isSelectedForStart;
+    protected String pluginKey;
+    protected PluginLanguage pluginLanguage;
+    protected String pluginName;
+    protected PluginType pluginType;
+    protected File pluginVersionRoot;
+    protected String pluginVersionnedName;
+    protected String version;
+
+    public PluginJavaConfigImp(final PluginJavaConfigImp that) {
+        this.bundleJarPath = that.bundleJarPath;
+        this.isDisabled = that.isDisabled;
+        this.isSelectedForStart = that.isSelectedForStart;
+        this.pluginKey = that.pluginKey;
+        this.pluginLanguage = that.pluginLanguage;
+        this.pluginName = that.pluginName;
+        this.pluginType = that.pluginType;
+        this.pluginVersionRoot = that.pluginVersionRoot;
+        this.pluginVersionnedName = that.pluginVersionnedName;
+        this.version = that.version;
+    }
+    protected PluginJavaConfigImp(final PluginJavaConfigImp.Builder<?> builder) {
+        this.bundleJarPath = builder.bundleJarPath;
+        this.isDisabled = builder.isDisabled;
+        this.isSelectedForStart = builder.isSelectedForStart;
+        this.pluginKey = builder.pluginKey;
+        this.pluginLanguage = builder.pluginLanguage;
+        this.pluginName = builder.pluginName;
+        this.pluginType = builder.pluginType;
+        this.pluginVersionRoot = builder.pluginVersionRoot;
+        this.pluginVersionnedName = builder.pluginVersionnedName;
+        this.version = builder.version;
+    }
+    protected PluginJavaConfigImp() { }
+    @Override
+    public String getBundleJarPath() {
+        return this.bundleJarPath;
+    }
+    @Override
+    @JsonGetter("isDisabled")
+    public boolean isDisabled() {
+        return this.isDisabled;
+    }
+    @Override
+    @JsonGetter("isSelectedForStart")
+    public boolean isSelectedForStart() {
+        return this.isSelectedForStart;
+    }
+    @Override
+    public String getPluginKey() {
+        return this.pluginKey;
+    }
+    @Override
+    public PluginLanguage getPluginLanguage() {
+        return this.pluginLanguage;
+    }
+    @Override
+    public String getPluginName() {
+        return this.pluginName;
+    }
+    @Override
+    public PluginType getPluginType() {
+        return this.pluginType;
+    }
+    @Override
+    public File getPluginVersionRoot() {
+        return this.pluginVersionRoot;
+    }
+    @Override
+    public String getPluginVersionnedName() {
+        return this.pluginVersionnedName;
+    }
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+    @Override
+    public int compareTo(final PluginConfig a) {
+        throw new UnsupportedOperationException("compareTo(org.killbill.billing.osgi.api.config.PluginConfig) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PluginJavaConfigImp that = (PluginJavaConfigImp) o;
+        if( !Objects.equals(this.bundleJarPath, that.bundleJarPath) ) {
+            return false;
+        }
+        if( this.isDisabled != that.isDisabled ) {
+            return false;
+        }
+        if( this.isSelectedForStart != that.isSelectedForStart ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginKey, that.pluginKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginLanguage, that.pluginLanguage) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginName, that.pluginName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginType, that.pluginType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginVersionRoot, that.pluginVersionRoot) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginVersionnedName, that.pluginVersionnedName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.version, that.version) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.bundleJarPath);
+        result = ( 31 * result ) + Objects.hashCode(this.isDisabled);
+        result = ( 31 * result ) + Objects.hashCode(this.isSelectedForStart);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginKey);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginLanguage);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginName);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginType);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginVersionRoot);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginVersionnedName);
+        result = ( 31 * result ) + Objects.hashCode(this.version);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("bundleJarPath=");
+        if( this.bundleJarPath == null ) {
+            sb.append(this.bundleJarPath);
+        }else{
+            sb.append("'").append(this.bundleJarPath).append("'");
+        }
+        sb.append(", ");
+        sb.append("isDisabled=").append(this.isDisabled);
+        sb.append(", ");
+        sb.append("isSelectedForStart=").append(this.isSelectedForStart);
+        sb.append(", ");
+        sb.append("pluginKey=");
+        if( this.pluginKey == null ) {
+            sb.append(this.pluginKey);
+        }else{
+            sb.append("'").append(this.pluginKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginLanguage=").append(this.pluginLanguage);
+        sb.append(", ");
+        sb.append("pluginName=");
+        if( this.pluginName == null ) {
+            sb.append(this.pluginName);
+        }else{
+            sb.append("'").append(this.pluginName).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginType=").append(this.pluginType);
+        sb.append(", ");
+        sb.append("pluginVersionRoot=").append(this.pluginVersionRoot);
+        sb.append(", ");
+        sb.append("pluginVersionnedName=");
+        if( this.pluginVersionnedName == null ) {
+            sb.append(this.pluginVersionnedName);
+        }else{
+            sb.append("'").append(this.pluginVersionnedName).append("'");
+        }
+        sb.append(", ");
+        sb.append("version=");
+        if( this.version == null ) {
+            sb.append(this.version);
+        }else{
+            sb.append("'").append(this.version).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginJavaConfigImp.Builder<T>> {
+
+        protected String bundleJarPath;
+        protected boolean isDisabled;
+        protected boolean isSelectedForStart;
+        protected String pluginKey;
+        protected PluginLanguage pluginLanguage;
+        protected String pluginName;
+        protected PluginType pluginType;
+        protected File pluginVersionRoot;
+        protected String pluginVersionnedName;
+        protected String version;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.bundleJarPath = that.bundleJarPath;
+            this.isDisabled = that.isDisabled;
+            this.isSelectedForStart = that.isSelectedForStart;
+            this.pluginKey = that.pluginKey;
+            this.pluginLanguage = that.pluginLanguage;
+            this.pluginName = that.pluginName;
+            this.pluginType = that.pluginType;
+            this.pluginVersionRoot = that.pluginVersionRoot;
+            this.pluginVersionnedName = that.pluginVersionnedName;
+            this.version = that.version;
+        }
+        public T withBundleJarPath(final String bundleJarPath) {
+            this.bundleJarPath = bundleJarPath;
+            return (T) this;
+        }
+        public T withIsDisabled(final boolean isDisabled) {
+            this.isDisabled = isDisabled;
+            return (T) this;
+        }
+        public T withIsSelectedForStart(final boolean isSelectedForStart) {
+            this.isSelectedForStart = isSelectedForStart;
+            return (T) this;
+        }
+        public T withPluginKey(final String pluginKey) {
+            this.pluginKey = pluginKey;
+            return (T) this;
+        }
+        public T withPluginLanguage(final PluginLanguage pluginLanguage) {
+            this.pluginLanguage = pluginLanguage;
+            return (T) this;
+        }
+        public T withPluginName(final String pluginName) {
+            this.pluginName = pluginName;
+            return (T) this;
+        }
+        public T withPluginType(final PluginType pluginType) {
+            this.pluginType = pluginType;
+            return (T) this;
+        }
+        public T withPluginVersionRoot(final File pluginVersionRoot) {
+            this.pluginVersionRoot = pluginVersionRoot;
+            return (T) this;
+        }
+        public T withPluginVersionnedName(final String pluginVersionnedName) {
+            this.pluginVersionnedName = pluginVersionnedName;
+            return (T) this;
+        }
+        public T withVersion(final String version) {
+            this.version = version;
+            return (T) this;
+        }
+        public T source(final PluginJavaConfig that) {
+            this.bundleJarPath = that.getBundleJarPath();
+            this.isDisabled = that.isDisabled();
+            this.isSelectedForStart = that.isSelectedForStart();
+            this.pluginKey = that.getPluginKey();
+            this.pluginLanguage = that.getPluginLanguage();
+            this.pluginName = that.getPluginName();
+            this.pluginType = that.getPluginType();
+            this.pluginVersionRoot = that.getPluginVersionRoot();
+            this.pluginVersionnedName = that.getPluginVersionnedName();
+            this.version = that.getVersion();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PluginJavaConfigImp build() {
+            return new PluginJavaConfigImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/PluginRubyConfigImp.java
+++ b/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/PluginRubyConfigImp.java
@@ -1,0 +1,363 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.config.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.File;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.config.PluginConfig;
+import org.killbill.billing.osgi.api.config.PluginLanguage;
+import org.killbill.billing.osgi.api.config.PluginRubyConfig;
+import org.killbill.billing.osgi.api.config.PluginType;
+
+@JsonDeserialize( builder = PluginRubyConfigImp.Builder.class )
+public class PluginRubyConfigImp implements PluginRubyConfig, Serializable {
+
+    private static final long serialVersionUID = 0x901C01B3EBBA102DL;
+
+    protected boolean isDisabled;
+    protected boolean isSelectedForStart;
+    protected String pluginKey;
+    protected PluginLanguage pluginLanguage;
+    protected String pluginName;
+    protected PluginType pluginType;
+    protected File pluginVersionRoot;
+    protected String pluginVersionnedName;
+    protected String rubyLoadDir;
+    protected String rubyMainClass;
+    protected String rubyRequire;
+    protected String version;
+
+    public PluginRubyConfigImp(final PluginRubyConfigImp that) {
+        this.isDisabled = that.isDisabled;
+        this.isSelectedForStart = that.isSelectedForStart;
+        this.pluginKey = that.pluginKey;
+        this.pluginLanguage = that.pluginLanguage;
+        this.pluginName = that.pluginName;
+        this.pluginType = that.pluginType;
+        this.pluginVersionRoot = that.pluginVersionRoot;
+        this.pluginVersionnedName = that.pluginVersionnedName;
+        this.rubyLoadDir = that.rubyLoadDir;
+        this.rubyMainClass = that.rubyMainClass;
+        this.rubyRequire = that.rubyRequire;
+        this.version = that.version;
+    }
+    protected PluginRubyConfigImp(final PluginRubyConfigImp.Builder<?> builder) {
+        this.isDisabled = builder.isDisabled;
+        this.isSelectedForStart = builder.isSelectedForStart;
+        this.pluginKey = builder.pluginKey;
+        this.pluginLanguage = builder.pluginLanguage;
+        this.pluginName = builder.pluginName;
+        this.pluginType = builder.pluginType;
+        this.pluginVersionRoot = builder.pluginVersionRoot;
+        this.pluginVersionnedName = builder.pluginVersionnedName;
+        this.rubyLoadDir = builder.rubyLoadDir;
+        this.rubyMainClass = builder.rubyMainClass;
+        this.rubyRequire = builder.rubyRequire;
+        this.version = builder.version;
+    }
+    protected PluginRubyConfigImp() { }
+    @Override
+    @JsonGetter("isDisabled")
+    public boolean isDisabled() {
+        return this.isDisabled;
+    }
+    @Override
+    @JsonGetter("isSelectedForStart")
+    public boolean isSelectedForStart() {
+        return this.isSelectedForStart;
+    }
+    @Override
+    public String getPluginKey() {
+        return this.pluginKey;
+    }
+    @Override
+    public PluginLanguage getPluginLanguage() {
+        return this.pluginLanguage;
+    }
+    @Override
+    public String getPluginName() {
+        return this.pluginName;
+    }
+    @Override
+    public PluginType getPluginType() {
+        return this.pluginType;
+    }
+    @Override
+    public File getPluginVersionRoot() {
+        return this.pluginVersionRoot;
+    }
+    @Override
+    public String getPluginVersionnedName() {
+        return this.pluginVersionnedName;
+    }
+    @Override
+    public String getRubyLoadDir() {
+        return this.rubyLoadDir;
+    }
+    @Override
+    public String getRubyMainClass() {
+        return this.rubyMainClass;
+    }
+    @Override
+    public String getRubyRequire() {
+        return this.rubyRequire;
+    }
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+    @Override
+    public int compareTo(final PluginConfig a) {
+        throw new UnsupportedOperationException("compareTo(org.killbill.billing.osgi.api.config.PluginConfig) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PluginRubyConfigImp that = (PluginRubyConfigImp) o;
+        if( this.isDisabled != that.isDisabled ) {
+            return false;
+        }
+        if( this.isSelectedForStart != that.isSelectedForStart ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginKey, that.pluginKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginLanguage, that.pluginLanguage) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginName, that.pluginName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginType, that.pluginType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginVersionRoot, that.pluginVersionRoot) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginVersionnedName, that.pluginVersionnedName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.rubyLoadDir, that.rubyLoadDir) ) {
+            return false;
+        }
+        if( !Objects.equals(this.rubyMainClass, that.rubyMainClass) ) {
+            return false;
+        }
+        if( !Objects.equals(this.rubyRequire, that.rubyRequire) ) {
+            return false;
+        }
+        if( !Objects.equals(this.version, that.version) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.isDisabled);
+        result = ( 31 * result ) + Objects.hashCode(this.isSelectedForStart);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginKey);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginLanguage);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginName);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginType);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginVersionRoot);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginVersionnedName);
+        result = ( 31 * result ) + Objects.hashCode(this.rubyLoadDir);
+        result = ( 31 * result ) + Objects.hashCode(this.rubyMainClass);
+        result = ( 31 * result ) + Objects.hashCode(this.rubyRequire);
+        result = ( 31 * result ) + Objects.hashCode(this.version);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("isDisabled=").append(this.isDisabled);
+        sb.append(", ");
+        sb.append("isSelectedForStart=").append(this.isSelectedForStart);
+        sb.append(", ");
+        sb.append("pluginKey=");
+        if( this.pluginKey == null ) {
+            sb.append(this.pluginKey);
+        }else{
+            sb.append("'").append(this.pluginKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginLanguage=").append(this.pluginLanguage);
+        sb.append(", ");
+        sb.append("pluginName=");
+        if( this.pluginName == null ) {
+            sb.append(this.pluginName);
+        }else{
+            sb.append("'").append(this.pluginName).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginType=").append(this.pluginType);
+        sb.append(", ");
+        sb.append("pluginVersionRoot=").append(this.pluginVersionRoot);
+        sb.append(", ");
+        sb.append("pluginVersionnedName=");
+        if( this.pluginVersionnedName == null ) {
+            sb.append(this.pluginVersionnedName);
+        }else{
+            sb.append("'").append(this.pluginVersionnedName).append("'");
+        }
+        sb.append(", ");
+        sb.append("rubyLoadDir=");
+        if( this.rubyLoadDir == null ) {
+            sb.append(this.rubyLoadDir);
+        }else{
+            sb.append("'").append(this.rubyLoadDir).append("'");
+        }
+        sb.append(", ");
+        sb.append("rubyMainClass=");
+        if( this.rubyMainClass == null ) {
+            sb.append(this.rubyMainClass);
+        }else{
+            sb.append("'").append(this.rubyMainClass).append("'");
+        }
+        sb.append(", ");
+        sb.append("rubyRequire=");
+        if( this.rubyRequire == null ) {
+            sb.append(this.rubyRequire);
+        }else{
+            sb.append("'").append(this.rubyRequire).append("'");
+        }
+        sb.append(", ");
+        sb.append("version=");
+        if( this.version == null ) {
+            sb.append(this.version);
+        }else{
+            sb.append("'").append(this.version).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginRubyConfigImp.Builder<T>> {
+
+        protected boolean isDisabled;
+        protected boolean isSelectedForStart;
+        protected String pluginKey;
+        protected PluginLanguage pluginLanguage;
+        protected String pluginName;
+        protected PluginType pluginType;
+        protected File pluginVersionRoot;
+        protected String pluginVersionnedName;
+        protected String rubyLoadDir;
+        protected String rubyMainClass;
+        protected String rubyRequire;
+        protected String version;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.isDisabled = that.isDisabled;
+            this.isSelectedForStart = that.isSelectedForStart;
+            this.pluginKey = that.pluginKey;
+            this.pluginLanguage = that.pluginLanguage;
+            this.pluginName = that.pluginName;
+            this.pluginType = that.pluginType;
+            this.pluginVersionRoot = that.pluginVersionRoot;
+            this.pluginVersionnedName = that.pluginVersionnedName;
+            this.rubyLoadDir = that.rubyLoadDir;
+            this.rubyMainClass = that.rubyMainClass;
+            this.rubyRequire = that.rubyRequire;
+            this.version = that.version;
+        }
+        public T withIsDisabled(final boolean isDisabled) {
+            this.isDisabled = isDisabled;
+            return (T) this;
+        }
+        public T withIsSelectedForStart(final boolean isSelectedForStart) {
+            this.isSelectedForStart = isSelectedForStart;
+            return (T) this;
+        }
+        public T withPluginKey(final String pluginKey) {
+            this.pluginKey = pluginKey;
+            return (T) this;
+        }
+        public T withPluginLanguage(final PluginLanguage pluginLanguage) {
+            this.pluginLanguage = pluginLanguage;
+            return (T) this;
+        }
+        public T withPluginName(final String pluginName) {
+            this.pluginName = pluginName;
+            return (T) this;
+        }
+        public T withPluginType(final PluginType pluginType) {
+            this.pluginType = pluginType;
+            return (T) this;
+        }
+        public T withPluginVersionRoot(final File pluginVersionRoot) {
+            this.pluginVersionRoot = pluginVersionRoot;
+            return (T) this;
+        }
+        public T withPluginVersionnedName(final String pluginVersionnedName) {
+            this.pluginVersionnedName = pluginVersionnedName;
+            return (T) this;
+        }
+        public T withRubyLoadDir(final String rubyLoadDir) {
+            this.rubyLoadDir = rubyLoadDir;
+            return (T) this;
+        }
+        public T withRubyMainClass(final String rubyMainClass) {
+            this.rubyMainClass = rubyMainClass;
+            return (T) this;
+        }
+        public T withRubyRequire(final String rubyRequire) {
+            this.rubyRequire = rubyRequire;
+            return (T) this;
+        }
+        public T withVersion(final String version) {
+            this.version = version;
+            return (T) this;
+        }
+        public T source(final PluginRubyConfig that) {
+            this.isDisabled = that.isDisabled();
+            this.isSelectedForStart = that.isSelectedForStart();
+            this.pluginKey = that.getPluginKey();
+            this.pluginLanguage = that.getPluginLanguage();
+            this.pluginName = that.getPluginName();
+            this.pluginType = that.getPluginType();
+            this.pluginVersionRoot = that.getPluginVersionRoot();
+            this.pluginVersionnedName = that.getPluginVersionnedName();
+            this.rubyLoadDir = that.getRubyLoadDir();
+            this.rubyMainClass = that.getRubyMainClass();
+            this.rubyRequire = that.getRubyRequire();
+            this.version = that.getVersion();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PluginRubyConfigImp build() {
+            return new PluginRubyConfigImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/osgi/api/config/boilerplate/Resolver.java
@@ -1,0 +1,33 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.osgi.api.config.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.osgi.api.config.PluginConfig;
+import org.killbill.billing.osgi.api.config.PluginConfigServiceApi;
+import org.killbill.billing.osgi.api.config.PluginJavaConfig;
+import org.killbill.billing.osgi.api.config.PluginRubyConfig;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(PluginConfig.class, PluginConfigImp.class);
+        this.addMapping(PluginConfigServiceApi.class, PluginConfigServiceApiImp.class);
+        this.addMapping(PluginJavaConfig.class, PluginJavaConfigImp.class);
+        this.addMapping(PluginRubyConfig.class, PluginRubyConfigImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/overdue/api/boilerplate/EmailNotificationImp.java
+++ b/src/main/java/org/killbill/billing/overdue/api/boilerplate/EmailNotificationImp.java
@@ -1,0 +1,149 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.overdue.api.EmailNotification;
+
+@JsonDeserialize( builder = EmailNotificationImp.Builder.class )
+public class EmailNotificationImp implements EmailNotification, Serializable {
+
+    private static final long serialVersionUID = 0xE60FBB8D4C6B579FL;
+
+    protected Boolean isHTML;
+    protected String subject;
+    protected String templateName;
+
+    public EmailNotificationImp(final EmailNotificationImp that) {
+        this.isHTML = that.isHTML;
+        this.subject = that.subject;
+        this.templateName = that.templateName;
+    }
+    protected EmailNotificationImp(final EmailNotificationImp.Builder<?> builder) {
+        this.isHTML = builder.isHTML;
+        this.subject = builder.subject;
+        this.templateName = builder.templateName;
+    }
+    protected EmailNotificationImp() { }
+    @Override
+    @JsonGetter("isHTML")
+    public Boolean isHTML() {
+        return this.isHTML;
+    }
+    @Override
+    public String getSubject() {
+        return this.subject;
+    }
+    @Override
+    public String getTemplateName() {
+        return this.templateName;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final EmailNotificationImp that = (EmailNotificationImp) o;
+        if( !Objects.equals(this.isHTML, that.isHTML) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subject, that.subject) ) {
+            return false;
+        }
+        if( !Objects.equals(this.templateName, that.templateName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.isHTML);
+        result = ( 31 * result ) + Objects.hashCode(this.subject);
+        result = ( 31 * result ) + Objects.hashCode(this.templateName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("isHTML=").append(this.isHTML);
+        sb.append(", ");
+        sb.append("subject=");
+        if( this.subject == null ) {
+            sb.append(this.subject);
+        }else{
+            sb.append("'").append(this.subject).append("'");
+        }
+        sb.append(", ");
+        sb.append("templateName=");
+        if( this.templateName == null ) {
+            sb.append(this.templateName);
+        }else{
+            sb.append("'").append(this.templateName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends EmailNotificationImp.Builder<T>> {
+
+        protected Boolean isHTML;
+        protected String subject;
+        protected String templateName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.isHTML = that.isHTML;
+            this.subject = that.subject;
+            this.templateName = that.templateName;
+        }
+        public T withIsHTML(final Boolean isHTML) {
+            this.isHTML = isHTML;
+            return (T) this;
+        }
+        public T withSubject(final String subject) {
+            this.subject = subject;
+            return (T) this;
+        }
+        public T withTemplateName(final String templateName) {
+            this.templateName = templateName;
+            return (T) this;
+        }
+        public T source(final EmailNotification that) {
+            this.isHTML = that.isHTML();
+            this.subject = that.getSubject();
+            this.templateName = that.getTemplateName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public EmailNotificationImp build() {
+            return new EmailNotificationImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/overdue/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/overdue/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.overdue.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueApiImp.java
+++ b/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueApiImp.java
@@ -1,0 +1,101 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.overdue.api.OverdueApi;
+import org.killbill.billing.overdue.api.OverdueApiException;
+import org.killbill.billing.overdue.api.OverdueConfig;
+import org.killbill.billing.overdue.api.OverdueState;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = OverdueApiImp.Builder.class )
+public class OverdueApiImp implements OverdueApi, Serializable {
+
+    private static final long serialVersionUID = 0xB51D1B98180BE0EBL;
+
+
+    public OverdueApiImp(final OverdueApiImp that) {
+    }
+    protected OverdueApiImp(final OverdueApiImp.Builder<?> builder) {
+    }
+    protected OverdueApiImp() { }
+    @Override
+    public void uploadOverdueConfig(final OverdueConfig overdueConfig, final CallContext callContext) {
+        throw new UnsupportedOperationException("uploadOverdueConfig(org.killbill.billing.overdue.api.OverdueConfig, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public OverdueState getOverdueStateFor(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getOverdueStateFor(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void uploadOverdueConfig(final String overdueXML, final CallContext context) {
+        throw new UnsupportedOperationException("uploadOverdueConfig(java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public OverdueConfig getOverdueConfig(final TenantContext context) {
+        throw new UnsupportedOperationException("getOverdueConfig(org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final OverdueApiImp that = (OverdueApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends OverdueApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final OverdueApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public OverdueApiImp build() {
+            return new OverdueApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueConditionImp.java
+++ b/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueConditionImp.java
@@ -1,0 +1,202 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Duration;
+import org.killbill.billing.overdue.api.OverdueCondition;
+import org.killbill.billing.payment.api.PaymentResponse;
+import org.killbill.billing.util.tag.ControlTagType;
+
+@JsonDeserialize( builder = OverdueConditionImp.Builder.class )
+public class OverdueConditionImp implements OverdueCondition, Serializable {
+
+    private static final long serialVersionUID = 0x2AB7DE125D71E096L;
+
+    protected ControlTagType exclusionControlTagType;
+    protected ControlTagType inclusionControlTagType;
+    protected Integer numberOfUnpaidInvoicesEqualsOrExceeds;
+    protected PaymentResponse[] responseForLastFailedPaymentIn;
+    protected Duration timeSinceEarliestUnpaidInvoiceEqualsOrExceeds;
+    protected BigDecimal totalUnpaidInvoiceBalanceEqualsOrExceeds;
+
+    public OverdueConditionImp(final OverdueConditionImp that) {
+        this.exclusionControlTagType = that.exclusionControlTagType;
+        this.inclusionControlTagType = that.inclusionControlTagType;
+        this.numberOfUnpaidInvoicesEqualsOrExceeds = that.numberOfUnpaidInvoicesEqualsOrExceeds;
+        this.responseForLastFailedPaymentIn = that.responseForLastFailedPaymentIn;
+        this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds = that.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds;
+        this.totalUnpaidInvoiceBalanceEqualsOrExceeds = that.totalUnpaidInvoiceBalanceEqualsOrExceeds;
+    }
+    protected OverdueConditionImp(final OverdueConditionImp.Builder<?> builder) {
+        this.exclusionControlTagType = builder.exclusionControlTagType;
+        this.inclusionControlTagType = builder.inclusionControlTagType;
+        this.numberOfUnpaidInvoicesEqualsOrExceeds = builder.numberOfUnpaidInvoicesEqualsOrExceeds;
+        this.responseForLastFailedPaymentIn = builder.responseForLastFailedPaymentIn;
+        this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds = builder.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds;
+        this.totalUnpaidInvoiceBalanceEqualsOrExceeds = builder.totalUnpaidInvoiceBalanceEqualsOrExceeds;
+    }
+    protected OverdueConditionImp() { }
+    @Override
+    public ControlTagType getExclusionControlTagType() {
+        return this.exclusionControlTagType;
+    }
+    @Override
+    public ControlTagType getInclusionControlTagType() {
+        return this.inclusionControlTagType;
+    }
+    @Override
+    public Integer getNumberOfUnpaidInvoicesEqualsOrExceeds() {
+        return this.numberOfUnpaidInvoicesEqualsOrExceeds;
+    }
+    @Override
+    public PaymentResponse[] getResponseForLastFailedPaymentIn() {
+        return this.responseForLastFailedPaymentIn;
+    }
+    @Override
+    public Duration getTimeSinceEarliestUnpaidInvoiceEqualsOrExceeds() {
+        return this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds;
+    }
+    @Override
+    public BigDecimal getTotalUnpaidInvoiceBalanceEqualsOrExceeds() {
+        return this.totalUnpaidInvoiceBalanceEqualsOrExceeds;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final OverdueConditionImp that = (OverdueConditionImp) o;
+        if( !Objects.equals(this.exclusionControlTagType, that.exclusionControlTagType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.inclusionControlTagType, that.inclusionControlTagType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.numberOfUnpaidInvoicesEqualsOrExceeds, that.numberOfUnpaidInvoicesEqualsOrExceeds) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.responseForLastFailedPaymentIn, that.responseForLastFailedPaymentIn) ) {
+            return false;
+        }
+        if( !Objects.equals(this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds, that.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds) ) {
+            return false;
+        }
+        if( ( this.totalUnpaidInvoiceBalanceEqualsOrExceeds != null ) ? ( 0 != this.totalUnpaidInvoiceBalanceEqualsOrExceeds.compareTo(that.totalUnpaidInvoiceBalanceEqualsOrExceeds) ) : ( that.totalUnpaidInvoiceBalanceEqualsOrExceeds != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.exclusionControlTagType);
+        result = ( 31 * result ) + Objects.hashCode(this.inclusionControlTagType);
+        result = ( 31 * result ) + Objects.hashCode(this.numberOfUnpaidInvoicesEqualsOrExceeds);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.responseForLastFailedPaymentIn);
+        result = ( 31 * result ) + Objects.hashCode(this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds);
+        result = ( 31 * result ) + Objects.hashCode(this.totalUnpaidInvoiceBalanceEqualsOrExceeds);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("exclusionControlTagType=").append(this.exclusionControlTagType);
+        sb.append(", ");
+        sb.append("inclusionControlTagType=").append(this.inclusionControlTagType);
+        sb.append(", ");
+        sb.append("numberOfUnpaidInvoicesEqualsOrExceeds=").append(this.numberOfUnpaidInvoicesEqualsOrExceeds);
+        sb.append(", ");
+        sb.append("responseForLastFailedPaymentIn=").append(Arrays.toString(this.responseForLastFailedPaymentIn));
+        sb.append(", ");
+        sb.append("timeSinceEarliestUnpaidInvoiceEqualsOrExceeds=").append(this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds);
+        sb.append(", ");
+        sb.append("totalUnpaidInvoiceBalanceEqualsOrExceeds=").append(this.totalUnpaidInvoiceBalanceEqualsOrExceeds);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends OverdueConditionImp.Builder<T>> {
+
+        protected ControlTagType exclusionControlTagType;
+        protected ControlTagType inclusionControlTagType;
+        protected Integer numberOfUnpaidInvoicesEqualsOrExceeds;
+        protected PaymentResponse[] responseForLastFailedPaymentIn;
+        protected Duration timeSinceEarliestUnpaidInvoiceEqualsOrExceeds;
+        protected BigDecimal totalUnpaidInvoiceBalanceEqualsOrExceeds;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.exclusionControlTagType = that.exclusionControlTagType;
+            this.inclusionControlTagType = that.inclusionControlTagType;
+            this.numberOfUnpaidInvoicesEqualsOrExceeds = that.numberOfUnpaidInvoicesEqualsOrExceeds;
+            this.responseForLastFailedPaymentIn = that.responseForLastFailedPaymentIn;
+            this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds = that.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds;
+            this.totalUnpaidInvoiceBalanceEqualsOrExceeds = that.totalUnpaidInvoiceBalanceEqualsOrExceeds;
+        }
+        public T withExclusionControlTagType(final ControlTagType exclusionControlTagType) {
+            this.exclusionControlTagType = exclusionControlTagType;
+            return (T) this;
+        }
+        public T withInclusionControlTagType(final ControlTagType inclusionControlTagType) {
+            this.inclusionControlTagType = inclusionControlTagType;
+            return (T) this;
+        }
+        public T withNumberOfUnpaidInvoicesEqualsOrExceeds(final Integer numberOfUnpaidInvoicesEqualsOrExceeds) {
+            this.numberOfUnpaidInvoicesEqualsOrExceeds = numberOfUnpaidInvoicesEqualsOrExceeds;
+            return (T) this;
+        }
+        public T withResponseForLastFailedPaymentIn(final PaymentResponse[] responseForLastFailedPaymentIn) {
+            this.responseForLastFailedPaymentIn = responseForLastFailedPaymentIn;
+            return (T) this;
+        }
+        public T withTimeSinceEarliestUnpaidInvoiceEqualsOrExceeds(final Duration timeSinceEarliestUnpaidInvoiceEqualsOrExceeds) {
+            this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds = timeSinceEarliestUnpaidInvoiceEqualsOrExceeds;
+            return (T) this;
+        }
+        public T withTotalUnpaidInvoiceBalanceEqualsOrExceeds(final BigDecimal totalUnpaidInvoiceBalanceEqualsOrExceeds) {
+            this.totalUnpaidInvoiceBalanceEqualsOrExceeds = totalUnpaidInvoiceBalanceEqualsOrExceeds;
+            return (T) this;
+        }
+        public T source(final OverdueCondition that) {
+            this.exclusionControlTagType = that.getExclusionControlTagType();
+            this.inclusionControlTagType = that.getInclusionControlTagType();
+            this.numberOfUnpaidInvoicesEqualsOrExceeds = that.getNumberOfUnpaidInvoicesEqualsOrExceeds();
+            this.responseForLastFailedPaymentIn = that.getResponseForLastFailedPaymentIn();
+            this.timeSinceEarliestUnpaidInvoiceEqualsOrExceeds = that.getTimeSinceEarliestUnpaidInvoiceEqualsOrExceeds();
+            this.totalUnpaidInvoiceBalanceEqualsOrExceeds = that.getTotalUnpaidInvoiceBalanceEqualsOrExceeds();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public OverdueConditionImp build() {
+            return new OverdueConditionImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueConfigImp.java
+++ b/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueConfigImp.java
@@ -1,0 +1,99 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.overdue.api.OverdueConfig;
+import org.killbill.billing.overdue.api.OverdueStatesAccount;
+
+@JsonDeserialize( builder = OverdueConfigImp.Builder.class )
+public class OverdueConfigImp implements OverdueConfig, Serializable {
+
+    private static final long serialVersionUID = 0xFBDCFEF03EB6F0BEL;
+
+    protected OverdueStatesAccount overdueStatesAccount;
+
+    public OverdueConfigImp(final OverdueConfigImp that) {
+        this.overdueStatesAccount = that.overdueStatesAccount;
+    }
+    protected OverdueConfigImp(final OverdueConfigImp.Builder<?> builder) {
+        this.overdueStatesAccount = builder.overdueStatesAccount;
+    }
+    protected OverdueConfigImp() { }
+    @Override
+    public OverdueStatesAccount getOverdueStatesAccount() {
+        return this.overdueStatesAccount;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final OverdueConfigImp that = (OverdueConfigImp) o;
+        if( !Objects.equals(this.overdueStatesAccount, that.overdueStatesAccount) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.overdueStatesAccount);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("overdueStatesAccount=").append(this.overdueStatesAccount);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends OverdueConfigImp.Builder<T>> {
+
+        protected OverdueStatesAccount overdueStatesAccount;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.overdueStatesAccount = that.overdueStatesAccount;
+        }
+        public T withOverdueStatesAccount(final OverdueStatesAccount overdueStatesAccount) {
+            this.overdueStatesAccount = overdueStatesAccount;
+            return (T) this;
+        }
+        public T source(final OverdueConfig that) {
+            this.overdueStatesAccount = that.getOverdueStatesAccount();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public OverdueConfigImp build() {
+            return new OverdueConfigImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueStateImp.java
+++ b/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueStateImp.java
@@ -1,0 +1,255 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.catalog.api.Duration;
+import org.killbill.billing.overdue.api.OverdueApiException;
+import org.killbill.billing.overdue.api.OverdueCancellationPolicy;
+import org.killbill.billing.overdue.api.OverdueCondition;
+import org.killbill.billing.overdue.api.OverdueState;
+
+@JsonDeserialize( builder = OverdueStateImp.Builder.class )
+public class OverdueStateImp implements OverdueState, Serializable {
+
+    private static final long serialVersionUID = 0x3CF6E8406781974EL;
+
+    protected Duration autoReevaluationInterval;
+    protected String externalMessage;
+    protected boolean isBlockChanges;
+    protected boolean isClearState;
+    protected boolean isDisableEntitlementAndChangesBlocked;
+    protected String name;
+    protected OverdueCancellationPolicy overdueCancellationPolicy;
+    protected OverdueCondition overdueCondition;
+
+    public OverdueStateImp(final OverdueStateImp that) {
+        this.autoReevaluationInterval = that.autoReevaluationInterval;
+        this.externalMessage = that.externalMessage;
+        this.isBlockChanges = that.isBlockChanges;
+        this.isClearState = that.isClearState;
+        this.isDisableEntitlementAndChangesBlocked = that.isDisableEntitlementAndChangesBlocked;
+        this.name = that.name;
+        this.overdueCancellationPolicy = that.overdueCancellationPolicy;
+        this.overdueCondition = that.overdueCondition;
+    }
+    protected OverdueStateImp(final OverdueStateImp.Builder<?> builder) {
+        this.autoReevaluationInterval = builder.autoReevaluationInterval;
+        this.externalMessage = builder.externalMessage;
+        this.isBlockChanges = builder.isBlockChanges;
+        this.isClearState = builder.isClearState;
+        this.isDisableEntitlementAndChangesBlocked = builder.isDisableEntitlementAndChangesBlocked;
+        this.name = builder.name;
+        this.overdueCancellationPolicy = builder.overdueCancellationPolicy;
+        this.overdueCondition = builder.overdueCondition;
+    }
+    protected OverdueStateImp() { }
+    @Override
+    public Duration getAutoReevaluationInterval() {
+        return this.autoReevaluationInterval;
+    }
+    @Override
+    public String getExternalMessage() {
+        return this.externalMessage;
+    }
+    @Override
+    @JsonGetter("isBlockChanges")
+    public boolean isBlockChanges() {
+        return this.isBlockChanges;
+    }
+    @Override
+    @JsonGetter("isClearState")
+    public boolean isClearState() {
+        return this.isClearState;
+    }
+    @Override
+    @JsonGetter("isDisableEntitlementAndChangesBlocked")
+    public boolean isDisableEntitlementAndChangesBlocked() {
+        return this.isDisableEntitlementAndChangesBlocked;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public OverdueCancellationPolicy getOverdueCancellationPolicy() {
+        return this.overdueCancellationPolicy;
+    }
+    @Override
+    public OverdueCondition getOverdueCondition() {
+        return this.overdueCondition;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final OverdueStateImp that = (OverdueStateImp) o;
+        if( !Objects.equals(this.autoReevaluationInterval, that.autoReevaluationInterval) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalMessage, that.externalMessage) ) {
+            return false;
+        }
+        if( this.isBlockChanges != that.isBlockChanges ) {
+            return false;
+        }
+        if( this.isClearState != that.isClearState ) {
+            return false;
+        }
+        if( this.isDisableEntitlementAndChangesBlocked != that.isDisableEntitlementAndChangesBlocked ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( !Objects.equals(this.overdueCancellationPolicy, that.overdueCancellationPolicy) ) {
+            return false;
+        }
+        if( !Objects.equals(this.overdueCondition, that.overdueCondition) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.autoReevaluationInterval);
+        result = ( 31 * result ) + Objects.hashCode(this.externalMessage);
+        result = ( 31 * result ) + Objects.hashCode(this.isBlockChanges);
+        result = ( 31 * result ) + Objects.hashCode(this.isClearState);
+        result = ( 31 * result ) + Objects.hashCode(this.isDisableEntitlementAndChangesBlocked);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.overdueCancellationPolicy);
+        result = ( 31 * result ) + Objects.hashCode(this.overdueCondition);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("autoReevaluationInterval=").append(this.autoReevaluationInterval);
+        sb.append(", ");
+        sb.append("externalMessage=");
+        if( this.externalMessage == null ) {
+            sb.append(this.externalMessage);
+        }else{
+            sb.append("'").append(this.externalMessage).append("'");
+        }
+        sb.append(", ");
+        sb.append("isBlockChanges=").append(this.isBlockChanges);
+        sb.append(", ");
+        sb.append("isClearState=").append(this.isClearState);
+        sb.append(", ");
+        sb.append("isDisableEntitlementAndChangesBlocked=").append(this.isDisableEntitlementAndChangesBlocked);
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("overdueCancellationPolicy=").append(this.overdueCancellationPolicy);
+        sb.append(", ");
+        sb.append("overdueCondition=").append(this.overdueCondition);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends OverdueStateImp.Builder<T>> {
+
+        protected Duration autoReevaluationInterval;
+        protected String externalMessage;
+        protected boolean isBlockChanges;
+        protected boolean isClearState;
+        protected boolean isDisableEntitlementAndChangesBlocked;
+        protected String name;
+        protected OverdueCancellationPolicy overdueCancellationPolicy;
+        protected OverdueCondition overdueCondition;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.autoReevaluationInterval = that.autoReevaluationInterval;
+            this.externalMessage = that.externalMessage;
+            this.isBlockChanges = that.isBlockChanges;
+            this.isClearState = that.isClearState;
+            this.isDisableEntitlementAndChangesBlocked = that.isDisableEntitlementAndChangesBlocked;
+            this.name = that.name;
+            this.overdueCancellationPolicy = that.overdueCancellationPolicy;
+            this.overdueCondition = that.overdueCondition;
+        }
+        public T withAutoReevaluationInterval(final Duration autoReevaluationInterval) {
+            this.autoReevaluationInterval = autoReevaluationInterval;
+            return (T) this;
+        }
+        public T withExternalMessage(final String externalMessage) {
+            this.externalMessage = externalMessage;
+            return (T) this;
+        }
+        public T withIsBlockChanges(final boolean isBlockChanges) {
+            this.isBlockChanges = isBlockChanges;
+            return (T) this;
+        }
+        public T withIsClearState(final boolean isClearState) {
+            this.isClearState = isClearState;
+            return (T) this;
+        }
+        public T withIsDisableEntitlementAndChangesBlocked(final boolean isDisableEntitlementAndChangesBlocked) {
+            this.isDisableEntitlementAndChangesBlocked = isDisableEntitlementAndChangesBlocked;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withOverdueCancellationPolicy(final OverdueCancellationPolicy overdueCancellationPolicy) {
+            this.overdueCancellationPolicy = overdueCancellationPolicy;
+            return (T) this;
+        }
+        public T withOverdueCondition(final OverdueCondition overdueCondition) {
+            this.overdueCondition = overdueCondition;
+            return (T) this;
+        }
+        public T source(final OverdueState that) throws OverdueApiException {
+            this.autoReevaluationInterval = that.getAutoReevaluationInterval();
+            this.externalMessage = that.getExternalMessage();
+            this.isBlockChanges = that.isBlockChanges();
+            this.isClearState = that.isClearState();
+            this.isDisableEntitlementAndChangesBlocked = that.isDisableEntitlementAndChangesBlocked();
+            this.name = that.getName();
+            this.overdueCancellationPolicy = that.getOverdueCancellationPolicy();
+            this.overdueCondition = that.getOverdueCondition();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public OverdueStateImp build() {
+            return new OverdueStateImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueStatesAccountImp.java
+++ b/src/main/java/org/killbill/billing/overdue/api/boilerplate/OverdueStatesAccountImp.java
@@ -1,0 +1,120 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.joda.time.Period;
+import org.killbill.billing.overdue.api.OverdueState;
+import org.killbill.billing.overdue.api.OverdueStatesAccount;
+
+@JsonDeserialize( builder = OverdueStatesAccountImp.Builder.class )
+public class OverdueStatesAccountImp implements OverdueStatesAccount, Serializable {
+
+    private static final long serialVersionUID = 0x4828ABF3F348F92DL;
+
+    protected Period initialReevaluationInterval;
+    protected OverdueState[] states;
+
+    public OverdueStatesAccountImp(final OverdueStatesAccountImp that) {
+        this.initialReevaluationInterval = that.initialReevaluationInterval;
+        this.states = that.states;
+    }
+    protected OverdueStatesAccountImp(final OverdueStatesAccountImp.Builder<?> builder) {
+        this.initialReevaluationInterval = builder.initialReevaluationInterval;
+        this.states = builder.states;
+    }
+    protected OverdueStatesAccountImp() { }
+    @Override
+    public Period getInitialReevaluationInterval() {
+        return this.initialReevaluationInterval;
+    }
+    @Override
+    public OverdueState[] getStates() {
+        return this.states;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final OverdueStatesAccountImp that = (OverdueStatesAccountImp) o;
+        if( !Objects.equals(this.initialReevaluationInterval, that.initialReevaluationInterval) ) {
+            return false;
+        }
+        if( !Arrays.deepEquals(this.states, that.states) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.initialReevaluationInterval);
+        result = ( 31 * result ) + Arrays.deepHashCode(this.states);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("initialReevaluationInterval=").append(this.initialReevaluationInterval);
+        sb.append(", ");
+        sb.append("states=").append(Arrays.toString(this.states));
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends OverdueStatesAccountImp.Builder<T>> {
+
+        protected Period initialReevaluationInterval;
+        protected OverdueState[] states;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.initialReevaluationInterval = that.initialReevaluationInterval;
+            this.states = that.states;
+        }
+        public T withInitialReevaluationInterval(final Period initialReevaluationInterval) {
+            this.initialReevaluationInterval = initialReevaluationInterval;
+            return (T) this;
+        }
+        public T withStates(final OverdueState[] states) {
+            this.states = states;
+            return (T) this;
+        }
+        public T source(final OverdueStatesAccount that) {
+            this.initialReevaluationInterval = that.getInitialReevaluationInterval();
+            this.states = that.getStates();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public OverdueStatesAccountImp build() {
+            return new OverdueStatesAccountImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/overdue/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/overdue/api/boilerplate/Resolver.java
@@ -1,0 +1,37 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.overdue.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.overdue.api.EmailNotification;
+import org.killbill.billing.overdue.api.OverdueApi;
+import org.killbill.billing.overdue.api.OverdueCondition;
+import org.killbill.billing.overdue.api.OverdueConfig;
+import org.killbill.billing.overdue.api.OverdueState;
+import org.killbill.billing.overdue.api.OverdueStatesAccount;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(EmailNotification.class, EmailNotificationImp.class);
+        this.addMapping(OverdueApi.class, OverdueApiImp.class);
+        this.addMapping(OverdueCondition.class, OverdueConditionImp.class);
+        this.addMapping(OverdueConfig.class, OverdueConfigImp.class);
+        this.addMapping(OverdueState.class, OverdueStateImp.class);
+        this.addMapping(OverdueStatesAccount.class, OverdueStatesAccountImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/AdminPaymentApiImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/AdminPaymentApiImp.java
@@ -1,0 +1,89 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.payment.api.AdminPaymentApi;
+import org.killbill.billing.payment.api.Payment;
+import org.killbill.billing.payment.api.PaymentApiException;
+import org.killbill.billing.payment.api.PaymentTransaction;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.api.TransactionStatus;
+import org.killbill.billing.util.callcontext.CallContext;
+
+@JsonDeserialize( builder = AdminPaymentApiImp.Builder.class )
+public class AdminPaymentApiImp implements AdminPaymentApi, Serializable {
+
+    private static final long serialVersionUID = 0xCF79686F682D667FL;
+
+
+    public AdminPaymentApiImp(final AdminPaymentApiImp that) {
+    }
+    protected AdminPaymentApiImp(final AdminPaymentApiImp.Builder<?> builder) {
+    }
+    protected AdminPaymentApiImp() { }
+    @Override
+    public void fixPaymentTransactionState(final Payment payment, final PaymentTransaction paymentTransaction, final TransactionStatus transactionStatus, final String lastSuccessPaymentState, final String currentPaymentStateName, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("fixPaymentTransactionState(org.killbill.billing.payment.api.Payment, org.killbill.billing.payment.api.PaymentTransaction, org.killbill.billing.payment.api.TransactionStatus, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AdminPaymentApiImp that = (AdminPaymentApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AdminPaymentApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final AdminPaymentApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AdminPaymentApiImp build() {
+            return new AdminPaymentApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/InvoicePaymentApiImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/InvoicePaymentApiImp.java
@@ -1,0 +1,124 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.InvoicePayment;
+import org.killbill.billing.payment.api.InvoicePaymentApi;
+import org.killbill.billing.payment.api.PaymentApiException;
+import org.killbill.billing.payment.api.PaymentOptions;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = InvoicePaymentApiImp.Builder.class )
+public class InvoicePaymentApiImp implements InvoicePaymentApi, Serializable {
+
+    private static final long serialVersionUID = 0xB0A62AA1EE29BD1EL;
+
+
+    public InvoicePaymentApiImp(final InvoicePaymentApiImp that) {
+    }
+    protected InvoicePaymentApiImp(final InvoicePaymentApiImp.Builder<?> builder) {
+    }
+    protected InvoicePaymentApiImp() { }
+    @Override
+    public InvoicePayment createPurchaseForInvoicePayment(final Account account, final UUID invoiceId, final UUID paymentMethodId, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentExternalKey, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createPurchaseForInvoicePayment(org.killbill.billing.account.api.Account, java.util.UUID, java.util.UUID, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public InvoicePayment createCreditForInvoicePayment(final boolean isAdjusted, final Map<UUID, BigDecimal> adjustments, final Account account, final UUID originalPaymentId, final UUID paymentMethodId, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentExternalKey, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createCreditForInvoicePayment(boolean, java.util.Map<java.util.UUID, java.math.BigDecimal>, org.killbill.billing.account.api.Account, java.util.UUID, java.util.UUID, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<InvoicePayment> getInvoicePayments(final UUID paymentId, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicePayments(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public InvoicePayment getInvoicePayment(final UUID invoicePaymentId, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicePayment(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public InvoicePayment createChargebackReversalForInvoicePayment(final Account account, final UUID paymentId, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createChargebackReversalForInvoicePayment(org.killbill.billing.account.api.Account, java.util.UUID, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<InvoicePayment> getInvoicePaymentsByAccount(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicePaymentsByAccount(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public InvoicePayment createRefundForInvoicePayment(final boolean isAdjusted, final Map<UUID, BigDecimal> adjustments, final Account account, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createRefundForInvoicePayment(boolean, java.util.Map<java.util.UUID, java.math.BigDecimal>, org.killbill.billing.account.api.Account, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public InvoicePayment createChargebackForInvoicePayment(final Account account, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createChargebackForInvoicePayment(org.killbill.billing.account.api.Account, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final InvoicePaymentApiImp that = (InvoicePaymentApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends InvoicePaymentApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final InvoicePaymentApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public InvoicePaymentApiImp build() {
+            return new InvoicePaymentApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.payment.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentApiImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentApiImp.java
@@ -1,0 +1,280 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.Payment;
+import org.killbill.billing.payment.api.PaymentApi;
+import org.killbill.billing.payment.api.PaymentApiException;
+import org.killbill.billing.payment.api.PaymentMethod;
+import org.killbill.billing.payment.api.PaymentMethodPlugin;
+import org.killbill.billing.payment.api.PaymentOptions;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.util.api.AuditLevel;
+import org.killbill.billing.util.audit.AuditLogWithHistory;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.entity.Pagination;
+
+@JsonDeserialize( builder = PaymentApiImp.Builder.class )
+public class PaymentApiImp implements PaymentApi, Serializable {
+
+    private static final long serialVersionUID = 0x6092A6E7DA13BCFDL;
+
+
+    public PaymentApiImp(final PaymentApiImp that) {
+    }
+    protected PaymentApiImp(final PaymentApiImp.Builder<?> builder) {
+    }
+    protected PaymentApiImp() { }
+    @Override
+    public Pagination<Payment> getPayments(final Long offset, final Long limit, final String pluginName, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPayments(java.lang.Long, java.lang.Long, java.lang.String, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getPaymentMethodAuditLogsWithHistoryForId(final UUID paymentMethodId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentMethodAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment getPayment(final UUID paymentId, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPayment(java.util.UUID, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createVoidWithPaymentControl(final Account account, final UUID paymentId, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createVoidWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment createChargeback(final Account account, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentTransactionExternalKey, final CallContext context) {
+        throw new UnsupportedOperationException("createChargeback(org.killbill.billing.account.api.Account, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<PaymentMethod> refreshPaymentMethods(final Account account, final String pluginName, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("refreshPaymentMethods(org.killbill.billing.account.api.Account, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getPaymentAttemptAuditLogsWithHistoryForId(final UUID paymentAttemptId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentAttemptAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public UUID addPaymentMethodWithPaymentControl(final Account account, final String paymentMethodExternalKey, final String pluginName, final boolean setDefault, final PaymentMethodPlugin paymentMethodInfo, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("addPaymentMethodWithPaymentControl(org.killbill.billing.account.api.Account, java.lang.String, java.lang.String, boolean, org.killbill.billing.payment.api.PaymentMethodPlugin, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment getPaymentByExternalKey(final String paymentExternalKey, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentByExternalKey(java.lang.String, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createCapture(final Account account, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("createCapture(org.killbill.billing.account.api.Account, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getPaymentAuditLogsWithHistoryForId(final UUID paymentId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createPurchase(final Account account, final UUID paymentMethodId, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentExternalKey, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("createPurchase(org.killbill.billing.account.api.Account, java.util.UUID, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getPaymentTransactionAuditLogsWithHistoryForId(final UUID paymentTransactionId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentTransactionAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment notifyPendingTransactionOfStateChanged(final Account account, final UUID paymentTransactionId, final boolean isSuccess, final CallContext context) {
+        throw new UnsupportedOperationException("notifyPendingTransactionOfStateChanged(org.killbill.billing.account.api.Account, java.util.UUID, boolean, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Payment> searchPayments(final String searchKey, final Long offset, final Long limit, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("searchPayments(java.lang.String, java.lang.Long, java.lang.Long, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void cancelScheduledPaymentTransaction(final UUID paymentTransactionId, final CallContext context) {
+        throw new UnsupportedOperationException("cancelScheduledPaymentTransaction(java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment createRefundWithPaymentControl(final Account account, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createRefundWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment createCreditWithPaymentControl(final Account account, final UUID paymentMethodId, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentExternalKey, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createCreditWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment getPaymentByTransactionExternalKey(final String transactionExternalKey, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentByTransactionExternalKey(java.lang.String, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<PaymentMethod> refreshPaymentMethods(final Account account, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("refreshPaymentMethods(org.killbill.billing.account.api.Account, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<PaymentMethod> searchPaymentMethods(final String searchKey, final Long offset, final Long limit, final String pluginName, final boolean withPluginInfo, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("searchPaymentMethods(java.lang.String, java.lang.Long, java.lang.Long, java.lang.String, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public PaymentMethod getPaymentMethodByExternalKey(final String paymentMethodExternalKey, final boolean includedInactive, final boolean withPluginInfo, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentMethodByExternalKey(java.lang.String, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createChargebackWithPaymentControl(final Account account, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentTransactionExternalKey, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createChargebackWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<PaymentMethod> getPaymentMethods(final Long offset, final Long limit, final String pluginName, final boolean withPluginInfo, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentMethods(java.lang.Long, java.lang.Long, java.lang.String, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public UUID addPaymentMethod(final Account account, final String paymentMethodExternalKey, final String pluginName, final boolean setDefault, final PaymentMethodPlugin paymentMethodInfo, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("addPaymentMethod(org.killbill.billing.account.api.Account, java.lang.String, java.lang.String, boolean, org.killbill.billing.payment.api.PaymentMethodPlugin, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void setDefaultPaymentMethod(final Account account, final UUID paymentMethodId, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("setDefaultPaymentMethod(org.killbill.billing.account.api.Account, java.util.UUID, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void cancelScheduledPaymentTransaction(final String paymentTransactionExternalKey, final CallContext context) {
+        throw new UnsupportedOperationException("cancelScheduledPaymentTransaction(java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment createCredit(final Account account, final UUID paymentMethodId, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentExternalKey, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("createCredit(org.killbill.billing.account.api.Account, java.util.UUID, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment createAuthorization(final Account account, final UUID paymentMethodId, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentExternalKey, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("createAuthorization(org.killbill.billing.account.api.Account, java.util.UUID, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<PaymentMethod> getPaymentMethods(final Long offset, final Long limit, final boolean withPluginInfo, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentMethods(java.lang.Long, java.lang.Long, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createVoid(final Account account, final UUID paymentId, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("createVoid(org.killbill.billing.account.api.Account, java.util.UUID, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<PaymentMethod> searchPaymentMethods(final String searchKey, final Long offset, final Long limit, final boolean withPluginInfo, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("searchPaymentMethods(java.lang.String, java.lang.Long, java.lang.Long, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void deletePaymentMethod(final Account account, final UUID paymentMethodId, final boolean deleteDefaultPaymentMethodWithAutoPayOff, final boolean forceDefaultPaymentMethodDeletion, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("deletePaymentMethod(org.killbill.billing.account.api.Account, java.util.UUID, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment getPaymentByTransactionId(final UUID transactionId, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentByTransactionId(java.util.UUID, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createAuthorizationWithPaymentControl(final Account account, final UUID paymentMethodId, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentExternalKey, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createAuthorizationWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<Payment> getAccountPayments(final UUID accountId, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccountPayments(java.util.UUID, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Payment> searchPayments(final String searchKey, final Long offset, final Long limit, final String pluginName, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("searchPayments(java.lang.String, java.lang.Long, java.lang.Long, java.lang.String, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createRefund(final Account account, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("createRefund(org.killbill.billing.account.api.Account, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment notifyPendingTransactionOfStateChangedWithPaymentControl(final Account account, final UUID paymentTransactionId, final boolean isSuccess, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("notifyPendingTransactionOfStateChangedWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, boolean, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment createChargebackReversal(final Account account, final UUID paymentId, final DateTime effectiveDate, final String paymentTransactionExternalKey, final CallContext context) {
+        throw new UnsupportedOperationException("createChargebackReversal(org.killbill.billing.account.api.Account, java.util.UUID, org.joda.time.DateTime, java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<PaymentMethod> getAccountPaymentMethods(final UUID accountId, final boolean includedInactive, final boolean withPluginInfo, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccountPaymentMethods(java.util.UUID, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Payment> getPayments(final Long offset, final Long limit, final boolean withPluginInfo, final boolean withAttempts, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPayments(java.lang.Long, java.lang.Long, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createChargebackReversalWithPaymentControl(final Account account, final UUID paymentId, final DateTime effectiveDate, final String paymentTransactionExternalKey, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createChargebackReversalWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, org.joda.time.DateTime, java.lang.String, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Payment createCaptureWithPaymentControl(final Account account, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createCaptureWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public PaymentMethod getPaymentMethodById(final UUID paymentMethodId, final boolean includedInactive, final boolean withPluginInfo, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getPaymentMethodById(java.util.UUID, boolean, boolean, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Payment createPurchaseWithPaymentControl(final Account account, final UUID paymentMethodId, final UUID paymentId, final BigDecimal amount, final Currency currency, final DateTime effectiveDate, final String paymentExternalKey, final String paymentTransactionExternalKey, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("createPurchaseWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, java.util.UUID, java.math.BigDecimal, org.killbill.billing.catalog.api.Currency, org.joda.time.DateTime, java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentApiImp that = (PaymentApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final PaymentApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentApiImp build() {
+            return new PaymentApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentAttemptImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentAttemptImp.java
@@ -1,0 +1,405 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.PaymentAttempt;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.api.TransactionType;
+
+@JsonDeserialize( builder = PaymentAttemptImp.Builder.class )
+public class PaymentAttemptImp implements PaymentAttempt, Serializable {
+
+    private static final long serialVersionUID = 0x6754E4EB5E9F551L;
+
+    protected UUID accountId;
+    protected BigDecimal amount;
+    protected DateTime createdDate;
+    protected Currency currency;
+    protected DateTime effectiveDate;
+    protected UUID id;
+    protected String paymentExternalKey;
+    protected UUID paymentMethodId;
+    protected String pluginName;
+    protected List<PluginProperty> pluginProperties;
+    protected String stateName;
+    protected String transactionExternalKey;
+    protected UUID transactionId;
+    protected TransactionType transactionType;
+    protected DateTime updatedDate;
+
+    public PaymentAttemptImp(final PaymentAttemptImp that) {
+        this.accountId = that.accountId;
+        this.amount = that.amount;
+        this.createdDate = that.createdDate;
+        this.currency = that.currency;
+        this.effectiveDate = that.effectiveDate;
+        this.id = that.id;
+        this.paymentExternalKey = that.paymentExternalKey;
+        this.paymentMethodId = that.paymentMethodId;
+        this.pluginName = that.pluginName;
+        this.pluginProperties = that.pluginProperties;
+        this.stateName = that.stateName;
+        this.transactionExternalKey = that.transactionExternalKey;
+        this.transactionId = that.transactionId;
+        this.transactionType = that.transactionType;
+        this.updatedDate = that.updatedDate;
+    }
+    protected PaymentAttemptImp(final PaymentAttemptImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.amount = builder.amount;
+        this.createdDate = builder.createdDate;
+        this.currency = builder.currency;
+        this.effectiveDate = builder.effectiveDate;
+        this.id = builder.id;
+        this.paymentExternalKey = builder.paymentExternalKey;
+        this.paymentMethodId = builder.paymentMethodId;
+        this.pluginName = builder.pluginName;
+        this.pluginProperties = builder.pluginProperties;
+        this.stateName = builder.stateName;
+        this.transactionExternalKey = builder.transactionExternalKey;
+        this.transactionId = builder.transactionId;
+        this.transactionType = builder.transactionType;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected PaymentAttemptImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public BigDecimal getAmount() {
+        return this.amount;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public DateTime getEffectiveDate() {
+        return this.effectiveDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public String getPaymentExternalKey() {
+        return this.paymentExternalKey;
+    }
+    @Override
+    public UUID getPaymentMethodId() {
+        return this.paymentMethodId;
+    }
+    @Override
+    public String getPluginName() {
+        return this.pluginName;
+    }
+    @Override
+    public List<PluginProperty> getPluginProperties() {
+        return this.pluginProperties;
+    }
+    @Override
+    public String getStateName() {
+        return this.stateName;
+    }
+    @Override
+    public String getTransactionExternalKey() {
+        return this.transactionExternalKey;
+    }
+    @Override
+    public UUID getTransactionId() {
+        return this.transactionId;
+    }
+    @Override
+    public TransactionType getTransactionType() {
+        return this.transactionType;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentAttemptImp that = (PaymentAttemptImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.amount != null ) ? ( 0 != this.amount.compareTo(that.amount) ) : ( that.amount != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( ( this.effectiveDate != null ) ? ( 0 != this.effectiveDate.compareTo(that.effectiveDate) ) : ( that.effectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentExternalKey, that.paymentExternalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentMethodId, that.paymentMethodId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginName, that.pluginName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginProperties, that.pluginProperties) ) {
+            return false;
+        }
+        if( !Objects.equals(this.stateName, that.stateName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.transactionExternalKey, that.transactionExternalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.transactionId, that.transactionId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.transactionType, that.transactionType) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentExternalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentMethodId);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginName);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginProperties);
+        result = ( 31 * result ) + Objects.hashCode(this.stateName);
+        result = ( 31 * result ) + Objects.hashCode(this.transactionExternalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.transactionId);
+        result = ( 31 * result ) + Objects.hashCode(this.transactionType);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("paymentExternalKey=");
+        if( this.paymentExternalKey == null ) {
+            sb.append(this.paymentExternalKey);
+        }else{
+            sb.append("'").append(this.paymentExternalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("paymentMethodId=").append(this.paymentMethodId);
+        sb.append(", ");
+        sb.append("pluginName=");
+        if( this.pluginName == null ) {
+            sb.append(this.pluginName);
+        }else{
+            sb.append("'").append(this.pluginName).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginProperties=").append(this.pluginProperties);
+        sb.append(", ");
+        sb.append("stateName=");
+        if( this.stateName == null ) {
+            sb.append(this.stateName);
+        }else{
+            sb.append("'").append(this.stateName).append("'");
+        }
+        sb.append(", ");
+        sb.append("transactionExternalKey=");
+        if( this.transactionExternalKey == null ) {
+            sb.append(this.transactionExternalKey);
+        }else{
+            sb.append("'").append(this.transactionExternalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("transactionId=").append(this.transactionId);
+        sb.append(", ");
+        sb.append("transactionType=").append(this.transactionType);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentAttemptImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected BigDecimal amount;
+        protected DateTime createdDate;
+        protected Currency currency;
+        protected DateTime effectiveDate;
+        protected UUID id;
+        protected String paymentExternalKey;
+        protected UUID paymentMethodId;
+        protected String pluginName;
+        protected List<PluginProperty> pluginProperties;
+        protected String stateName;
+        protected String transactionExternalKey;
+        protected UUID transactionId;
+        protected TransactionType transactionType;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.amount = that.amount;
+            this.createdDate = that.createdDate;
+            this.currency = that.currency;
+            this.effectiveDate = that.effectiveDate;
+            this.id = that.id;
+            this.paymentExternalKey = that.paymentExternalKey;
+            this.paymentMethodId = that.paymentMethodId;
+            this.pluginName = that.pluginName;
+            this.pluginProperties = that.pluginProperties;
+            this.stateName = that.stateName;
+            this.transactionExternalKey = that.transactionExternalKey;
+            this.transactionId = that.transactionId;
+            this.transactionType = that.transactionType;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withAmount(final BigDecimal amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withEffectiveDate(final DateTime effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withPaymentExternalKey(final String paymentExternalKey) {
+            this.paymentExternalKey = paymentExternalKey;
+            return (T) this;
+        }
+        public T withPaymentMethodId(final UUID paymentMethodId) {
+            this.paymentMethodId = paymentMethodId;
+            return (T) this;
+        }
+        public T withPluginName(final String pluginName) {
+            this.pluginName = pluginName;
+            return (T) this;
+        }
+        public T withPluginProperties(final List<PluginProperty> pluginProperties) {
+            this.pluginProperties = pluginProperties;
+            return (T) this;
+        }
+        public T withStateName(final String stateName) {
+            this.stateName = stateName;
+            return (T) this;
+        }
+        public T withTransactionExternalKey(final String transactionExternalKey) {
+            this.transactionExternalKey = transactionExternalKey;
+            return (T) this;
+        }
+        public T withTransactionId(final UUID transactionId) {
+            this.transactionId = transactionId;
+            return (T) this;
+        }
+        public T withTransactionType(final TransactionType transactionType) {
+            this.transactionType = transactionType;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final PaymentAttempt that) {
+            this.accountId = that.getAccountId();
+            this.amount = that.getAmount();
+            this.createdDate = that.getCreatedDate();
+            this.currency = that.getCurrency();
+            this.effectiveDate = that.getEffectiveDate();
+            this.id = that.getId();
+            this.paymentExternalKey = that.getPaymentExternalKey();
+            this.paymentMethodId = that.getPaymentMethodId();
+            this.pluginName = that.getPluginName();
+            this.pluginProperties = that.getPluginProperties();
+            this.stateName = that.getStateName();
+            this.transactionExternalKey = that.getTransactionExternalKey();
+            this.transactionId = that.getTransactionId();
+            this.transactionType = that.getTransactionType();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentAttemptImp build() {
+            return new PaymentAttemptImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentGatewayApiImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentGatewayApiImp.java
@@ -1,0 +1,103 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.payment.api.PaymentApiException;
+import org.killbill.billing.payment.api.PaymentGatewayApi;
+import org.killbill.billing.payment.api.PaymentOptions;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.plugin.api.GatewayNotification;
+import org.killbill.billing.payment.plugin.api.HostedPaymentPageFormDescriptor;
+import org.killbill.billing.util.callcontext.CallContext;
+
+@JsonDeserialize( builder = PaymentGatewayApiImp.Builder.class )
+public class PaymentGatewayApiImp implements PaymentGatewayApi, Serializable {
+
+    private static final long serialVersionUID = 0x87B5E31851B496F9L;
+
+
+    public PaymentGatewayApiImp(final PaymentGatewayApiImp that) {
+    }
+    protected PaymentGatewayApiImp(final PaymentGatewayApiImp.Builder<?> builder) {
+    }
+    protected PaymentGatewayApiImp() { }
+    @Override
+    public GatewayNotification processNotification(final String notification, final String pluginName, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("processNotification(java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public HostedPaymentPageFormDescriptor buildFormDescriptor(final Account account, final UUID paymentMethodId, final Iterable<PluginProperty> customFields, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("buildFormDescriptor(org.killbill.billing.account.api.Account, java.util.UUID, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public HostedPaymentPageFormDescriptor buildFormDescriptorWithPaymentControl(final Account account, final UUID paymentMethodId, final Iterable<PluginProperty> customFields, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("buildFormDescriptorWithPaymentControl(org.killbill.billing.account.api.Account, java.util.UUID, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public GatewayNotification processNotificationWithPaymentControl(final String notification, final String pluginName, final Iterable<PluginProperty> properties, final PaymentOptions paymentOptions, final CallContext context) {
+        throw new UnsupportedOperationException("processNotificationWithPaymentControl(java.lang.String, java.lang.String, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.payment.api.PaymentOptions, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentGatewayApiImp that = (PaymentGatewayApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentGatewayApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final PaymentGatewayApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentGatewayApiImp build() {
+            return new PaymentGatewayApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentImp.java
@@ -1,0 +1,411 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.Payment;
+import org.killbill.billing.payment.api.PaymentAttempt;
+import org.killbill.billing.payment.api.PaymentTransaction;
+
+@JsonDeserialize( builder = PaymentImp.Builder.class )
+public class PaymentImp implements Payment, Serializable {
+
+    private static final long serialVersionUID = 0x7D2CBDE629F0CD4FL;
+
+    protected UUID accountId;
+    protected BigDecimal authAmount;
+    protected BigDecimal capturedAmount;
+    protected DateTime createdDate;
+    protected BigDecimal creditedAmount;
+    protected Currency currency;
+    protected String externalKey;
+    protected UUID id;
+    protected Boolean isAuthVoided;
+    protected List<PaymentAttempt> paymentAttempts;
+    protected UUID paymentMethodId;
+    protected Integer paymentNumber;
+    protected BigDecimal purchasedAmount;
+    protected BigDecimal refundedAmount;
+    protected List<PaymentTransaction> transactions;
+    protected DateTime updatedDate;
+
+    public PaymentImp(final PaymentImp that) {
+        this.accountId = that.accountId;
+        this.authAmount = that.authAmount;
+        this.capturedAmount = that.capturedAmount;
+        this.createdDate = that.createdDate;
+        this.creditedAmount = that.creditedAmount;
+        this.currency = that.currency;
+        this.externalKey = that.externalKey;
+        this.id = that.id;
+        this.isAuthVoided = that.isAuthVoided;
+        this.paymentAttempts = that.paymentAttempts;
+        this.paymentMethodId = that.paymentMethodId;
+        this.paymentNumber = that.paymentNumber;
+        this.purchasedAmount = that.purchasedAmount;
+        this.refundedAmount = that.refundedAmount;
+        this.transactions = that.transactions;
+        this.updatedDate = that.updatedDate;
+    }
+    protected PaymentImp(final PaymentImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.authAmount = builder.authAmount;
+        this.capturedAmount = builder.capturedAmount;
+        this.createdDate = builder.createdDate;
+        this.creditedAmount = builder.creditedAmount;
+        this.currency = builder.currency;
+        this.externalKey = builder.externalKey;
+        this.id = builder.id;
+        this.isAuthVoided = builder.isAuthVoided;
+        this.paymentAttempts = builder.paymentAttempts;
+        this.paymentMethodId = builder.paymentMethodId;
+        this.paymentNumber = builder.paymentNumber;
+        this.purchasedAmount = builder.purchasedAmount;
+        this.refundedAmount = builder.refundedAmount;
+        this.transactions = builder.transactions;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected PaymentImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public BigDecimal getAuthAmount() {
+        return this.authAmount;
+    }
+    @Override
+    public BigDecimal getCapturedAmount() {
+        return this.capturedAmount;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public BigDecimal getCreditedAmount() {
+        return this.creditedAmount;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    @JsonGetter("isAuthVoided")
+    public Boolean isAuthVoided() {
+        return this.isAuthVoided;
+    }
+    @Override
+    public List<PaymentAttempt> getPaymentAttempts() {
+        return this.paymentAttempts;
+    }
+    @Override
+    public UUID getPaymentMethodId() {
+        return this.paymentMethodId;
+    }
+    @Override
+    public Integer getPaymentNumber() {
+        return this.paymentNumber;
+    }
+    @Override
+    public BigDecimal getPurchasedAmount() {
+        return this.purchasedAmount;
+    }
+    @Override
+    public BigDecimal getRefundedAmount() {
+        return this.refundedAmount;
+    }
+    @Override
+    public List<PaymentTransaction> getTransactions() {
+        return this.transactions;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentImp that = (PaymentImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.authAmount != null ) ? ( 0 != this.authAmount.compareTo(that.authAmount) ) : ( that.authAmount != null ) ) {
+            return false;
+        }
+        if( ( this.capturedAmount != null ) ? ( 0 != this.capturedAmount.compareTo(that.capturedAmount) ) : ( that.capturedAmount != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( ( this.creditedAmount != null ) ? ( 0 != this.creditedAmount.compareTo(that.creditedAmount) ) : ( that.creditedAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isAuthVoided, that.isAuthVoided) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentAttempts, that.paymentAttempts) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentMethodId, that.paymentMethodId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentNumber, that.paymentNumber) ) {
+            return false;
+        }
+        if( ( this.purchasedAmount != null ) ? ( 0 != this.purchasedAmount.compareTo(that.purchasedAmount) ) : ( that.purchasedAmount != null ) ) {
+            return false;
+        }
+        if( ( this.refundedAmount != null ) ? ( 0 != this.refundedAmount.compareTo(that.refundedAmount) ) : ( that.refundedAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.transactions, that.transactions) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.authAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.capturedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.creditedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.isAuthVoided);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentAttempts);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentMethodId);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentNumber);
+        result = ( 31 * result ) + Objects.hashCode(this.purchasedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.refundedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.transactions);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("authAmount=").append(this.authAmount);
+        sb.append(", ");
+        sb.append("capturedAmount=").append(this.capturedAmount);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("creditedAmount=").append(this.creditedAmount);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("isAuthVoided=").append(this.isAuthVoided);
+        sb.append(", ");
+        sb.append("paymentAttempts=").append(this.paymentAttempts);
+        sb.append(", ");
+        sb.append("paymentMethodId=").append(this.paymentMethodId);
+        sb.append(", ");
+        sb.append("paymentNumber=").append(this.paymentNumber);
+        sb.append(", ");
+        sb.append("purchasedAmount=").append(this.purchasedAmount);
+        sb.append(", ");
+        sb.append("refundedAmount=").append(this.refundedAmount);
+        sb.append(", ");
+        sb.append("transactions=").append(this.transactions);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected BigDecimal authAmount;
+        protected BigDecimal capturedAmount;
+        protected DateTime createdDate;
+        protected BigDecimal creditedAmount;
+        protected Currency currency;
+        protected String externalKey;
+        protected UUID id;
+        protected Boolean isAuthVoided;
+        protected List<PaymentAttempt> paymentAttempts;
+        protected UUID paymentMethodId;
+        protected Integer paymentNumber;
+        protected BigDecimal purchasedAmount;
+        protected BigDecimal refundedAmount;
+        protected List<PaymentTransaction> transactions;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.authAmount = that.authAmount;
+            this.capturedAmount = that.capturedAmount;
+            this.createdDate = that.createdDate;
+            this.creditedAmount = that.creditedAmount;
+            this.currency = that.currency;
+            this.externalKey = that.externalKey;
+            this.id = that.id;
+            this.isAuthVoided = that.isAuthVoided;
+            this.paymentAttempts = that.paymentAttempts;
+            this.paymentMethodId = that.paymentMethodId;
+            this.paymentNumber = that.paymentNumber;
+            this.purchasedAmount = that.purchasedAmount;
+            this.refundedAmount = that.refundedAmount;
+            this.transactions = that.transactions;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withAuthAmount(final BigDecimal authAmount) {
+            this.authAmount = authAmount;
+            return (T) this;
+        }
+        public T withCapturedAmount(final BigDecimal capturedAmount) {
+            this.capturedAmount = capturedAmount;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCreditedAmount(final BigDecimal creditedAmount) {
+            this.creditedAmount = creditedAmount;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withIsAuthVoided(final Boolean isAuthVoided) {
+            this.isAuthVoided = isAuthVoided;
+            return (T) this;
+        }
+        public T withPaymentAttempts(final List<PaymentAttempt> paymentAttempts) {
+            this.paymentAttempts = paymentAttempts;
+            return (T) this;
+        }
+        public T withPaymentMethodId(final UUID paymentMethodId) {
+            this.paymentMethodId = paymentMethodId;
+            return (T) this;
+        }
+        public T withPaymentNumber(final Integer paymentNumber) {
+            this.paymentNumber = paymentNumber;
+            return (T) this;
+        }
+        public T withPurchasedAmount(final BigDecimal purchasedAmount) {
+            this.purchasedAmount = purchasedAmount;
+            return (T) this;
+        }
+        public T withRefundedAmount(final BigDecimal refundedAmount) {
+            this.refundedAmount = refundedAmount;
+            return (T) this;
+        }
+        public T withTransactions(final List<PaymentTransaction> transactions) {
+            this.transactions = transactions;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Payment that) {
+            this.accountId = that.getAccountId();
+            this.authAmount = that.getAuthAmount();
+            this.capturedAmount = that.getCapturedAmount();
+            this.createdDate = that.getCreatedDate();
+            this.creditedAmount = that.getCreditedAmount();
+            this.currency = that.getCurrency();
+            this.externalKey = that.getExternalKey();
+            this.id = that.getId();
+            this.isAuthVoided = that.isAuthVoided();
+            this.paymentAttempts = that.getPaymentAttempts();
+            this.paymentMethodId = that.getPaymentMethodId();
+            this.paymentNumber = that.getPaymentNumber();
+            this.purchasedAmount = that.getPurchasedAmount();
+            this.refundedAmount = that.getRefundedAmount();
+            this.transactions = that.getTransactions();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentImp build() {
+            return new PaymentImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentMethodImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentMethodImp.java
@@ -1,0 +1,252 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.payment.api.PaymentMethod;
+import org.killbill.billing.payment.api.PaymentMethodPlugin;
+
+@JsonDeserialize( builder = PaymentMethodImp.Builder.class )
+public class PaymentMethodImp implements PaymentMethod, Serializable {
+
+    private static final long serialVersionUID = 0x56F76B45BF91919BL;
+
+    protected UUID accountId;
+    protected DateTime createdDate;
+    protected String externalKey;
+    protected UUID id;
+    protected Boolean isActive;
+    protected PaymentMethodPlugin pluginDetail;
+    protected String pluginName;
+    protected DateTime updatedDate;
+
+    public PaymentMethodImp(final PaymentMethodImp that) {
+        this.accountId = that.accountId;
+        this.createdDate = that.createdDate;
+        this.externalKey = that.externalKey;
+        this.id = that.id;
+        this.isActive = that.isActive;
+        this.pluginDetail = that.pluginDetail;
+        this.pluginName = that.pluginName;
+        this.updatedDate = that.updatedDate;
+    }
+    protected PaymentMethodImp(final PaymentMethodImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.createdDate = builder.createdDate;
+        this.externalKey = builder.externalKey;
+        this.id = builder.id;
+        this.isActive = builder.isActive;
+        this.pluginDetail = builder.pluginDetail;
+        this.pluginName = builder.pluginName;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected PaymentMethodImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    @JsonGetter("isActive")
+    public Boolean isActive() {
+        return this.isActive;
+    }
+    @Override
+    public PaymentMethodPlugin getPluginDetail() {
+        return this.pluginDetail;
+    }
+    @Override
+    public String getPluginName() {
+        return this.pluginName;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentMethodImp that = (PaymentMethodImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isActive, that.isActive) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginDetail, that.pluginDetail) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginName, that.pluginName) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.isActive);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginDetail);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginName);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("isActive=").append(this.isActive);
+        sb.append(", ");
+        sb.append("pluginDetail=").append(this.pluginDetail);
+        sb.append(", ");
+        sb.append("pluginName=");
+        if( this.pluginName == null ) {
+            sb.append(this.pluginName);
+        }else{
+            sb.append("'").append(this.pluginName).append("'");
+        }
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentMethodImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected DateTime createdDate;
+        protected String externalKey;
+        protected UUID id;
+        protected Boolean isActive;
+        protected PaymentMethodPlugin pluginDetail;
+        protected String pluginName;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.createdDate = that.createdDate;
+            this.externalKey = that.externalKey;
+            this.id = that.id;
+            this.isActive = that.isActive;
+            this.pluginDetail = that.pluginDetail;
+            this.pluginName = that.pluginName;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withIsActive(final Boolean isActive) {
+            this.isActive = isActive;
+            return (T) this;
+        }
+        public T withPluginDetail(final PaymentMethodPlugin pluginDetail) {
+            this.pluginDetail = pluginDetail;
+            return (T) this;
+        }
+        public T withPluginName(final String pluginName) {
+            this.pluginName = pluginName;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final PaymentMethod that) {
+            this.accountId = that.getAccountId();
+            this.createdDate = that.getCreatedDate();
+            this.externalKey = that.getExternalKey();
+            this.id = that.getId();
+            this.isActive = that.isActive();
+            this.pluginDetail = that.getPluginDetail();
+            this.pluginName = that.getPluginName();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentMethodImp build() {
+            return new PaymentMethodImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentMethodPluginImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentMethodPluginImp.java
@@ -1,0 +1,167 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.payment.api.PaymentMethodPlugin;
+import org.killbill.billing.payment.api.PluginProperty;
+
+@JsonDeserialize( builder = PaymentMethodPluginImp.Builder.class )
+public class PaymentMethodPluginImp implements PaymentMethodPlugin, Serializable {
+
+    private static final long serialVersionUID = 0x42CEDE7E9AF09E20L;
+
+    protected String externalPaymentMethodId;
+    protected boolean isDefaultPaymentMethod;
+    protected UUID kbPaymentMethodId;
+    protected List<PluginProperty> properties;
+
+    public PaymentMethodPluginImp(final PaymentMethodPluginImp that) {
+        this.externalPaymentMethodId = that.externalPaymentMethodId;
+        this.isDefaultPaymentMethod = that.isDefaultPaymentMethod;
+        this.kbPaymentMethodId = that.kbPaymentMethodId;
+        this.properties = that.properties;
+    }
+    protected PaymentMethodPluginImp(final PaymentMethodPluginImp.Builder<?> builder) {
+        this.externalPaymentMethodId = builder.externalPaymentMethodId;
+        this.isDefaultPaymentMethod = builder.isDefaultPaymentMethod;
+        this.kbPaymentMethodId = builder.kbPaymentMethodId;
+        this.properties = builder.properties;
+    }
+    protected PaymentMethodPluginImp() { }
+    @Override
+    public String getExternalPaymentMethodId() {
+        return this.externalPaymentMethodId;
+    }
+    @Override
+    @JsonGetter("isDefaultPaymentMethod")
+    public boolean isDefaultPaymentMethod() {
+        return this.isDefaultPaymentMethod;
+    }
+    @Override
+    public UUID getKbPaymentMethodId() {
+        return this.kbPaymentMethodId;
+    }
+    @Override
+    public List<PluginProperty> getProperties() {
+        return this.properties;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentMethodPluginImp that = (PaymentMethodPluginImp) o;
+        if( !Objects.equals(this.externalPaymentMethodId, that.externalPaymentMethodId) ) {
+            return false;
+        }
+        if( this.isDefaultPaymentMethod != that.isDefaultPaymentMethod ) {
+            return false;
+        }
+        if( !Objects.equals(this.kbPaymentMethodId, that.kbPaymentMethodId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.properties, that.properties) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.externalPaymentMethodId);
+        result = ( 31 * result ) + Objects.hashCode(this.isDefaultPaymentMethod);
+        result = ( 31 * result ) + Objects.hashCode(this.kbPaymentMethodId);
+        result = ( 31 * result ) + Objects.hashCode(this.properties);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("externalPaymentMethodId=");
+        if( this.externalPaymentMethodId == null ) {
+            sb.append(this.externalPaymentMethodId);
+        }else{
+            sb.append("'").append(this.externalPaymentMethodId).append("'");
+        }
+        sb.append(", ");
+        sb.append("isDefaultPaymentMethod=").append(this.isDefaultPaymentMethod);
+        sb.append(", ");
+        sb.append("kbPaymentMethodId=").append(this.kbPaymentMethodId);
+        sb.append(", ");
+        sb.append("properties=").append(this.properties);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentMethodPluginImp.Builder<T>> {
+
+        protected String externalPaymentMethodId;
+        protected boolean isDefaultPaymentMethod;
+        protected UUID kbPaymentMethodId;
+        protected List<PluginProperty> properties;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.externalPaymentMethodId = that.externalPaymentMethodId;
+            this.isDefaultPaymentMethod = that.isDefaultPaymentMethod;
+            this.kbPaymentMethodId = that.kbPaymentMethodId;
+            this.properties = that.properties;
+        }
+        public T withExternalPaymentMethodId(final String externalPaymentMethodId) {
+            this.externalPaymentMethodId = externalPaymentMethodId;
+            return (T) this;
+        }
+        public T withIsDefaultPaymentMethod(final boolean isDefaultPaymentMethod) {
+            this.isDefaultPaymentMethod = isDefaultPaymentMethod;
+            return (T) this;
+        }
+        public T withKbPaymentMethodId(final UUID kbPaymentMethodId) {
+            this.kbPaymentMethodId = kbPaymentMethodId;
+            return (T) this;
+        }
+        public T withProperties(final List<PluginProperty> properties) {
+            this.properties = properties;
+            return (T) this;
+        }
+        public T source(final PaymentMethodPlugin that) {
+            this.externalPaymentMethodId = that.getExternalPaymentMethodId();
+            this.isDefaultPaymentMethod = that.isDefaultPaymentMethod();
+            this.kbPaymentMethodId = that.getKbPaymentMethodId();
+            this.properties = that.getProperties();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentMethodPluginImp build() {
+            return new PaymentMethodPluginImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentOptionsImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentOptionsImp.java
@@ -1,0 +1,120 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.payment.api.PaymentOptions;
+
+@JsonDeserialize( builder = PaymentOptionsImp.Builder.class )
+public class PaymentOptionsImp implements PaymentOptions, Serializable {
+
+    private static final long serialVersionUID = 0xE4101CDCE0CB5796L;
+
+    protected boolean isExternalPayment;
+    protected List<String> paymentControlPluginNames;
+
+    public PaymentOptionsImp(final PaymentOptionsImp that) {
+        this.isExternalPayment = that.isExternalPayment;
+        this.paymentControlPluginNames = that.paymentControlPluginNames;
+    }
+    protected PaymentOptionsImp(final PaymentOptionsImp.Builder<?> builder) {
+        this.isExternalPayment = builder.isExternalPayment;
+        this.paymentControlPluginNames = builder.paymentControlPluginNames;
+    }
+    protected PaymentOptionsImp() { }
+    @Override
+    @JsonGetter("isExternalPayment")
+    public boolean isExternalPayment() {
+        return this.isExternalPayment;
+    }
+    @Override
+    public List<String> getPaymentControlPluginNames() {
+        return this.paymentControlPluginNames;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentOptionsImp that = (PaymentOptionsImp) o;
+        if( this.isExternalPayment != that.isExternalPayment ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentControlPluginNames, that.paymentControlPluginNames) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.isExternalPayment);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentControlPluginNames);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("isExternalPayment=").append(this.isExternalPayment);
+        sb.append(", ");
+        sb.append("paymentControlPluginNames=").append(this.paymentControlPluginNames);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentOptionsImp.Builder<T>> {
+
+        protected boolean isExternalPayment;
+        protected List<String> paymentControlPluginNames;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.isExternalPayment = that.isExternalPayment;
+            this.paymentControlPluginNames = that.paymentControlPluginNames;
+        }
+        public T withIsExternalPayment(final boolean isExternalPayment) {
+            this.isExternalPayment = isExternalPayment;
+            return (T) this;
+        }
+        public T withPaymentControlPluginNames(final List<String> paymentControlPluginNames) {
+            this.paymentControlPluginNames = paymentControlPluginNames;
+            return (T) this;
+        }
+        public T source(final PaymentOptions that) {
+            this.isExternalPayment = that.isExternalPayment();
+            this.paymentControlPluginNames = that.getPaymentControlPluginNames();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentOptionsImp build() {
+            return new PaymentOptionsImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentTransactionImp.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/PaymentTransactionImp.java
@@ -1,0 +1,400 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.PaymentTransaction;
+import org.killbill.billing.payment.api.TransactionStatus;
+import org.killbill.billing.payment.api.TransactionType;
+import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+
+@JsonDeserialize( builder = PaymentTransactionImp.Builder.class )
+public class PaymentTransactionImp implements PaymentTransaction, Serializable {
+
+    private static final long serialVersionUID = 0x1B067DE9A179213FL;
+
+    protected BigDecimal amount;
+    protected DateTime createdDate;
+    protected Currency currency;
+    protected DateTime effectiveDate;
+    protected String externalKey;
+    protected String gatewayErrorCode;
+    protected String gatewayErrorMsg;
+    protected UUID id;
+    protected UUID paymentId;
+    protected PaymentTransactionInfoPlugin paymentInfoPlugin;
+    protected BigDecimal processedAmount;
+    protected Currency processedCurrency;
+    protected TransactionStatus transactionStatus;
+    protected TransactionType transactionType;
+    protected DateTime updatedDate;
+
+    public PaymentTransactionImp(final PaymentTransactionImp that) {
+        this.amount = that.amount;
+        this.createdDate = that.createdDate;
+        this.currency = that.currency;
+        this.effectiveDate = that.effectiveDate;
+        this.externalKey = that.externalKey;
+        this.gatewayErrorCode = that.gatewayErrorCode;
+        this.gatewayErrorMsg = that.gatewayErrorMsg;
+        this.id = that.id;
+        this.paymentId = that.paymentId;
+        this.paymentInfoPlugin = that.paymentInfoPlugin;
+        this.processedAmount = that.processedAmount;
+        this.processedCurrency = that.processedCurrency;
+        this.transactionStatus = that.transactionStatus;
+        this.transactionType = that.transactionType;
+        this.updatedDate = that.updatedDate;
+    }
+    protected PaymentTransactionImp(final PaymentTransactionImp.Builder<?> builder) {
+        this.amount = builder.amount;
+        this.createdDate = builder.createdDate;
+        this.currency = builder.currency;
+        this.effectiveDate = builder.effectiveDate;
+        this.externalKey = builder.externalKey;
+        this.gatewayErrorCode = builder.gatewayErrorCode;
+        this.gatewayErrorMsg = builder.gatewayErrorMsg;
+        this.id = builder.id;
+        this.paymentId = builder.paymentId;
+        this.paymentInfoPlugin = builder.paymentInfoPlugin;
+        this.processedAmount = builder.processedAmount;
+        this.processedCurrency = builder.processedCurrency;
+        this.transactionStatus = builder.transactionStatus;
+        this.transactionType = builder.transactionType;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected PaymentTransactionImp() { }
+    @Override
+    public BigDecimal getAmount() {
+        return this.amount;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public DateTime getEffectiveDate() {
+        return this.effectiveDate;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public String getGatewayErrorCode() {
+        return this.gatewayErrorCode;
+    }
+    @Override
+    public String getGatewayErrorMsg() {
+        return this.gatewayErrorMsg;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public UUID getPaymentId() {
+        return this.paymentId;
+    }
+    @Override
+    public PaymentTransactionInfoPlugin getPaymentInfoPlugin() {
+        return this.paymentInfoPlugin;
+    }
+    @Override
+    public BigDecimal getProcessedAmount() {
+        return this.processedAmount;
+    }
+    @Override
+    public Currency getProcessedCurrency() {
+        return this.processedCurrency;
+    }
+    @Override
+    public TransactionStatus getTransactionStatus() {
+        return this.transactionStatus;
+    }
+    @Override
+    public TransactionType getTransactionType() {
+        return this.transactionType;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentTransactionImp that = (PaymentTransactionImp) o;
+        if( ( this.amount != null ) ? ( 0 != this.amount.compareTo(that.amount) ) : ( that.amount != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( ( this.effectiveDate != null ) ? ( 0 != this.effectiveDate.compareTo(that.effectiveDate) ) : ( that.effectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.gatewayErrorCode, that.gatewayErrorCode) ) {
+            return false;
+        }
+        if( !Objects.equals(this.gatewayErrorMsg, that.gatewayErrorMsg) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentId, that.paymentId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.paymentInfoPlugin, that.paymentInfoPlugin) ) {
+            return false;
+        }
+        if( ( this.processedAmount != null ) ? ( 0 != this.processedAmount.compareTo(that.processedAmount) ) : ( that.processedAmount != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.processedCurrency, that.processedCurrency) ) {
+            return false;
+        }
+        if( !Objects.equals(this.transactionStatus, that.transactionStatus) ) {
+            return false;
+        }
+        if( !Objects.equals(this.transactionType, that.transactionType) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.gatewayErrorCode);
+        result = ( 31 * result ) + Objects.hashCode(this.gatewayErrorMsg);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentId);
+        result = ( 31 * result ) + Objects.hashCode(this.paymentInfoPlugin);
+        result = ( 31 * result ) + Objects.hashCode(this.processedAmount);
+        result = ( 31 * result ) + Objects.hashCode(this.processedCurrency);
+        result = ( 31 * result ) + Objects.hashCode(this.transactionStatus);
+        result = ( 31 * result ) + Objects.hashCode(this.transactionType);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("gatewayErrorCode=");
+        if( this.gatewayErrorCode == null ) {
+            sb.append(this.gatewayErrorCode);
+        }else{
+            sb.append("'").append(this.gatewayErrorCode).append("'");
+        }
+        sb.append(", ");
+        sb.append("gatewayErrorMsg=");
+        if( this.gatewayErrorMsg == null ) {
+            sb.append(this.gatewayErrorMsg);
+        }else{
+            sb.append("'").append(this.gatewayErrorMsg).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("paymentId=").append(this.paymentId);
+        sb.append(", ");
+        sb.append("paymentInfoPlugin=").append(this.paymentInfoPlugin);
+        sb.append(", ");
+        sb.append("processedAmount=").append(this.processedAmount);
+        sb.append(", ");
+        sb.append("processedCurrency=").append(this.processedCurrency);
+        sb.append(", ");
+        sb.append("transactionStatus=").append(this.transactionStatus);
+        sb.append(", ");
+        sb.append("transactionType=").append(this.transactionType);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentTransactionImp.Builder<T>> {
+
+        protected BigDecimal amount;
+        protected DateTime createdDate;
+        protected Currency currency;
+        protected DateTime effectiveDate;
+        protected String externalKey;
+        protected String gatewayErrorCode;
+        protected String gatewayErrorMsg;
+        protected UUID id;
+        protected UUID paymentId;
+        protected PaymentTransactionInfoPlugin paymentInfoPlugin;
+        protected BigDecimal processedAmount;
+        protected Currency processedCurrency;
+        protected TransactionStatus transactionStatus;
+        protected TransactionType transactionType;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.amount = that.amount;
+            this.createdDate = that.createdDate;
+            this.currency = that.currency;
+            this.effectiveDate = that.effectiveDate;
+            this.externalKey = that.externalKey;
+            this.gatewayErrorCode = that.gatewayErrorCode;
+            this.gatewayErrorMsg = that.gatewayErrorMsg;
+            this.id = that.id;
+            this.paymentId = that.paymentId;
+            this.paymentInfoPlugin = that.paymentInfoPlugin;
+            this.processedAmount = that.processedAmount;
+            this.processedCurrency = that.processedCurrency;
+            this.transactionStatus = that.transactionStatus;
+            this.transactionType = that.transactionType;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withAmount(final BigDecimal amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withEffectiveDate(final DateTime effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withGatewayErrorCode(final String gatewayErrorCode) {
+            this.gatewayErrorCode = gatewayErrorCode;
+            return (T) this;
+        }
+        public T withGatewayErrorMsg(final String gatewayErrorMsg) {
+            this.gatewayErrorMsg = gatewayErrorMsg;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withPaymentId(final UUID paymentId) {
+            this.paymentId = paymentId;
+            return (T) this;
+        }
+        public T withPaymentInfoPlugin(final PaymentTransactionInfoPlugin paymentInfoPlugin) {
+            this.paymentInfoPlugin = paymentInfoPlugin;
+            return (T) this;
+        }
+        public T withProcessedAmount(final BigDecimal processedAmount) {
+            this.processedAmount = processedAmount;
+            return (T) this;
+        }
+        public T withProcessedCurrency(final Currency processedCurrency) {
+            this.processedCurrency = processedCurrency;
+            return (T) this;
+        }
+        public T withTransactionStatus(final TransactionStatus transactionStatus) {
+            this.transactionStatus = transactionStatus;
+            return (T) this;
+        }
+        public T withTransactionType(final TransactionType transactionType) {
+            this.transactionType = transactionType;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final PaymentTransaction that) {
+            this.amount = that.getAmount();
+            this.createdDate = that.getCreatedDate();
+            this.currency = that.getCurrency();
+            this.effectiveDate = that.getEffectiveDate();
+            this.externalKey = that.getExternalKey();
+            this.gatewayErrorCode = that.getGatewayErrorCode();
+            this.gatewayErrorMsg = that.getGatewayErrorMsg();
+            this.id = that.getId();
+            this.paymentId = that.getPaymentId();
+            this.paymentInfoPlugin = that.getPaymentInfoPlugin();
+            this.processedAmount = that.getProcessedAmount();
+            this.processedCurrency = that.getProcessedCurrency();
+            this.transactionStatus = that.getTransactionStatus();
+            this.transactionType = that.getTransactionType();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentTransactionImp build() {
+            return new PaymentTransactionImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/payment/api/boilerplate/Resolver.java
@@ -1,0 +1,45 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.payment.api.AdminPaymentApi;
+import org.killbill.billing.payment.api.InvoicePaymentApi;
+import org.killbill.billing.payment.api.Payment;
+import org.killbill.billing.payment.api.PaymentApi;
+import org.killbill.billing.payment.api.PaymentAttempt;
+import org.killbill.billing.payment.api.PaymentGatewayApi;
+import org.killbill.billing.payment.api.PaymentMethod;
+import org.killbill.billing.payment.api.PaymentMethodPlugin;
+import org.killbill.billing.payment.api.PaymentOptions;
+import org.killbill.billing.payment.api.PaymentTransaction;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(AdminPaymentApi.class, AdminPaymentApiImp.class);
+        this.addMapping(InvoicePaymentApi.class, InvoicePaymentApiImp.class);
+        this.addMapping(PaymentApi.class, PaymentApiImp.class);
+        this.addMapping(PaymentAttempt.class, PaymentAttemptImp.class);
+        this.addMapping(PaymentGatewayApi.class, PaymentGatewayApiImp.class);
+        this.addMapping(Payment.class, PaymentImp.class);
+        this.addMapping(PaymentMethod.class, PaymentMethodImp.class);
+        this.addMapping(PaymentMethodPlugin.class, PaymentMethodPluginImp.class);
+        this.addMapping(PaymentOptions.class, PaymentOptionsImp.class);
+        this.addMapping(PaymentTransaction.class, PaymentTransactionImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/GatewayNotificationImp.java
+++ b/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/GatewayNotificationImp.java
@@ -1,0 +1,187 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.plugin.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.plugin.api.GatewayNotification;
+
+@JsonDeserialize( builder = GatewayNotificationImp.Builder.class )
+public class GatewayNotificationImp implements GatewayNotification, Serializable {
+
+    private static final long serialVersionUID = 0x4CAF1439F4E546C7L;
+
+    protected String entity;
+    protected Map<String, List<String>> headers;
+    protected UUID kbPaymentId;
+    protected List<PluginProperty> properties;
+    protected int status;
+
+    public GatewayNotificationImp(final GatewayNotificationImp that) {
+        this.entity = that.entity;
+        this.headers = that.headers;
+        this.kbPaymentId = that.kbPaymentId;
+        this.properties = that.properties;
+        this.status = that.status;
+    }
+    protected GatewayNotificationImp(final GatewayNotificationImp.Builder<?> builder) {
+        this.entity = builder.entity;
+        this.headers = builder.headers;
+        this.kbPaymentId = builder.kbPaymentId;
+        this.properties = builder.properties;
+        this.status = builder.status;
+    }
+    protected GatewayNotificationImp() { }
+    @Override
+    public String getEntity() {
+        return this.entity;
+    }
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return this.headers;
+    }
+    @Override
+    public UUID getKbPaymentId() {
+        return this.kbPaymentId;
+    }
+    @Override
+    public List<PluginProperty> getProperties() {
+        return this.properties;
+    }
+    @Override
+    public int getStatus() {
+        return this.status;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final GatewayNotificationImp that = (GatewayNotificationImp) o;
+        if( !Objects.equals(this.entity, that.entity) ) {
+            return false;
+        }
+        if( !Objects.equals(this.headers, that.headers) ) {
+            return false;
+        }
+        if( !Objects.equals(this.kbPaymentId, that.kbPaymentId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.properties, that.properties) ) {
+            return false;
+        }
+        if( this.status != that.status ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.entity);
+        result = ( 31 * result ) + Objects.hashCode(this.headers);
+        result = ( 31 * result ) + Objects.hashCode(this.kbPaymentId);
+        result = ( 31 * result ) + Objects.hashCode(this.properties);
+        result = ( 31 * result ) + Objects.hashCode(this.status);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("entity=");
+        if( this.entity == null ) {
+            sb.append(this.entity);
+        }else{
+            sb.append("'").append(this.entity).append("'");
+        }
+        sb.append(", ");
+        sb.append("headers=").append(this.headers);
+        sb.append(", ");
+        sb.append("kbPaymentId=").append(this.kbPaymentId);
+        sb.append(", ");
+        sb.append("properties=").append(this.properties);
+        sb.append(", ");
+        sb.append("status=").append(this.status);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends GatewayNotificationImp.Builder<T>> {
+
+        protected String entity;
+        protected Map<String, List<String>> headers;
+        protected UUID kbPaymentId;
+        protected List<PluginProperty> properties;
+        protected int status;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.entity = that.entity;
+            this.headers = that.headers;
+            this.kbPaymentId = that.kbPaymentId;
+            this.properties = that.properties;
+            this.status = that.status;
+        }
+        public T withEntity(final String entity) {
+            this.entity = entity;
+            return (T) this;
+        }
+        public T withHeaders(final Map<String, List<String>> headers) {
+            this.headers = headers;
+            return (T) this;
+        }
+        public T withKbPaymentId(final UUID kbPaymentId) {
+            this.kbPaymentId = kbPaymentId;
+            return (T) this;
+        }
+        public T withProperties(final List<PluginProperty> properties) {
+            this.properties = properties;
+            return (T) this;
+        }
+        public T withStatus(final int status) {
+            this.status = status;
+            return (T) this;
+        }
+        public T source(final GatewayNotification that) {
+            this.entity = that.getEntity();
+            this.headers = that.getHeaders();
+            this.kbPaymentId = that.getKbPaymentId();
+            this.properties = that.getProperties();
+            this.status = that.getStatus();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public GatewayNotificationImp build() {
+            return new GatewayNotificationImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/HostedPaymentPageFormDescriptorImp.java
+++ b/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/HostedPaymentPageFormDescriptorImp.java
@@ -1,0 +1,191 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.plugin.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.plugin.api.HostedPaymentPageFormDescriptor;
+
+@JsonDeserialize( builder = HostedPaymentPageFormDescriptorImp.Builder.class )
+public class HostedPaymentPageFormDescriptorImp implements HostedPaymentPageFormDescriptor, Serializable {
+
+    private static final long serialVersionUID = 0xB11ACD0862E725EBL;
+
+    protected List<PluginProperty> formFields;
+    protected String formMethod;
+    protected String formUrl;
+    protected UUID kbAccountId;
+    protected List<PluginProperty> properties;
+
+    public HostedPaymentPageFormDescriptorImp(final HostedPaymentPageFormDescriptorImp that) {
+        this.formFields = that.formFields;
+        this.formMethod = that.formMethod;
+        this.formUrl = that.formUrl;
+        this.kbAccountId = that.kbAccountId;
+        this.properties = that.properties;
+    }
+    protected HostedPaymentPageFormDescriptorImp(final HostedPaymentPageFormDescriptorImp.Builder<?> builder) {
+        this.formFields = builder.formFields;
+        this.formMethod = builder.formMethod;
+        this.formUrl = builder.formUrl;
+        this.kbAccountId = builder.kbAccountId;
+        this.properties = builder.properties;
+    }
+    protected HostedPaymentPageFormDescriptorImp() { }
+    @Override
+    public List<PluginProperty> getFormFields() {
+        return this.formFields;
+    }
+    @Override
+    public String getFormMethod() {
+        return this.formMethod;
+    }
+    @Override
+    public String getFormUrl() {
+        return this.formUrl;
+    }
+    @Override
+    public UUID getKbAccountId() {
+        return this.kbAccountId;
+    }
+    @Override
+    public List<PluginProperty> getProperties() {
+        return this.properties;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final HostedPaymentPageFormDescriptorImp that = (HostedPaymentPageFormDescriptorImp) o;
+        if( !Objects.equals(this.formFields, that.formFields) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formMethod, that.formMethod) ) {
+            return false;
+        }
+        if( !Objects.equals(this.formUrl, that.formUrl) ) {
+            return false;
+        }
+        if( !Objects.equals(this.kbAccountId, that.kbAccountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.properties, that.properties) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.formFields);
+        result = ( 31 * result ) + Objects.hashCode(this.formMethod);
+        result = ( 31 * result ) + Objects.hashCode(this.formUrl);
+        result = ( 31 * result ) + Objects.hashCode(this.kbAccountId);
+        result = ( 31 * result ) + Objects.hashCode(this.properties);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("formFields=").append(this.formFields);
+        sb.append(", ");
+        sb.append("formMethod=");
+        if( this.formMethod == null ) {
+            sb.append(this.formMethod);
+        }else{
+            sb.append("'").append(this.formMethod).append("'");
+        }
+        sb.append(", ");
+        sb.append("formUrl=");
+        if( this.formUrl == null ) {
+            sb.append(this.formUrl);
+        }else{
+            sb.append("'").append(this.formUrl).append("'");
+        }
+        sb.append(", ");
+        sb.append("kbAccountId=").append(this.kbAccountId);
+        sb.append(", ");
+        sb.append("properties=").append(this.properties);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends HostedPaymentPageFormDescriptorImp.Builder<T>> {
+
+        protected List<PluginProperty> formFields;
+        protected String formMethod;
+        protected String formUrl;
+        protected UUID kbAccountId;
+        protected List<PluginProperty> properties;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.formFields = that.formFields;
+            this.formMethod = that.formMethod;
+            this.formUrl = that.formUrl;
+            this.kbAccountId = that.kbAccountId;
+            this.properties = that.properties;
+        }
+        public T withFormFields(final List<PluginProperty> formFields) {
+            this.formFields = formFields;
+            return (T) this;
+        }
+        public T withFormMethod(final String formMethod) {
+            this.formMethod = formMethod;
+            return (T) this;
+        }
+        public T withFormUrl(final String formUrl) {
+            this.formUrl = formUrl;
+            return (T) this;
+        }
+        public T withKbAccountId(final UUID kbAccountId) {
+            this.kbAccountId = kbAccountId;
+            return (T) this;
+        }
+        public T withProperties(final List<PluginProperty> properties) {
+            this.properties = properties;
+            return (T) this;
+        }
+        public T source(final HostedPaymentPageFormDescriptor that) {
+            this.formFields = that.getFormFields();
+            this.formMethod = that.getFormMethod();
+            this.formUrl = that.getFormUrl();
+            this.kbAccountId = that.getKbAccountId();
+            this.properties = that.getProperties();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public HostedPaymentPageFormDescriptorImp build() {
+            return new HostedPaymentPageFormDescriptorImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.plugin.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.payment.plugin.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/PaymentTransactionInfoPluginImp.java
+++ b/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/PaymentTransactionInfoPluginImp.java
@@ -1,0 +1,366 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.plugin.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.api.TransactionType;
+import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
+import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+
+@JsonDeserialize( builder = PaymentTransactionInfoPluginImp.Builder.class )
+public class PaymentTransactionInfoPluginImp implements PaymentTransactionInfoPlugin, Serializable {
+
+    private static final long serialVersionUID = 0x292A311E7FCC3204L;
+
+    protected BigDecimal amount;
+    protected DateTime createdDate;
+    protected Currency currency;
+    protected DateTime effectiveDate;
+    protected String firstPaymentReferenceId;
+    protected String gatewayError;
+    protected String gatewayErrorCode;
+    protected UUID kbPaymentId;
+    protected UUID kbTransactionPaymentId;
+    protected List<PluginProperty> properties;
+    protected String secondPaymentReferenceId;
+    protected PaymentPluginStatus status;
+    protected TransactionType transactionType;
+
+    public PaymentTransactionInfoPluginImp(final PaymentTransactionInfoPluginImp that) {
+        this.amount = that.amount;
+        this.createdDate = that.createdDate;
+        this.currency = that.currency;
+        this.effectiveDate = that.effectiveDate;
+        this.firstPaymentReferenceId = that.firstPaymentReferenceId;
+        this.gatewayError = that.gatewayError;
+        this.gatewayErrorCode = that.gatewayErrorCode;
+        this.kbPaymentId = that.kbPaymentId;
+        this.kbTransactionPaymentId = that.kbTransactionPaymentId;
+        this.properties = that.properties;
+        this.secondPaymentReferenceId = that.secondPaymentReferenceId;
+        this.status = that.status;
+        this.transactionType = that.transactionType;
+    }
+    protected PaymentTransactionInfoPluginImp(final PaymentTransactionInfoPluginImp.Builder<?> builder) {
+        this.amount = builder.amount;
+        this.createdDate = builder.createdDate;
+        this.currency = builder.currency;
+        this.effectiveDate = builder.effectiveDate;
+        this.firstPaymentReferenceId = builder.firstPaymentReferenceId;
+        this.gatewayError = builder.gatewayError;
+        this.gatewayErrorCode = builder.gatewayErrorCode;
+        this.kbPaymentId = builder.kbPaymentId;
+        this.kbTransactionPaymentId = builder.kbTransactionPaymentId;
+        this.properties = builder.properties;
+        this.secondPaymentReferenceId = builder.secondPaymentReferenceId;
+        this.status = builder.status;
+        this.transactionType = builder.transactionType;
+    }
+    protected PaymentTransactionInfoPluginImp() { }
+    @Override
+    public BigDecimal getAmount() {
+        return this.amount;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public Currency getCurrency() {
+        return this.currency;
+    }
+    @Override
+    public DateTime getEffectiveDate() {
+        return this.effectiveDate;
+    }
+    @Override
+    public String getFirstPaymentReferenceId() {
+        return this.firstPaymentReferenceId;
+    }
+    @Override
+    public String getGatewayError() {
+        return this.gatewayError;
+    }
+    @Override
+    public String getGatewayErrorCode() {
+        return this.gatewayErrorCode;
+    }
+    @Override
+    public UUID getKbPaymentId() {
+        return this.kbPaymentId;
+    }
+    @Override
+    public UUID getKbTransactionPaymentId() {
+        return this.kbTransactionPaymentId;
+    }
+    @Override
+    public List<PluginProperty> getProperties() {
+        return this.properties;
+    }
+    @Override
+    public String getSecondPaymentReferenceId() {
+        return this.secondPaymentReferenceId;
+    }
+    @Override
+    public PaymentPluginStatus getStatus() {
+        return this.status;
+    }
+    @Override
+    public TransactionType getTransactionType() {
+        return this.transactionType;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PaymentTransactionInfoPluginImp that = (PaymentTransactionInfoPluginImp) o;
+        if( ( this.amount != null ) ? ( 0 != this.amount.compareTo(that.amount) ) : ( that.amount != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( ( this.effectiveDate != null ) ? ( 0 != this.effectiveDate.compareTo(that.effectiveDate) ) : ( that.effectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.firstPaymentReferenceId, that.firstPaymentReferenceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.gatewayError, that.gatewayError) ) {
+            return false;
+        }
+        if( !Objects.equals(this.gatewayErrorCode, that.gatewayErrorCode) ) {
+            return false;
+        }
+        if( !Objects.equals(this.kbPaymentId, that.kbPaymentId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.kbTransactionPaymentId, that.kbTransactionPaymentId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.properties, that.properties) ) {
+            return false;
+        }
+        if( !Objects.equals(this.secondPaymentReferenceId, that.secondPaymentReferenceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.status, that.status) ) {
+            return false;
+        }
+        if( !Objects.equals(this.transactionType, that.transactionType) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.firstPaymentReferenceId);
+        result = ( 31 * result ) + Objects.hashCode(this.gatewayError);
+        result = ( 31 * result ) + Objects.hashCode(this.gatewayErrorCode);
+        result = ( 31 * result ) + Objects.hashCode(this.kbPaymentId);
+        result = ( 31 * result ) + Objects.hashCode(this.kbTransactionPaymentId);
+        result = ( 31 * result ) + Objects.hashCode(this.properties);
+        result = ( 31 * result ) + Objects.hashCode(this.secondPaymentReferenceId);
+        result = ( 31 * result ) + Objects.hashCode(this.status);
+        result = ( 31 * result ) + Objects.hashCode(this.transactionType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("firstPaymentReferenceId=");
+        if( this.firstPaymentReferenceId == null ) {
+            sb.append(this.firstPaymentReferenceId);
+        }else{
+            sb.append("'").append(this.firstPaymentReferenceId).append("'");
+        }
+        sb.append(", ");
+        sb.append("gatewayError=");
+        if( this.gatewayError == null ) {
+            sb.append(this.gatewayError);
+        }else{
+            sb.append("'").append(this.gatewayError).append("'");
+        }
+        sb.append(", ");
+        sb.append("gatewayErrorCode=");
+        if( this.gatewayErrorCode == null ) {
+            sb.append(this.gatewayErrorCode);
+        }else{
+            sb.append("'").append(this.gatewayErrorCode).append("'");
+        }
+        sb.append(", ");
+        sb.append("kbPaymentId=").append(this.kbPaymentId);
+        sb.append(", ");
+        sb.append("kbTransactionPaymentId=").append(this.kbTransactionPaymentId);
+        sb.append(", ");
+        sb.append("properties=").append(this.properties);
+        sb.append(", ");
+        sb.append("secondPaymentReferenceId=");
+        if( this.secondPaymentReferenceId == null ) {
+            sb.append(this.secondPaymentReferenceId);
+        }else{
+            sb.append("'").append(this.secondPaymentReferenceId).append("'");
+        }
+        sb.append(", ");
+        sb.append("status=").append(this.status);
+        sb.append(", ");
+        sb.append("transactionType=").append(this.transactionType);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PaymentTransactionInfoPluginImp.Builder<T>> {
+
+        protected BigDecimal amount;
+        protected DateTime createdDate;
+        protected Currency currency;
+        protected DateTime effectiveDate;
+        protected String firstPaymentReferenceId;
+        protected String gatewayError;
+        protected String gatewayErrorCode;
+        protected UUID kbPaymentId;
+        protected UUID kbTransactionPaymentId;
+        protected List<PluginProperty> properties;
+        protected String secondPaymentReferenceId;
+        protected PaymentPluginStatus status;
+        protected TransactionType transactionType;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.amount = that.amount;
+            this.createdDate = that.createdDate;
+            this.currency = that.currency;
+            this.effectiveDate = that.effectiveDate;
+            this.firstPaymentReferenceId = that.firstPaymentReferenceId;
+            this.gatewayError = that.gatewayError;
+            this.gatewayErrorCode = that.gatewayErrorCode;
+            this.kbPaymentId = that.kbPaymentId;
+            this.kbTransactionPaymentId = that.kbTransactionPaymentId;
+            this.properties = that.properties;
+            this.secondPaymentReferenceId = that.secondPaymentReferenceId;
+            this.status = that.status;
+            this.transactionType = that.transactionType;
+        }
+        public T withAmount(final BigDecimal amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+        public T withEffectiveDate(final DateTime effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+        public T withFirstPaymentReferenceId(final String firstPaymentReferenceId) {
+            this.firstPaymentReferenceId = firstPaymentReferenceId;
+            return (T) this;
+        }
+        public T withGatewayError(final String gatewayError) {
+            this.gatewayError = gatewayError;
+            return (T) this;
+        }
+        public T withGatewayErrorCode(final String gatewayErrorCode) {
+            this.gatewayErrorCode = gatewayErrorCode;
+            return (T) this;
+        }
+        public T withKbPaymentId(final UUID kbPaymentId) {
+            this.kbPaymentId = kbPaymentId;
+            return (T) this;
+        }
+        public T withKbTransactionPaymentId(final UUID kbTransactionPaymentId) {
+            this.kbTransactionPaymentId = kbTransactionPaymentId;
+            return (T) this;
+        }
+        public T withProperties(final List<PluginProperty> properties) {
+            this.properties = properties;
+            return (T) this;
+        }
+        public T withSecondPaymentReferenceId(final String secondPaymentReferenceId) {
+            this.secondPaymentReferenceId = secondPaymentReferenceId;
+            return (T) this;
+        }
+        public T withStatus(final PaymentPluginStatus status) {
+            this.status = status;
+            return (T) this;
+        }
+        public T withTransactionType(final TransactionType transactionType) {
+            this.transactionType = transactionType;
+            return (T) this;
+        }
+        public T source(final PaymentTransactionInfoPlugin that) {
+            this.amount = that.getAmount();
+            this.createdDate = that.getCreatedDate();
+            this.currency = that.getCurrency();
+            this.effectiveDate = that.getEffectiveDate();
+            this.firstPaymentReferenceId = that.getFirstPaymentReferenceId();
+            this.gatewayError = that.getGatewayError();
+            this.gatewayErrorCode = that.getGatewayErrorCode();
+            this.kbPaymentId = that.getKbPaymentId();
+            this.kbTransactionPaymentId = that.getKbTransactionPaymentId();
+            this.properties = that.getProperties();
+            this.secondPaymentReferenceId = that.getSecondPaymentReferenceId();
+            this.status = that.getStatus();
+            this.transactionType = that.getTransactionType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public PaymentTransactionInfoPluginImp build() {
+            return new PaymentTransactionInfoPluginImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/payment/plugin/api/boilerplate/Resolver.java
@@ -1,0 +1,31 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.payment.plugin.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.payment.plugin.api.GatewayNotification;
+import org.killbill.billing.payment.plugin.api.HostedPaymentPageFormDescriptor;
+import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(GatewayNotification.class, GatewayNotificationImp.class);
+        this.addMapping(HostedPaymentPageFormDescriptor.class, HostedPaymentPageFormDescriptorImp.class);
+        this.addMapping(PaymentTransactionInfoPlugin.class, PaymentTransactionInfoPluginImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/api/PluginCallContext.java
+++ b/src/main/java/org/killbill/billing/plugin/api/PluginCallContext.java
@@ -21,178 +21,82 @@ package org.killbill.billing.plugin.api;
 import java.util.UUID;
 
 import org.joda.time.DateTime;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.callcontext.boilerplate.CallContextImp;
 
-public class PluginCallContext implements CallContext {
-
-    protected final UUID userToken;
-    protected final String userName;
-    protected final CallOrigin callOrigin;
-    protected final UserType userType;
-    protected final String reasonCode;
-    protected final String comments;
-    protected final DateTime createdDate;
-    protected final DateTime updatedDate;
-    protected final UUID accountId;
-    protected final UUID tenantId;
+@JsonDeserialize( builder = PluginCallContext.Builder.class )
+public class PluginCallContext extends CallContextImp {
 
     public PluginCallContext(final String pluginName, final DateTime utcNow, final UUID accountId, final UUID tenantId) {
         this(UUID.randomUUID(),
-             pluginName,
-             CallOrigin.EXTERNAL,
-             UserType.SYSTEM,
-             null,
-             null,
-             utcNow,
-             utcNow,
-             accountId,
-             tenantId);
+                pluginName,
+                CallOrigin.EXTERNAL,
+                UserType.SYSTEM,
+                null,
+                null,
+                utcNow,
+                utcNow,
+                accountId,
+                tenantId);
     }
 
     public PluginCallContext(final UUID userToken,
-                             final String userName,
-                             final CallOrigin callOrigin,
-                             final UserType userType,
-                             final String reasonCode,
-                             final String comments,
-                             final DateTime createdDate,
-                             final DateTime updatedDate,
-                             final UUID accountId,
-                             final UUID tenantId) {
-        this.userToken = userToken;
-        this.userName = userName;
-        this.callOrigin = callOrigin;
-        this.userType = userType;
-        this.reasonCode = reasonCode;
-        this.comments = comments;
-        this.createdDate = createdDate;
-        this.updatedDate = updatedDate;
-        this.accountId = accountId;
-        this.tenantId = tenantId;
+            final String userName,
+            final CallOrigin callOrigin,
+            final UserType userType,
+            final String reasonCode,
+            final String comments,
+            final DateTime createdDate,
+            final DateTime updatedDate,
+            final UUID accountId,
+            final UUID tenantId) {
+        this(new Builder<>() 
+                .withUserToken(userToken)
+                .withUserName(userName)
+                .withCallOrigin(callOrigin)
+                .withUserType(userType)
+                .withReasonCode(reasonCode)
+                .withComments(comments)
+                .withCreatedDate(createdDate)
+                .withUpdatedDate(updatedDate)
+                .withAccountId(accountId)
+                .withTenantId(tenantId)
+                .validate());
     }
 
-    @Override
-    public UUID getUserToken() {
-        return userToken;
+    protected PluginCallContext(final PluginCallContext.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public String getUserName() {
-        return userName;
+    public PluginCallContext(final PluginCallContext that) {
+        super(that);
     }
 
-    @Override
-    public CallOrigin getCallOrigin() {
-        return callOrigin;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginCallContext.Builder<T>>
+        extends CallContextImp.Builder<T> {
 
-    @Override
-    public UserType getUserType() {
-        return userType;
-    }
-
-    @Override
-    public String getReasonCode() {
-        return reasonCode;
-    }
-
-    @Override
-    public String getComments() {
-        return comments;
-    }
-
-    @Override
-    public DateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    @Override
-    public DateTime getUpdatedDate() {
-        return updatedDate;
-    }
-
-    @Override
-    public UUID getAccountId() {
-        return accountId;
-    }
-
-    @Override
-    public UUID getTenantId() {
-        return tenantId;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginCallContext{");
-        sb.append("userToken=").append(userToken);
-        sb.append(", userName='").append(userName).append('\'');
-        sb.append(", callOrigin=").append(callOrigin);
-        sb.append(", userType=").append(userType);
-        sb.append(", reasonCode='").append(reasonCode).append('\'');
-        sb.append(", comments='").append(comments).append('\'');
-        sb.append(", createdDate=").append(createdDate);
-        sb.append(", updatedDate=").append(updatedDate);
-        sb.append(", accountId=").append(accountId);
-        sb.append(", tenantId=").append(tenantId);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
+            this.withUserToken(UUID.randomUUID());
+            this.withCallOrigin(CallOrigin.EXTERNAL);
+            this.withUserType(UserType.SYSTEM);
         }
 
-        final PluginCallContext that = (PluginCallContext) o;
+        public Builder(final Builder that) {
+            super(that);
+        }
 
-        if (userToken != null ? !userToken.equals(that.userToken) : that.userToken != null) {
-            return false;
+        @Override
+        public Builder validate() {
+            return this;
         }
-        if (userName != null ? !userName.equals(that.userName) : that.userName != null) {
-            return false;
-        }
-        if (callOrigin != that.callOrigin) {
-            return false;
-        }
-        if (userType != that.userType) {
-            return false;
-        }
-        if (reasonCode != null ? !reasonCode.equals(that.reasonCode) : that.reasonCode != null) {
-            return false;
-        }
-        if (comments != null ? !comments.equals(that.comments) : that.comments != null) {
-            return false;
-        }
-        if (createdDate != null ? createdDate.compareTo(that.createdDate) != 0 : that.createdDate != null) {
-            return false;
-        }
-        if (updatedDate != null ? updatedDate.compareTo(that.updatedDate) != 0 : that.updatedDate != null) {
-            return false;
-        }
-        if (accountId != null ? !accountId.equals(that.accountId) : that.accountId != null) {
-            return false;
-        }
-        return tenantId != null ? tenantId.equals(that.tenantId) : that.tenantId == null;
-    }
 
-    @Override
-    public int hashCode() {
-        int result = userToken != null ? userToken.hashCode() : 0;
-        result = 31 * result + (userName != null ? userName.hashCode() : 0);
-        result = 31 * result + (callOrigin != null ? callOrigin.hashCode() : 0);
-        result = 31 * result + (userType != null ? userType.hashCode() : 0);
-        result = 31 * result + (reasonCode != null ? reasonCode.hashCode() : 0);
-        result = 31 * result + (comments != null ? comments.hashCode() : 0);
-        result = 31 * result + (createdDate != null ? createdDate.hashCode() : 0);
-        result = 31 * result + (updatedDate != null ? updatedDate.hashCode() : 0);
-        result = 31 * result + (accountId != null ? accountId.hashCode() : 0);
-        result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
-        return result;
+        @Override
+        public PluginCallContext build() {
+            return new PluginCallContext(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/PluginTenantContext.java
+++ b/src/main/java/org/killbill/billing/plugin/api/PluginTenantContext.java
@@ -19,61 +19,48 @@
 package org.killbill.billing.plugin.api;
 
 import java.util.UUID;
-
 import javax.annotation.Nullable;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.callcontext.boilerplate.TenantContextImp;
 
-public class PluginTenantContext implements TenantContext {
-
-    protected final UUID accountId;
-    protected final UUID tenantId;
+@JsonDeserialize( builder = PluginTenantContext.Builder.class )
+public class PluginTenantContext extends TenantContextImp {
 
     public PluginTenantContext(@Nullable final UUID accountId, final UUID tenantId) {
-        this.accountId = accountId;
-        this.tenantId = tenantId;
+        this(new Builder<>()
+        .withAccountId(accountId)
+        .withTenantId(tenantId)
+        .validate());
     }
 
-    @Override
-    public UUID getAccountId() {
-        return accountId;
+    protected PluginTenantContext(final PluginTenantContext.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public UUID getTenantId() {
-        return tenantId;
+    public PluginTenantContext(final PluginTenantContext that) {
+        super(that);
     }
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginTenantContext{");
-        sb.append("accountId=").append(accountId);
-        sb.append(", tenantId=").append(tenantId);
-        sb.append('}');
-        return sb.toString();
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginTenantContext.Builder<T>> 
+        extends TenantContextImp.Builder<T> {
 
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
         }
 
-        final PluginTenantContext that = (PluginTenantContext) o;
-
-        if (accountId != null ? !accountId.equals(that.accountId) : that.accountId != null) {
-            return false;
+        public Builder(final Builder that) {
+            super(that);
         }
-        return tenantId != null ? tenantId.equals(that.tenantId) : that.tenantId == null;
-    }
 
-    @Override
-    public int hashCode() {
-        int result = accountId != null ? accountId.hashCode() : 0;
-        result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
-        return result;
+        @Override
+        public Builder validate() {
+            return this;
+        }
+
+        @Override
+        public PluginTenantContext build() {
+            return new PluginTenantContext(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/core/PluginAccountData.java
+++ b/src/main/java/org/killbill/billing/plugin/api/core/PluginAccountData.java
@@ -20,361 +20,132 @@ package org.killbill.billing.plugin.api.core;
 
 import java.util.Locale;
 import java.util.UUID;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+
 import org.killbill.billing.account.api.AccountData;
 import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.account.api.boilerplate.AccountDataImp;
 
-public class PluginAccountData implements AccountData {
-
-    protected final String externalKey;
-    protected final String email;
-    protected final String name;
-    protected final Integer firstNameLength;
-    protected final Currency currency;
-    protected final UUID parentAccountId;
-    protected final Boolean isPaymentDelegatedToParent;
-    protected final Integer billCycleDayLocal;
-    protected final UUID paymentMethodId;
-    protected final DateTime referenceTime;
-    protected final DateTimeZone timeZone;
-    protected final String locale;
-    protected final String address1;
-    protected final String address2;
-    protected final String companyName;
-    protected final String city;
-    protected final String stateOrProvince;
-    protected final String country;
-    protected final String postalCode;
-    protected final String phone;
-    protected final String notes;
-    protected final Boolean isMigrated;
+@JsonDeserialize( builder = PluginAccountData.Builder.class )
+public class PluginAccountData extends AccountDataImp {
 
     public PluginAccountData(final String externalKey) {
         this(externalKey, Currency.USD, DateTimeZone.UTC, Locale.US.toString(), "US");
     }
 
     public PluginAccountData(final String externalKey,
-                             final Currency currency,
-                             final DateTimeZone timeZone,
-                             final String locale,
-                             final String country) {
+            final Currency currency,
+            final DateTimeZone timeZone,
+            final String locale,
+            final String country) {
         this(externalKey,
-             null,
-             null,
-             null,
-             currency,
-             null,
-             null,
-             null,
-             null,
-             null,
-             timeZone,
-             locale,
-             null,
-             null,
-             null,
-             null,
-             null,
-             country,
-             null,
-             null,
-             null,
-             null,
-             null);
+                null,
+                null,
+                null,
+                currency,
+                null,
+                null,
+                null,
+                null,
+                null,
+                timeZone,
+                locale,
+                null,
+                null,
+                null,
+                null,
+                null,
+                country,
+                null,
+                null,
+                null,
+                null,
+                null);
     }
 
     public PluginAccountData(final String externalKey,
-                             final String email,
-                             final String name,
-                             final Integer firstNameLength,
-                             final Currency currency,
-                             final UUID parentAccountId,
-                             final Boolean isPaymentDelegatedToParent,
-                             final Integer billCycleDayLocal,
-                             final UUID paymentMethodId,
-                             final DateTime referenceTime,
-                             final DateTimeZone timeZone,
-                             final String locale,
-                             final String address1,
-                             final String address2,
-                             final String companyName,
-                             final String city,
-                             final String stateOrProvince,
-                             final String country,
-                             final String postalCode,
-                             final String phone,
-                             final String notes,
-                             final Boolean isMigrated,
-                             final Boolean isNotifiedForInvoices) {
-        this.externalKey = externalKey;
-        this.email = email;
-        this.name = name;
-        this.firstNameLength = firstNameLength;
-        this.currency = currency;
-        this.parentAccountId = parentAccountId;
-        this.isPaymentDelegatedToParent = isPaymentDelegatedToParent;
-        this.billCycleDayLocal = billCycleDayLocal;
-        this.paymentMethodId = paymentMethodId;
-        this.referenceTime = referenceTime;
-        this.timeZone = timeZone;
-        this.locale = locale;
-        this.address1 = address1;
-        this.address2 = address2;
-        this.companyName = companyName;
-        this.city = city;
-        this.stateOrProvince = stateOrProvince;
-        this.postalCode = postalCode;
-        this.country = country;
-        this.phone = phone;
-        this.notes = notes;
-        this.isMigrated = isMigrated;
+            final String email,
+            final String name,
+            final Integer firstNameLength,
+            final Currency currency,
+            final UUID parentAccountId,
+            final Boolean isPaymentDelegatedToParent,
+            final Integer billCycleDayLocal,
+            final UUID paymentMethodId,
+            final DateTime referenceTime,
+            final DateTimeZone timeZone,
+            final String locale,
+            final String address1,
+            final String address2,
+            final String companyName,
+            final String city,
+            final String stateOrProvince,
+            final String country,
+            final String postalCode,
+            final String phone,
+            final String notes,
+            final Boolean isMigrated,
+            final Boolean isNotifiedForInvoices) {
+
+                this(new Builder<>()
+                        .withExternalKey(externalKey)
+                        .withEmail(email)
+                        .withName(name)
+                        .withFirstNameLength(firstNameLength)
+                        .withCurrency(currency)
+                        .withParentAccountId(parentAccountId)
+                        .withIsPaymentDelegatedToParent(isPaymentDelegatedToParent)
+                        .withBillCycleDayLocal(billCycleDayLocal)
+                        .withPaymentMethodId(paymentMethodId)
+                        .withReferenceTime(referenceTime)
+                        .withTimeZone(timeZone)
+                        .withLocale(locale)
+                        .withAddress1(address1)
+                        .withAddress2(address2)
+                        .withCompanyName(companyName)
+                        .withCity(city)
+                        .withStateOrProvince(stateOrProvince)
+                        .withPostalCode(postalCode)
+                        .withCountry(country)
+                        .withPhone(phone)
+                        .withNotes(notes)
+                        .withIsMigrated(isMigrated)
+                        .validate());
     }
 
-    @Override
-    public String getExternalKey() {
-        return externalKey;
+    protected PluginAccountData(final PluginAccountData.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public String getName() {
-        return name;
+    public PluginAccountData(final PluginAccountData that) {
+        super(that);
     }
 
-    @Override
-    public String getEmail() {
-        return email;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginAccountData.Builder<T>> 
+        extends AccountDataImp.Builder<T> {
 
-    @Override
-    public Integer getFirstNameLength() {
-        return firstNameLength;
-    }
-
-    @Override
-    public Currency getCurrency() {
-        return currency;
-    }
-
-    @Override
-    public UUID getParentAccountId() {
-        return parentAccountId;
-    }
-
-    @Override
-    public Boolean isPaymentDelegatedToParent() {
-        return isPaymentDelegatedToParent;
-    }
-
-    @Override
-    public Integer getBillCycleDayLocal() {
-        return billCycleDayLocal;
-    }
-
-    @Override
-    public UUID getPaymentMethodId() {
-        return paymentMethodId;
-    }
-
-    @Override
-    public DateTime getReferenceTime() {
-        return referenceTime;
-    }
-
-    @Override
-    public DateTimeZone getTimeZone() {
-        return timeZone;
-    }
-
-    @Override
-    public String getLocale() {
-        return locale;
-    }
-
-    @Override
-    public String getAddress1() {
-        return address1;
-    }
-
-    @Override
-    public String getAddress2() {
-        return address2;
-    }
-
-    @Override
-    public String getCompanyName() {
-        return companyName;
-    }
-
-    @Override
-    public String getCity() {
-        return city;
-    }
-
-    @Override
-    public String getStateOrProvince() {
-        return stateOrProvince;
-    }
-
-    @Override
-    public String getPostalCode() {
-        return postalCode;
-    }
-
-    @Override
-    public String getCountry() {
-        return country;
-    }
-
-    @Override
-    public Boolean isMigrated() {
-        return isMigrated;
-    }
-
-    @Override
-    public String getPhone() {
-        return phone;
-    }
-
-    @Override
-    public String getNotes() {
-        return notes;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginAccountData{");
-        sb.append("externalKey='").append(externalKey).append('\'');
-        sb.append(", email='").append(email).append('\'');
-        sb.append(", name='").append(name).append('\'');
-        sb.append(", firstNameLength=").append(firstNameLength);
-        sb.append(", currency=").append(currency);
-        sb.append(", parentAccountId=").append(parentAccountId);
-        sb.append(", isPaymentDelegatedToParent=").append(isPaymentDelegatedToParent);
-        sb.append(", billCycleDayLocal=").append(billCycleDayLocal);
-        sb.append(", paymentMethodId=").append(paymentMethodId);
-        sb.append(", timeZone=").append(timeZone);
-        sb.append(", locale='").append(locale).append('\'');
-        sb.append(", address1='").append(address1).append('\'');
-        sb.append(", address2='").append(address2).append('\'');
-        sb.append(", companyName='").append(companyName).append('\'');
-        sb.append(", city='").append(city).append('\'');
-        sb.append(", stateOrProvince='").append(stateOrProvince).append('\'');
-        sb.append(", country='").append(country).append('\'');
-        sb.append(", postalCode='").append(postalCode).append('\'');
-        sb.append(", phone='").append(phone).append('\'');
-        sb.append(", notes='").append(notes).append('\'');
-        sb.append(", isMigrated=").append(isMigrated);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
+        public Builder() {
+            this.withCurrency(Currency.USD);
+            this.withTimeZone(DateTimeZone.UTC);
+            this.withLocale(Locale.US.toString());
+            this.withCountry("US");
         }
 
-        final PluginAccountData that = (PluginAccountData) o;
-
-        if (billCycleDayLocal != null ? !billCycleDayLocal.equals(that.billCycleDayLocal) : that.billCycleDayLocal != null) {
-            return false;
-        }
-        if (address1 != null ? !address1.equals(that.address1) : that.address1 != null) {
-            return false;
-        }
-        if (address2 != null ? !address2.equals(that.address2) : that.address2 != null) {
-            return false;
-        }
-        if (city != null ? !city.equals(that.city) : that.city != null) {
-            return false;
-        }
-        if (companyName != null ? !companyName.equals(that.companyName) : that.companyName != null) {
-            return false;
-        }
-        if (country != null ? !country.equals(that.country) : that.country != null) {
-            return false;
-        }
-        if (currency != that.currency) {
-            return false;
-        }
-        if (parentAccountId != null ? !parentAccountId.equals(that.parentAccountId) : that.parentAccountId != null) {
-            return false;
-        }
-        if (isPaymentDelegatedToParent != null ? !isPaymentDelegatedToParent.equals(that.isPaymentDelegatedToParent) : that.isPaymentDelegatedToParent != null) {
-            return false;
-        }
-        if (email != null ? !email.equals(that.email) : that.email != null) {
-            return false;
-        }
-        if (externalKey != null ? !externalKey.equals(that.externalKey) : that.externalKey != null) {
-            return false;
-        }
-        if (firstNameLength != null ? !firstNameLength.equals(that.firstNameLength) : that.firstNameLength != null) {
-            return false;
-        }
-        if (isMigrated != null ? !isMigrated.equals(that.isMigrated) : that.isMigrated != null) {
-            return false;
-        }
-        if (locale != null ? !locale.equals(that.locale) : that.locale != null) {
-            return false;
-        }
-        if (name != null ? !name.equals(that.name) : that.name != null) {
-            return false;
-        }
-        if (paymentMethodId != null ? !paymentMethodId.equals(that.paymentMethodId) : that.paymentMethodId != null) {
-            return false;
-        }
-        if (phone != null ? !phone.equals(that.phone) : that.phone != null) {
-            return false;
-        }
-        if (postalCode != null ? !postalCode.equals(that.postalCode) : that.postalCode != null) {
-            return false;
-        }
-        if (stateOrProvince != null ? !stateOrProvince.equals(that.stateOrProvince) : that.stateOrProvince != null) {
-            return false;
-        }
-        if (timeZone != null ? !timeZone.equals(that.timeZone) : that.timeZone != null) {
-            return false;
-        }
-        if (notes != null ? !notes.equals(that.notes) : that.notes != null) {
-            return false;
+        public Builder(final Builder that) {
+            super(that);
         }
 
-        return true;
-    }
+        @Override
+        public Builder validate() {
+            return this;
+        }
 
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (externalKey != null ? externalKey.hashCode() : 0);
-        result = 31 * result + (email != null ? email.hashCode() : 0);
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (firstNameLength != null ? firstNameLength.hashCode() : 0);
-        result = 31 * result + (currency != null ? currency.hashCode() : 0);
-        result = 31 * result + (parentAccountId != null ? parentAccountId.hashCode() : 0);
-        result = 31 * result + (isPaymentDelegatedToParent != null ? isPaymentDelegatedToParent.hashCode() : 0);
-        result = 31 * result + billCycleDayLocal;
-        result = 31 * result + (paymentMethodId != null ? paymentMethodId.hashCode() : 0);
-        result = 31 * result + (timeZone != null ? timeZone.hashCode() : 0);
-        result = 31 * result + (locale != null ? locale.hashCode() : 0);
-        result = 31 * result + (address1 != null ? address1.hashCode() : 0);
-        result = 31 * result + (address2 != null ? address2.hashCode() : 0);
-        result = 31 * result + (companyName != null ? companyName.hashCode() : 0);
-        result = 31 * result + (city != null ? city.hashCode() : 0);
-        result = 31 * result + (stateOrProvince != null ? stateOrProvince.hashCode() : 0);
-        result = 31 * result + (country != null ? country.hashCode() : 0);
-        result = 31 * result + (postalCode != null ? postalCode.hashCode() : 0);
-        result = 31 * result + (phone != null ? phone.hashCode() : 0);
-        result = 31 * result + (notes != null ? notes.hashCode() : 0);
-        result = 31 * result + (isMigrated != null ? isMigrated.hashCode() : 0);
-        return result;
+        @Override
+        public PluginAccountData build() {
+            return new PluginAccountData(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/core/PluginCustomField.java
+++ b/src/main/java/org/killbill/billing/plugin/api/core/PluginCustomField.java
@@ -19,141 +19,75 @@
 package org.killbill.billing.plugin.api.core;
 
 import java.util.UUID;
-
 import org.joda.time.DateTime;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.util.customfield.CustomField;
+import org.killbill.billing.util.customfield.boilerplate.CustomFieldImp;
 
-public class PluginCustomField implements CustomField {
-
-    protected final UUID objectId;
-    protected final ObjectType objectType;
-    protected final String fieldName;
-    protected final String fieldValue;
-    protected final UUID id;
-    protected final DateTime createdDate;
-    protected final DateTime updatedDate;
+@JsonDeserialize( builder = PluginCustomField.Builder.class )
+public class PluginCustomField extends CustomFieldImp {
 
     public PluginCustomField(final UUID objectId,
-                             final ObjectType objectType,
-                             final String fieldName,
-                             final String fieldValue,
-                             final DateTime date) {
+            final ObjectType objectType,
+            final String fieldName,
+            final String fieldValue,
+            final DateTime date) {
         this(objectId,
-             objectType,
-             fieldName,
-             fieldValue,
-             null,
-             date,
-             date);
+                objectType,
+                fieldName,
+                fieldValue,
+                null,
+                date,
+                date);
     }
 
     public PluginCustomField(final UUID objectId,
-                             final ObjectType objectType,
-                             final String fieldName,
-                             final String fieldValue,
-                             final UUID id,
-                             final DateTime createdDate,
-                             final DateTime updatedDate) {
-        this.objectId = objectId;
-        this.objectType = objectType;
-        this.fieldName = fieldName;
-        this.fieldValue = fieldValue;
-        this.id = id;
-        this.createdDate = createdDate;
-        this.updatedDate = updatedDate;
+            final ObjectType objectType,
+            final String fieldName,
+            final String fieldValue,
+            final UUID id,
+            final DateTime createdDate,
+            final DateTime updatedDate) {
+
+        this(new Builder<>()
+                .withObjectId(objectId)
+                .withObjectType(objectType)
+                .withFieldName(fieldName)
+                .withFieldValue(fieldValue)
+                .withId(id)
+                .withCreatedDate(createdDate)
+                .withUpdatedDate(updatedDate)
+                .validate());
     }
 
-    @Override
-    public UUID getObjectId() {
-        return objectId;
+    protected PluginCustomField(final PluginCustomField.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public ObjectType getObjectType() {
-        return objectType;
+    public PluginCustomField(final PluginCustomField that) {
+        super(that);
     }
 
-    @Override
-    public String getFieldName() {
-        return fieldName;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginCustomField.Builder<T>> 
+        extends CustomFieldImp.Builder<T> {
 
-    @Override
-    public String getFieldValue() {
-        return fieldValue;
-    }
-
-    @Override
-    public UUID getId() {
-        return id;
-    }
-
-    @Override
-    public DateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    @Override
-    public DateTime getUpdatedDate() {
-        return updatedDate;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginCustomField{");
-        sb.append("objectId=").append(objectId);
-        sb.append(", objectType=").append(objectType);
-        sb.append(", fieldName='").append(fieldName).append('\'');
-        sb.append(", fieldValue='").append(fieldValue).append('\'');
-        sb.append(", id=").append(id);
-        sb.append(", createdDate=").append(createdDate);
-        sb.append(", updatedDate=").append(updatedDate);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
         }
 
-        final PluginCustomField that = (PluginCustomField) o;
+        public Builder(final Builder that) {
+            super(that);
+        }
 
-        if (objectId != null ? !objectId.equals(that.objectId) : that.objectId != null) {
-            return false;
+        @Override
+        public Builder validate() {
+            return this;
         }
-        if (objectType != that.objectType) {
-            return false;
-        }
-        if (fieldName != null ? !fieldName.equals(that.fieldName) : that.fieldName != null) {
-            return false;
-        }
-        if (fieldValue != null ? !fieldValue.equals(that.fieldValue) : that.fieldValue != null) {
-            return false;
-        }
-        if (id != null ? !id.equals(that.id) : that.id != null) {
-            return false;
-        }
-        if (createdDate != null ? createdDate.compareTo(that.createdDate) != 0 : that.createdDate != null) {
-            return false;
-        }
-        return updatedDate != null ? updatedDate.compareTo(that.updatedDate) == 0 : that.updatedDate == null;
-    }
 
-    @Override
-    public int hashCode() {
-        int result = objectId != null ? objectId.hashCode() : 0;
-        result = 31 * result + (objectType != null ? objectType.hashCode() : 0);
-        result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
-        result = 31 * result + (fieldValue != null ? fieldValue.hashCode() : 0);
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (createdDate != null ? createdDate.hashCode() : 0);
-        result = 31 * result + (updatedDate != null ? updatedDate.hashCode() : 0);
-        return result;
+        @Override
+        public PluginCustomField build() {
+            return new PluginCustomField(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/core/PluginDryRunArguments.java
+++ b/src/main/java/org/killbill/billing/plugin/api/core/PluginDryRunArguments.java
@@ -19,140 +19,74 @@
 package org.killbill.billing.plugin.api.core;
 
 import java.util.UUID;
-
 import org.joda.time.LocalDate;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.entitlement.api.EntitlementSpecifier;
 import org.killbill.billing.entitlement.api.SubscriptionEventType;
 import org.killbill.billing.invoice.api.DryRunArguments;
 import org.killbill.billing.invoice.api.DryRunType;
+import org.killbill.billing.invoice.api.boilerplate.DryRunArgumentsImp;
 
-public class PluginDryRunArguments implements DryRunArguments {
-
-    private final DryRunType dryRunType;
-    private final EntitlementSpecifier entitlementSpecifier;
-    private final SubscriptionEventType action;
-    private final UUID subscriptionId;
-    private final LocalDate effectiveDate;
-    private final UUID bundleId;
-    private final BillingActionPolicy billingActionPolicy;
+@JsonDeserialize( builder = PluginDryRunArguments.Builder.class )
+public class PluginDryRunArguments extends DryRunArgumentsImp {
 
     public PluginDryRunArguments(final UUID bundleId, final UUID subscriptionId) {
         this(DryRunType.UPCOMING_INVOICE,
-             null,
-             null,
-             subscriptionId,
-             null,
-             bundleId,
-             null);
+                null,
+                null,
+                subscriptionId,
+                null,
+                bundleId,
+                null);
     }
 
     public PluginDryRunArguments(final DryRunType dryRunType,
-                                 final EntitlementSpecifier entitlementSpecifier,
-                                 final SubscriptionEventType action,
-                                 final UUID subscriptionId,
-                                 final LocalDate effectiveDate,
-                                 final UUID bundleId,
-                                 final BillingActionPolicy billingActionPolicy) {
-        this.dryRunType = dryRunType;
-        this.entitlementSpecifier = entitlementSpecifier;
-        this.action = action;
-        this.subscriptionId = subscriptionId;
-        this.effectiveDate = effectiveDate;
-        this.bundleId = bundleId;
-        this.billingActionPolicy = billingActionPolicy;
+            final EntitlementSpecifier entitlementSpecifier,
+            final SubscriptionEventType action,
+            final UUID subscriptionId,
+            final LocalDate effectiveDate,
+            final UUID bundleId,
+            final BillingActionPolicy billingActionPolicy) {
+
+        this(new Builder<>()
+                .withDryRunType(dryRunType)
+                .withEntitlementSpecifier(entitlementSpecifier)
+                .withAction(action)
+                .withSubscriptionId(subscriptionId)
+                .withEffectiveDate(effectiveDate)
+                .withBundleId(bundleId)
+                .withBillingActionPolicy(billingActionPolicy)
+                .validate());
     }
 
-    @Override
-    public DryRunType getDryRunType() {
-        return dryRunType;
+    protected PluginDryRunArguments(final PluginDryRunArguments.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public EntitlementSpecifier getEntitlementSpecifier() {
-        return entitlementSpecifier;
+    public PluginDryRunArguments(final PluginDryRunArguments that) {
+        super(that);
     }
 
-    @Override
-    public SubscriptionEventType getAction() {
-        return action;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginDryRunArguments.Builder<T>> 
+        extends DryRunArgumentsImp.Builder<T> {
 
-    @Override
-    public UUID getSubscriptionId() {
-        return subscriptionId;
-    }
-
-    @Override
-    public LocalDate getEffectiveDate() {
-        return effectiveDate;
-    }
-
-    @Override
-    public UUID getBundleId() {
-        return bundleId;
-    }
-
-    @Override
-    public BillingActionPolicy getBillingActionPolicy() {
-        return billingActionPolicy;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginDryRunArguments{");
-        sb.append("dryRunType=").append(dryRunType);
-        sb.append(", entitlementSpecifier=").append(entitlementSpecifier);
-        sb.append(", action=").append(action);
-        sb.append(", subscriptionId=").append(subscriptionId);
-        sb.append(", effectiveDate=").append(effectiveDate);
-        sb.append(", bundleId=").append(bundleId);
-        sb.append(", billingActionPolicy=").append(billingActionPolicy);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
         }
 
-        final PluginDryRunArguments that = (PluginDryRunArguments) o;
+        public Builder(final Builder that) {
+            super(that);
+        }
 
-        if (dryRunType != that.dryRunType) {
-            return false;
+        @Override
+        public Builder validate() {
+            return this;
         }
-        if (entitlementSpecifier != null ? !entitlementSpecifier.equals(that.entitlementSpecifier) : that.entitlementSpecifier != null) {
-            return false;
-        }
-        if (action != that.action) {
-            return false;
-        }
-        if (subscriptionId != null ? !subscriptionId.equals(that.subscriptionId) : that.subscriptionId != null) {
-            return false;
-        }
-        if (effectiveDate != null ? effectiveDate.compareTo(that.effectiveDate) != 0 : that.effectiveDate != null) {
-            return false;
-        }
-        if (bundleId != null ? !bundleId.equals(that.bundleId) : that.bundleId != null) {
-            return false;
-        }
-        return billingActionPolicy == that.billingActionPolicy;
-    }
 
-    @Override
-    public int hashCode() {
-        int result = dryRunType != null ? dryRunType.hashCode() : 0;
-        result = 31 * result + (entitlementSpecifier != null ? entitlementSpecifier.hashCode() : 0);
-        result = 31 * result + (action != null ? action.hashCode() : 0);
-        result = 31 * result + (subscriptionId != null ? subscriptionId.hashCode() : 0);
-        result = 31 * result + (effectiveDate != null ? effectiveDate.hashCode() : 0);
-        result = 31 * result + (bundleId != null ? bundleId.hashCode() : 0);
-        result = 31 * result + (billingActionPolicy != null ? billingActionPolicy.hashCode() : 0);
-        return result;
+        @Override
+        public PluginDryRunArguments build() {
+            return new PluginDryRunArguments(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/core/PluginEntitlementSpecifier.java
+++ b/src/main/java/org/killbill/billing/plugin/api/core/PluginEntitlementSpecifier.java
@@ -19,88 +19,55 @@
 package org.killbill.billing.plugin.api.core;
 
 import java.util.List;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+import org.killbill.billing.entitlement.api.boilerplate.EntitlementSpecifierImp;
 
-public class PluginEntitlementSpecifier implements EntitlementSpecifier {
-
-    private final PlanPhaseSpecifier planPhaseSpecifier;
-    private final Integer billCycleDay;
-    private final String externalKey;
-    private final List<PlanPhasePriceOverride> overrides;
+@JsonDeserialize( builder = PluginEntitlementSpecifier.Builder.class )
+public class PluginEntitlementSpecifier extends EntitlementSpecifierImp {
 
     public PluginEntitlementSpecifier(final PlanPhaseSpecifier planPhaseSpecifier,
-                                      final Integer billCycleDay,
-                                      final String externalKey,
-                                      final List<PlanPhasePriceOverride> overrides) {
-        this.planPhaseSpecifier = planPhaseSpecifier;
-        this.billCycleDay = billCycleDay;
-        this.externalKey = externalKey;
-        this.overrides = overrides;
+            final Integer billCycleDay,
+            final String externalKey,
+            final List<PlanPhasePriceOverride> overrides) {
+
+        this(new Builder<>()
+                .withPlanPhaseSpecifier(planPhaseSpecifier)
+                .withBillCycleDay(billCycleDay)
+                .withExternalKey(externalKey)
+                .withOverrides(overrides)
+                .validate());
     }
 
-    @Override
-    public PlanPhaseSpecifier getPlanPhaseSpecifier() {
-        return planPhaseSpecifier;
+    protected PluginEntitlementSpecifier(final PluginEntitlementSpecifier.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public Integer getBillCycleDay() {
-        return billCycleDay;
+    public PluginEntitlementSpecifier(final PluginEntitlementSpecifier that) {
+        super(that);
     }
 
-    @Override
-    public String getExternalKey() {
-        return externalKey;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginEntitlementSpecifier.Builder<T>> 
+        extends EntitlementSpecifierImp.Builder<T> {
 
-    @Override
-    public List<PlanPhasePriceOverride> getOverrides() {
-        return overrides;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginEntitlementSpecifier{");
-        sb.append("planPhaseSpecifier=").append(planPhaseSpecifier);
-        sb.append(", billCycleDay=").append(billCycleDay);
-        sb.append(", externalKey=").append(externalKey);
-        sb.append(", overrides=").append(overrides);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
         }
 
-        final PluginEntitlementSpecifier that = (PluginEntitlementSpecifier) o;
+        public Builder(final Builder that) {
+            super(that);
+        }
 
-        if (planPhaseSpecifier != null ? !planPhaseSpecifier.equals(that.planPhaseSpecifier) : that.planPhaseSpecifier != null) {
-            return false;
+        @Override
+        public Builder validate() {
+            return this;
         }
-        if (billCycleDay != null ? !billCycleDay.equals(that.billCycleDay) : that.billCycleDay != null) {
-            return false;
-        }
-        if (externalKey != null ? !externalKey.equals(that.externalKey) : that.externalKey != null) {
-            return false;
-        }
-        return overrides != null ? overrides.equals(that.overrides) : that.overrides == null;
-    }
 
-    @Override
-    public int hashCode() {
-        int result = planPhaseSpecifier != null ? planPhaseSpecifier.hashCode() : 0;
-        result = 31 * result + (billCycleDay != null ? billCycleDay.hashCode() : 0);
-        result = 31 * result + (externalKey != null ? externalKey.hashCode() : 0);
-        result = 31 * result + (overrides != null ? overrides.hashCode() : 0);
-        return result;
+        @Override
+        public PluginEntitlementSpecifier build() {
+            return new PluginEntitlementSpecifier(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/core/PluginPaymentOptions.java
+++ b/src/main/java/org/killbill/billing/plugin/api/core/PluginPaymentOptions.java
@@ -19,15 +19,13 @@
 package org.killbill.billing.plugin.api.core;
 
 import java.util.List;
-
-import org.killbill.billing.payment.api.PaymentOptions;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
+import org.killbill.billing.payment.api.PaymentOptions;
+import org.killbill.billing.payment.api.boilerplate.PaymentOptionsImp;
 
-public class PluginPaymentOptions implements PaymentOptions {
-
-    private final boolean isExternalPayment;
-    private final List<String> paymentControlPluginNames;
+@JsonDeserialize( builder = PluginPaymentOptions.Builder.class )
+public class PluginPaymentOptions extends PaymentOptionsImp {
 
     public PluginPaymentOptions() {
         this(false, ImmutableList.<String>of());
@@ -38,49 +36,40 @@ public class PluginPaymentOptions implements PaymentOptions {
     }
 
     public PluginPaymentOptions(final boolean isExternalPayment, final List<String> paymentControlPluginNames) {
-        this.isExternalPayment = isExternalPayment;
-        this.paymentControlPluginNames = paymentControlPluginNames;
+        this(new Builder<>()
+        .withIsExternalPayment(isExternalPayment)
+        .withPaymentControlPluginNames(paymentControlPluginNames)
+        .validate());
+
     }
 
-    @Override
-    public boolean isExternalPayment() {
-        return isExternalPayment;
+    protected PluginPaymentOptions(final PluginPaymentOptions.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public List<String> getPaymentControlPluginNames() {
-        return paymentControlPluginNames;
+    public PluginPaymentOptions(final PluginPaymentOptions that) {
+        super(that);
     }
 
-    @Override
-    public String toString() {
-        return "PluginPaymentOptions{" +
-               "isExternalPayment=" + isExternalPayment +
-               ", paymentControlPluginNames=" + paymentControlPluginNames +
-               '}';
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginPaymentOptions.Builder<T>> 
+        extends PaymentOptionsImp.Builder<T> {
 
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
         }
 
-        final PluginPaymentOptions that = (PluginPaymentOptions) o;
-
-        if (isExternalPayment != that.isExternalPayment) {
-            return false;
+        public Builder(final Builder that) {
+            super(that);
         }
-        return paymentControlPluginNames != null ? paymentControlPluginNames.equals(that.paymentControlPluginNames) : that.paymentControlPluginNames == null;
-    }
 
-    @Override
-    public int hashCode() {
-        int result = (isExternalPayment ? 1 : 0);
-        result = 31 * result + (paymentControlPluginNames != null ? paymentControlPluginNames.hashCode() : 0);
-        return result;
+        @Override
+        public Builder validate() {
+            return this;
+        }
+
+        @Override
+        public PluginPaymentOptions build() {
+            return new PluginPaymentOptions(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/core/PluginPlanPhasePriceOverride.java
+++ b/src/main/java/org/killbill/billing/plugin/api/core/PluginPlanPhasePriceOverride.java
@@ -20,121 +20,66 @@ package org.killbill.billing.plugin.api.core;
 
 import java.math.BigDecimal;
 import java.util.List;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
 import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
 import org.killbill.billing.catalog.api.UsagePriceOverride;
+import org.killbill.billing.catalog.api.boilerplate.PlanPhasePriceOverrideImp;
 
-public class PluginPlanPhasePriceOverride implements PlanPhasePriceOverride {
-
-    private final String phaseName;
-    private final PlanPhaseSpecifier planPhaseSpecifier;
-    private final Currency currency;
-    private final BigDecimal fixedPrice;
-    private final BigDecimal recurringPrice;
-    private final List<UsagePriceOverride> usagePriceOverrides;
+@JsonDeserialize( builder = PluginPlanPhasePriceOverride.Builder.class )
+public class PluginPlanPhasePriceOverride extends PlanPhasePriceOverrideImp {
 
     public PluginPlanPhasePriceOverride(final String phaseName,
-                                        final BigDecimal recurringPrice,
-                                        final Currency currency) {
+            final BigDecimal recurringPrice,
+            final Currency currency) {
         this(phaseName, null, currency, null, recurringPrice, null);
     }
 
     public PluginPlanPhasePriceOverride(final String phaseName,
-                                        final PlanPhaseSpecifier planPhaseSpecifier,
-                                        final Currency currency,
-                                        final BigDecimal fixedPrice,
-                                        final BigDecimal recurringPrice,
-                                        final List<UsagePriceOverride> usagePriceOverrides) {
-        this.phaseName = phaseName;
-        this.planPhaseSpecifier = planPhaseSpecifier;
-        this.currency = currency;
-        this.fixedPrice = fixedPrice;
-        this.recurringPrice = recurringPrice;
-        this.usagePriceOverrides = usagePriceOverrides;
+            final PlanPhaseSpecifier planPhaseSpecifier,
+            final Currency currency,
+            final BigDecimal fixedPrice,
+            final BigDecimal recurringPrice,
+            final List<UsagePriceOverride> usagePriceOverrides) {
+
+        this(new Builder<>()
+                .withPhaseName(phaseName)
+                .withPlanPhaseSpecifier(planPhaseSpecifier)
+                .withCurrency(currency)
+                .withFixedPrice(fixedPrice)
+                .withRecurringPrice(recurringPrice)
+                .withUsagePriceOverrides(usagePriceOverrides)
+                .validate());
     }
 
-    @Override
-    public String getPhaseName() {
-        return phaseName;
+    protected PluginPlanPhasePriceOverride(final PluginPlanPhasePriceOverride.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public PlanPhaseSpecifier getPlanPhaseSpecifier() {
-        return planPhaseSpecifier;
+    public PluginPlanPhasePriceOverride(final PluginPlanPhasePriceOverride that) {
+        super(that);
     }
 
-    @Override
-    public Currency getCurrency() {
-        return currency;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginPlanPhasePriceOverride.Builder<T>> 
+        extends PlanPhasePriceOverrideImp.Builder<T> {
 
-    @Override
-    public BigDecimal getFixedPrice() {
-        return fixedPrice;
-    }
-
-    @Override
-    public BigDecimal getRecurringPrice() {
-        return recurringPrice;
-    }
-
-    @Override
-    public List<UsagePriceOverride> getUsagePriceOverrides() {
-        return usagePriceOverrides;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginPlanPhasePriceOverride{");
-        sb.append("phaseName='").append(phaseName).append('\'');
-        sb.append(", planPhaseSpecifier=").append(planPhaseSpecifier);
-        sb.append(", currency=").append(currency);
-        sb.append(", fixedPrice=").append(fixedPrice);
-        sb.append(", recurringPrice=").append(recurringPrice);
-        sb.append(", usagePriceOverrides=").append(usagePriceOverrides);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
         }
 
-        final PluginPlanPhasePriceOverride that = (PluginPlanPhasePriceOverride) o;
+        public Builder(final Builder that) {
+            super(that);
+        }
 
-        if (phaseName != null ? !phaseName.equals(that.phaseName) : that.phaseName != null) {
-            return false;
+        @Override
+        public Builder validate() {
+            return this;
         }
-        if (planPhaseSpecifier != null ? !planPhaseSpecifier.equals(that.planPhaseSpecifier) : that.planPhaseSpecifier != null) {
-            return false;
-        }
-        if (currency != that.currency) {
-            return false;
-        }
-        if (fixedPrice != null ? fixedPrice.compareTo(that.fixedPrice) != 0 : that.fixedPrice != null) {
-            return false;
-        }
-        if (recurringPrice != null ? recurringPrice.compareTo(that.recurringPrice) != 0 : that.recurringPrice != null) {
-            return false;
-        }
-        return usagePriceOverrides != null ? usagePriceOverrides.equals(that.usagePriceOverrides) : that.usagePriceOverrides == null;
-    }
 
-    @Override
-    public int hashCode() {
-        int result = phaseName != null ? phaseName.hashCode() : 0;
-        result = 31 * result + (planPhaseSpecifier != null ? planPhaseSpecifier.hashCode() : 0);
-        result = 31 * result + (currency != null ? currency.hashCode() : 0);
-        result = 31 * result + (fixedPrice != null ? fixedPrice.hashCode() : 0);
-        result = 31 * result + (recurringPrice != null ? recurringPrice.hashCode() : 0);
-        result = 31 * result + (usagePriceOverrides != null ? usagePriceOverrides.hashCode() : 0);
-        return result;
+        @Override
+        public PluginPlanPhasePriceOverride build() {
+            return new PluginPlanPhasePriceOverride(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/core/PluginTag.java
+++ b/src/main/java/org/killbill/billing/plugin/api/core/PluginTag.java
@@ -19,126 +19,71 @@
 package org.killbill.billing.plugin.api.core;
 
 import java.util.UUID;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.joda.time.DateTime;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.util.tag.Tag;
+import org.killbill.billing.util.tag.boilerplate.TagImp;
 
-public class PluginTag implements Tag {
-
-    protected final UUID objectId;
-    protected final ObjectType objectType;
-    protected final UUID tagDefinitionId;
-    protected final UUID id;
-    protected final DateTime createdDate;
-    protected final DateTime updatedDate;
+@JsonDeserialize( builder = PluginTag.Builder.class )
+public class PluginTag extends TagImp {
 
     public PluginTag(final UUID objectId,
-                     final ObjectType objectType,
-                     final UUID tagDefinitionId,
-                     final DateTime date) {
+            final ObjectType objectType,
+            final UUID tagDefinitionId,
+            final DateTime date) {
         this(objectId,
-             objectType,
-             tagDefinitionId,
-             null,
-             date,
-             date);
+                objectType,
+                tagDefinitionId,
+                null,
+                date,
+                date);
     }
 
     public PluginTag(final UUID objectId,
-                     final ObjectType objectType,
-                     final UUID tagDefinitionId,
-                     final UUID id,
-                     final DateTime createdDate,
-                     final DateTime updatedDate) {
-        this.objectId = objectId;
-        this.objectType = objectType;
-        this.tagDefinitionId = tagDefinitionId;
-        this.id = id;
-        this.createdDate = createdDate;
-        this.updatedDate = updatedDate;
+            final ObjectType objectType,
+            final UUID tagDefinitionId,
+            final UUID id,
+            final DateTime createdDate,
+            final DateTime updatedDate) {
+
+        this(new Builder<>()
+                .withObjectId(objectId)
+                .withObjectType(objectType)
+                .withTagDefinitionId(tagDefinitionId)
+                .withId(id)
+                .withCreatedDate(createdDate)
+                .withUpdatedDate(updatedDate)
+                .validate());
     }
 
-    @Override
-    public UUID getTagDefinitionId() {
-        return tagDefinitionId;
+    protected PluginTag(final PluginTag.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public ObjectType getObjectType() {
-        return objectType;
+    public PluginTag(final PluginTag that) {
+        super(that);
     }
 
-    @Override
-    public UUID getObjectId() {
-        return objectId;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginTag.Builder<T>> 
+        extends TagImp.Builder<T> {
 
-    @Override
-    public UUID getId() {
-        return id;
-    }
-
-    @Override
-    public DateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    @Override
-    public DateTime getUpdatedDate() {
-        return updatedDate;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginTag{");
-        sb.append("objectId=").append(objectId);
-        sb.append(", objectType=").append(objectType);
-        sb.append(", tagDefinitionId=").append(tagDefinitionId);
-        sb.append(", id=").append(id);
-        sb.append(", createdDate=").append(createdDate);
-        sb.append(", updatedDate=").append(updatedDate);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
         }
 
-        final PluginTag pluginTag = (PluginTag) o;
+        public Builder(final Builder that) {
+            super(that);
+        }
 
-        if (objectId != null ? !objectId.equals(pluginTag.objectId) : pluginTag.objectId != null) {
-            return false;
+        @Override
+        public Builder validate() {
+            return this;
         }
-        if (objectType != pluginTag.objectType) {
-            return false;
-        }
-        if (tagDefinitionId != null ? !tagDefinitionId.equals(pluginTag.tagDefinitionId) : pluginTag.tagDefinitionId != null) {
-            return false;
-        }
-        if (id != null ? !id.equals(pluginTag.id) : pluginTag.id != null) {
-            return false;
-        }
-        if (createdDate != null ? createdDate.compareTo(pluginTag.createdDate) != 0 : pluginTag.createdDate != null) {
-            return false;
-        }
-        return updatedDate != null ? updatedDate.compareTo(pluginTag.updatedDate) == 0 : pluginTag.updatedDate == null;
-    }
 
-    @Override
-    public int hashCode() {
-        int result = objectId != null ? objectId.hashCode() : 0;
-        result = 31 * result + (objectType != null ? objectType.hashCode() : 0);
-        result = 31 * result + (tagDefinitionId != null ? tagDefinitionId.hashCode() : 0);
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        result = 31 * result + (createdDate != null ? createdDate.hashCode() : 0);
-        result = 31 * result + (updatedDate != null ? updatedDate.hashCode() : 0);
-        return result;
+        @Override
+        public PluginTag build() {
+            return new PluginTag(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoiceItem.java
+++ b/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoiceItem.java
@@ -20,477 +20,165 @@ package org.killbill.billing.plugin.api.invoice;
 
 import java.math.BigDecimal;
 import java.util.UUID;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
+import org.killbill.billing.invoice.api.boilerplate.InvoiceItemImp;
 
-public class PluginInvoiceItem implements InvoiceItem {
+@JsonDeserialize( builder = PluginInvoiceItem.Builder.class )
+public class PluginInvoiceItem extends InvoiceItemImp {
 
-    protected final UUID id;
-    protected final InvoiceItemType invoiceItemType;
-    protected final UUID invoiceId;
-    protected final UUID accountId;
-    protected final UUID childAccountId;
-    protected final LocalDate startDate;
-    protected final LocalDate endDate;
-    protected final BigDecimal amount;
-    protected final Currency currency;
-    protected final String description;
-    protected final UUID subscriptionId;
-    protected final UUID bundleId;
-    protected final DateTime catalogEffectiveDate;
-    protected final String productName;
-    protected final String prettyProductName;
-    protected final String planName;
-    protected final String prettyPlanName;
-    protected final String phaseName;
-    protected final String prettyPhaseName;
-    protected final BigDecimal rate;
-    protected final UUID linkedItemId;
-    protected final String usageName;
-    protected final String prettyUsageName;
-    protected final Integer quantity;
-    protected final String itemDetails;
-    protected final DateTime createdDate;
-    protected final DateTime updatedDate;
+  public static PluginInvoiceItem createTaxItem(final InvoiceItem model,
+      final UUID invoiceId,
+      final BigDecimal amount,
+      final String description) {
+    return create(model, invoiceId, model.getStartDate(), model.getEndDate(), amount, description, InvoiceItemType.TAX);
+  }
 
-    public static PluginInvoiceItem createTaxItem(final InvoiceItem model,
-                                                  final UUID invoiceId,
-                                                  final BigDecimal amount,
-                                                  final String description) {
-        return create(model, invoiceId, model.getStartDate(), model.getEndDate(), amount, description, InvoiceItemType.TAX);
+  public static PluginInvoiceItem createTaxItem(final InvoiceItem model,
+      final UUID invoiceId,
+      final LocalDate startDate,
+      final LocalDate endDate,
+      final BigDecimal amount,
+      final String description) {
+    return create(model, invoiceId, startDate, endDate, amount, description, InvoiceItemType.TAX);
+  }
+
+  public static PluginInvoiceItem createAdjustmentItem(final InvoiceItem model,
+      final UUID invoiceId,
+      final LocalDate startDate,
+      final LocalDate endDate,
+      final BigDecimal amount,
+      final String description) {
+    return create(model, invoiceId, startDate, endDate, amount, description, InvoiceItemType.ITEM_ADJ);
+  }
+
+  public static PluginInvoiceItem create(final InvoiceItem model,
+      final UUID invoiceId,
+      final LocalDate startDate,
+      final LocalDate endDate,
+      final BigDecimal amount,
+      final String description,
+      final InvoiceItemType invoiceItemType) {
+    return new PluginInvoiceItem(UUID.randomUUID(),
+        invoiceItemType,
+        invoiceId,
+        model.getAccountId(),
+        model.getChildAccountId(),
+        startDate,
+        endDate,
+        amount,
+        model.getCurrency(),
+        description,
+        model.getSubscriptionId(),
+        model.getBundleId(),
+        model.getCatalogEffectiveDate(),
+        model.getProductName(),
+        model.getPrettyProductName(),
+        model.getPlanName(),
+        model.getPrettyPlanName(),
+        model.getPhaseName(),
+        model.getPrettyPhaseName(),
+        model.getRate(),
+        model.getId(),
+        model.getUsageName(),
+        model.getPrettyUsageName(),
+        model.getQuantity(),
+        model.getItemDetails(),
+        model.getCreatedDate(),
+        model.getUpdatedDate());
+  }
+
+  public PluginInvoiceItem(final UUID id,
+      final InvoiceItemType invoiceItemType,
+      final UUID invoiceId,
+      final UUID accountId,
+      final UUID childAccountId,
+      final LocalDate startDate,
+      final LocalDate endDate,
+      final BigDecimal amount,
+      final Currency currency,
+      final String description,
+      final UUID subscriptionId,
+      final UUID bundleId,
+      final DateTime catalogEffectiveDate,
+      final String productName,
+      final String prettyProductName,
+      final String planName,
+      final String prettyPlanName,
+      final String phaseName,
+      final String prettyPhaseName,
+      final BigDecimal rate,
+      final UUID linkedItemId,
+      final String usageName,
+      final String prettyUsageName,
+      final Integer quantity,
+      final String itemDetails,
+      final DateTime createdDate,
+      final DateTime updatedDate) {
+
+        this(new Builder<>()
+            .withId(id)
+            .withInvoiceItemType(invoiceItemType)
+            .withInvoiceId(invoiceId)
+            .withAccountId(accountId)
+            .withChildAccountId(childAccountId)
+            .withStartDate(startDate)
+            .withEndDate(endDate)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withDescription(description)
+            .withSubscriptionId(subscriptionId)
+            .withBundleId(bundleId)
+            .withCatalogEffectiveDate(catalogEffectiveDate)
+            .withProductName(productName)
+            .withPrettyProductName(prettyProductName)
+            .withPlanName(planName)
+            .withPrettyPlanName(prettyPlanName)
+            .withPhaseName(phaseName)
+            .withPrettyPhaseName(prettyPhaseName)
+            .withRate(rate)
+            .withLinkedItemId(linkedItemId)
+            .withUsageName(usageName)
+            .withPrettyUsageName(prettyUsageName)
+            .withQuantity(quantity)
+            .withItemDetails(itemDetails)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .validate()
+            );
+  }
+
+  protected PluginInvoiceItem(final PluginInvoiceItem.Builder<?> builder) {
+    super(builder);
+  }
+
+  public PluginInvoiceItem(final PluginInvoiceItem that) {
+    super(that);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static class Builder<T extends PluginInvoiceItem.Builder<T>> 
+    extends InvoiceItemImp.Builder<T> {
+
+    public Builder() {
     }
 
-    public static PluginInvoiceItem createTaxItem(final InvoiceItem model,
-                                                  final UUID invoiceId,
-                                                  final LocalDate startDate,
-                                                  final LocalDate endDate,
-                                                  final BigDecimal amount,
-                                                  final String description) {
-        return create(model, invoiceId, startDate, endDate, amount, description, InvoiceItemType.TAX);
-    }
-
-    public static PluginInvoiceItem createAdjustmentItem(final InvoiceItem model,
-                                                         final UUID invoiceId,
-                                                         final LocalDate startDate,
-                                                         final LocalDate endDate,
-                                                         final BigDecimal amount,
-                                                         final String description) {
-        return create(model, invoiceId, startDate, endDate, amount, description, InvoiceItemType.ITEM_ADJ);
-    }
-
-    public static PluginInvoiceItem create(final InvoiceItem model,
-                                           final UUID invoiceId,
-                                           final LocalDate startDate,
-                                           final LocalDate endDate,
-                                           final BigDecimal amount,
-                                           final String description,
-                                           final InvoiceItemType invoiceItemType) {
-        return new PluginInvoiceItem(UUID.randomUUID(),
-                                     invoiceItemType,
-                                     invoiceId,
-                                     model.getAccountId(),
-                                     model.getChildAccountId(),
-                                     startDate,
-                                     endDate,
-                                     amount,
-                                     model.getCurrency(),
-                                     description,
-                                     model.getSubscriptionId(),
-                                     model.getBundleId(),
-                                     model.getCatalogEffectiveDate(),
-                                     model.getProductName(),
-                                     model.getPrettyProductName(),
-                                     model.getPlanName(),
-                                     model.getPrettyPlanName(),
-                                     model.getPhaseName(),
-                                     model.getPrettyPhaseName(),
-                                     model.getRate(),
-                                     model.getId(),
-                                     model.getUsageName(),
-                                     model.getPrettyUsageName(),
-                                     model.getQuantity(),
-                                     model.getItemDetails(),
-                                     model.getCreatedDate(),
-                                     model.getUpdatedDate());
-    }
-
-    public PluginInvoiceItem(final UUID id,
-                             final InvoiceItemType invoiceItemType,
-                             final UUID invoiceId,
-                             final UUID accountId,
-                             final UUID childAccountId,
-                             final LocalDate startDate,
-                             final LocalDate endDate,
-                             final BigDecimal amount,
-                             final Currency currency,
-                             final String description,
-                             final UUID subscriptionId,
-                             final UUID bundleId,
-                             final DateTime catalogEffectiveDate,
-                             final String productName,
-                             final String prettyProductName,
-                             final String planName,
-                             final String prettyPlanName,
-                             final String phaseName,
-                             final String prettyPhaseName,
-                             final BigDecimal rate,
-                             final UUID linkedItemId,
-                             final String usageName,
-                             final String prettyUsageName,
-                             final Integer quantity,
-                             final String itemDetails,
-                             final DateTime createdDate,
-                             final DateTime updatedDate) {
-        this.id = id;
-        this.invoiceItemType = invoiceItemType;
-        this.invoiceId = invoiceId;
-        this.accountId = accountId;
-        this.childAccountId = childAccountId;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.amount = amount;
-        this.currency = currency;
-        this.description = description;
-        this.subscriptionId = subscriptionId;
-        this.bundleId = bundleId;
-        this.catalogEffectiveDate = catalogEffectiveDate;
-        this.productName = productName;
-        this.prettyProductName = prettyProductName;
-        this.planName = planName;
-        this.prettyPlanName = prettyPlanName;
-        this.phaseName = phaseName;
-        this.prettyPhaseName = prettyPhaseName;
-        this.rate = rate;
-        this.linkedItemId = linkedItemId;
-        this.usageName = usageName;
-        this.prettyUsageName = prettyUsageName;
-        this.quantity = quantity;
-        this.itemDetails = itemDetails;
-        this.createdDate = createdDate;
-        this.updatedDate = updatedDate;
+    public Builder(final Builder that) {
+      super(that);
     }
 
     @Override
-    public UUID getId() {
-        return id;
+    public Builder validate() {
+      return this;
     }
 
     @Override
-    public InvoiceItemType getInvoiceItemType() {
-        return invoiceItemType;
+    public PluginInvoiceItem build() {
+      return new PluginInvoiceItem(this.validate());
     }
-
-    @Override
-    public UUID getInvoiceId() {
-        return invoiceId;
-    }
-
-    @Override
-    public UUID getAccountId() {
-        return accountId;
-    }
-
-    @Override
-    public UUID getChildAccountId() {
-        return childAccountId;
-    }
-
-    @Override
-    public LocalDate getStartDate() {
-        return startDate;
-    }
-
-    @Override
-    public LocalDate getEndDate() {
-        return endDate;
-    }
-
-    @Override
-    public BigDecimal getAmount() {
-        return amount;
-    }
-
-    @Override
-    public Currency getCurrency() {
-        return currency;
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public UUID getSubscriptionId() {
-        return subscriptionId;
-    }
-
-    @Override
-    public String getProductName() {
-        return this.productName;
-    }
-
-    @Override
-    public String getPrettyProductName() {
-        return this.prettyProductName;
-    }
-
-    @Override
-    public UUID getBundleId() {
-        return bundleId;
-    }
-
-    @Override
-    public DateTime getCatalogEffectiveDate() {
-        return catalogEffectiveDate;
-    }
-
-    @Override
-    public String getPlanName() {
-        return planName;
-    }
-
-    @Override
-    public String getPrettyPlanName() {
-        return prettyPlanName;
-    }
-
-    @Override
-    public String getPhaseName() {
-        return phaseName;
-    }
-
-    @Override
-    public String getPrettyPhaseName() {
-        return prettyPhaseName;
-    }
-
-    @Override
-    public BigDecimal getRate() {
-        return rate;
-    }
-
-    @Override
-    public UUID getLinkedItemId() {
-        return linkedItemId;
-    }
-
-    @Override
-    public String getUsageName() {
-        return usageName;
-    }
-
-    @Override
-    public String getPrettyUsageName() {
-        return prettyUsageName;
-    }
-
-    @Override
-    public Integer getQuantity() {
-        return quantity;
-    }
-
-    @Override
-    public String getItemDetails() {
-        return itemDetails;
-    }
-
-    @Override
-    public DateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    @Override
-    public DateTime getUpdatedDate() {
-        return updatedDate;
-    }
-
-    @Override
-    public boolean matches(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof PluginInvoiceItem)) {
-            return false;
-        }
-
-        final PluginInvoiceItem that = (PluginInvoiceItem) o;
-
-        if (accountId != null ? !accountId.equals(that.accountId) : that.accountId != null) {
-            return false;
-        }
-        if (childAccountId != null ? !childAccountId.equals(that.childAccountId) : that.childAccountId != null) {
-            return false;
-        }
-        if (bundleId != null ? !bundleId.equals(that.bundleId) : that.bundleId != null) {
-            return false;
-        }
-        if (subscriptionId != null ? !subscriptionId.equals(that.subscriptionId) : that.subscriptionId != null) {
-            return false;
-        }
-        if (invoiceItemType != that.invoiceItemType) {
-            return false;
-        }
-        if (safeCompareTo(catalogEffectiveDate, that.catalogEffectiveDate) != 0) {
-            return false;
-        }
-        if (safeCompareTo(startDate, that.startDate) != 0) {
-            return false;
-        }
-        if (safeCompareTo(endDate, that.endDate) != 0) {
-            return false;
-        }
-        if (safeCompareTo(amount, that.amount) != 0) {
-            return false;
-        }
-        if (safeCompareTo(rate, that.rate) != 0) {
-            return false;
-        }
-        if (currency != that.currency) {
-            return false;
-        }
-        if (phaseName != null ? !phaseName.equals(that.phaseName) : that.phaseName != null) {
-            return false;
-        }
-        if (prettyPhaseName != null ? !prettyPhaseName.equals(that.prettyPhaseName) : that.prettyPhaseName != null) {
-            return false;
-        }
-        if (planName != null ? !planName.equals(that.planName) : that.planName != null) {
-            return false;
-        }
-        if (prettyPlanName != null ? !prettyPlanName.equals(that.prettyPlanName) : that.prettyPlanName != null) {
-            return false;
-        }
-        if (usageName != null ? !usageName.equals(that.usageName) : that.usageName != null) {
-            return false;
-        }
-        if (prettyUsageName != null ? !prettyUsageName.equals(that.prettyUsageName) : that.prettyUsageName != null) {
-            return false;
-        }
-        if (quantity != null ? !quantity.equals(that.quantity) : that.quantity != null) {
-            return false;
-        }
-        if (itemDetails != null ? !itemDetails.equals(that.itemDetails) : that.itemDetails != null) {
-            return false;
-        }
-        return true;
-    }
-
-    protected <T> int safeCompareTo(final Comparable<T> c1, final T c2) {
-        if (c1 == null && c2 == null) {
-            return 0;
-        } else if (c1 == null) {
-            return -1;
-        } else if (c2 == null) {
-            return 1;
-        } else {
-            return c1.compareTo(c2);
-        }
-    }
-
-    @Override
-    public String toString() {
-        final StringBuffer sb = new StringBuffer("PluginInvoiceItem{");
-        sb.append("id=").append(id);
-        sb.append(", invoiceItemType=").append(invoiceItemType);
-        sb.append(", invoiceId=").append(invoiceId);
-        sb.append(", accountId=").append(accountId);
-        sb.append(", childAccountId=").append(childAccountId);
-        sb.append(", startDate=").append(startDate);
-        sb.append(", endDate=").append(endDate);
-        sb.append(", amount=").append(amount);
-        sb.append(", currency=").append(currency);
-        sb.append(", description='").append(description).append('\'');
-        sb.append(", subscriptionId=").append(subscriptionId);
-        sb.append(", bundleId=").append(bundleId);
-        sb.append(", catalogEffectiveDate=").append(catalogEffectiveDate);
-        sb.append(", productName='").append(productName).append('\'');
-        sb.append(", prettyProductName='").append(prettyProductName).append('\'');
-        sb.append(", planName='").append(planName).append('\'');
-        sb.append(", prettyPlanName='").append(prettyPlanName).append('\'');
-        sb.append(", phaseName='").append(phaseName).append('\'');
-        sb.append(", prettyPhaseName='").append(prettyPhaseName).append('\'');
-        sb.append(", rate=").append(rate);
-        sb.append(", linkedItemId=").append(linkedItemId);
-        sb.append(", usageName='").append(usageName).append('\'');
-        sb.append(", prettyUsageName='").append(prettyUsageName).append('\'');
-        sb.append(", quantity=").append(quantity);
-        sb.append(", itemDetails='").append(itemDetails).append('\'');
-        sb.append(", createdDate=").append(createdDate);
-        sb.append(", updatedDate=").append(updatedDate);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!matches(o)) {
-            return false;
-        }
-
-        final PluginInvoiceItem that = (PluginInvoiceItem) o;
-
-        if (createdDate != null ? !createdDate.equals(that.createdDate) : that.createdDate != null) {
-            return false;
-        }
-        if (description != null ? !description.equals(that.description) : that.description != null) {
-            return false;
-        }
-        if (id != null ? !id.equals(that.id) : that.id != null) {
-            return false;
-        }
-        if (invoiceId != null ? !invoiceId.equals(that.invoiceId) : that.invoiceId != null) {
-            return false;
-        }
-        if (linkedItemId != null ? !linkedItemId.equals(that.linkedItemId) : that.linkedItemId != null) {
-            return false;
-        }
-        if (updatedDate != null ? !updatedDate.equals(that.updatedDate) : that.updatedDate != null) {
-            return false;
-        }
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (invoiceItemType != null ? invoiceItemType.hashCode() : 0);
-        result = 31 * result + (invoiceId != null ? invoiceId.hashCode() : 0);
-        result = 31 * result + (accountId != null ? accountId.hashCode() : 0);
-        result = 31 * result + (childAccountId != null ? childAccountId.hashCode() : 0);
-        result = 31 * result + (startDate != null ? startDate.hashCode() : 0);
-        result = 31 * result + (endDate != null ? endDate.hashCode() : 0);
-        result = 31 * result + (amount != null ? amount.hashCode() : 0);
-        result = 31 * result + (currency != null ? currency.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (subscriptionId != null ? subscriptionId.hashCode() : 0);
-        result = 31 * result + (bundleId != null ? bundleId.hashCode() : 0);
-        result = 31 * result + (catalogEffectiveDate != null ? catalogEffectiveDate.hashCode() : 0);
-        result = 31 * result + (productName != null ? productName.hashCode() : 0);
-        result = 31 * result + (prettyProductName != null ? prettyProductName.hashCode() : 0);
-        result = 31 * result + (planName != null ? planName.hashCode() : 0);
-        result = 31 * result + (prettyPlanName != null ? prettyPlanName.hashCode() : 0);
-        result = 31 * result + (phaseName != null ? phaseName.hashCode() : 0);
-        result = 31 * result + (prettyPhaseName != null ? prettyPhaseName.hashCode() : 0);
-        result = 31 * result + (rate != null ? rate.hashCode() : 0);
-        result = 31 * result + (linkedItemId != null ? linkedItemId.hashCode() : 0);
-        result = 31 * result + (usageName != null ? usageName.hashCode() : 0);
-        result = 31 * result + (prettyUsageName != null ? prettyUsageName.hashCode() : 0);
-        result = 31 * result + (quantity != null ? quantity.hashCode() : 0);
-        result = 31 * result + (itemDetails != null ? itemDetails.hashCode() : 0);
-        result = 31 * result + (createdDate != null ? createdDate.hashCode() : 0);
-        result = 31 * result + (updatedDate != null ? updatedDate.hashCode() : 0);
-        return result;
-    }
+  }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/payment/PluginGatewayNotification.java
+++ b/src/main/java/org/killbill/billing/plugin/api/payment/PluginGatewayNotification.java
@@ -22,114 +22,68 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.killbill.billing.payment.api.PluginProperty;
-import org.killbill.billing.payment.plugin.api.GatewayNotification;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.plugin.api.GatewayNotification;
+import org.killbill.billing.payment.plugin.api.boilerplate.GatewayNotificationImp;
 
-public class PluginGatewayNotification implements GatewayNotification {
-
-    protected final UUID kbPaymentId;
-    protected final int status;
-    protected final String entity;
-    protected final Map<String, List<String>> headers;
-    protected final List<PluginProperty> properties;
+@JsonDeserialize( builder = PluginGatewayNotification.Builder.class )
+public class PluginGatewayNotification extends GatewayNotificationImp {
 
     public PluginGatewayNotification(final String entity) {
         this(null,
-             200,
-             entity,
-             ImmutableMap.<String, List<String>>of(),
-             ImmutableList.<PluginProperty>of());
+                200,
+                entity,
+                ImmutableMap.<String, List<String>>of(),
+                ImmutableList.<PluginProperty>of());
     }
 
     public PluginGatewayNotification(final UUID kbPaymentId,
-                                     final int status,
-                                     final String entity,
-                                     final Map<String, List<String>> headers,
-                                     final List<PluginProperty> properties) {
-        this.kbPaymentId = kbPaymentId;
-        this.status = status;
-        this.entity = entity;
-        this.headers = headers;
-        this.properties = properties;
+            final int status,
+            final String entity,
+            final Map<String, List<String>> headers,
+            final List<PluginProperty> properties) {
+        this(new Builder<>()
+                .withKbPaymentId(kbPaymentId)
+                .withStatus(status)
+                .withEntity(entity)
+                .withHeaders(headers)
+                .withProperties(properties)
+                .validate());
     }
 
-    @Override
-    public UUID getKbPaymentId() {
-        return kbPaymentId;
+    protected PluginGatewayNotification(final PluginGatewayNotification.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public int getStatus() {
-        return status;
+    public PluginGatewayNotification(final PluginGatewayNotification that) {
+        super(that);
     }
 
-    @Override
-    public String getEntity() {
-        return entity;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginGatewayNotification.Builder<T>> 
+        extends GatewayNotificationImp.Builder<T> {
 
-    @Override
-    public Map<String, List<String>> getHeaders() {
-        return headers;
-    }
-
-    @Override
-    public List<PluginProperty> getProperties() {
-        return properties;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginGatewayNotification{");
-        sb.append("kbPaymentId=").append(kbPaymentId);
-        sb.append(", status=").append(status);
-        sb.append(", entity='").append(entity).append('\'');
-        sb.append(", headers=").append(headers);
-        sb.append(", properties=").append(properties);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
+            this.withStatus(200);
+            this.withHeaders(ImmutableMap.<String, List<String>>of());
+            this.withProperties(ImmutableList.<PluginProperty>of());
         }
 
-        final PluginGatewayNotification that = (PluginGatewayNotification) o;
-
-        if (status != that.status) {
-            return false;
-        }
-        if (entity != null ? !entity.equals(that.entity) : that.entity != null) {
-            return false;
-        }
-        if (headers != null ? !headers.equals(that.headers) : that.headers != null) {
-            return false;
-        }
-        if (kbPaymentId != null ? !kbPaymentId.equals(that.kbPaymentId) : that.kbPaymentId != null) {
-            return false;
-        }
-        if (properties != null ? !properties.equals(that.properties) : that.properties != null) {
-            return false;
+        public Builder(final Builder that) {
+            super(that);
         }
 
-        return true;
-    }
+        @Override
+        public Builder validate() {
+          return this;
+        }
 
-    @Override
-    public int hashCode() {
-        int result = kbPaymentId != null ? kbPaymentId.hashCode() : 0;
-        result = 31 * result + status;
-        result = 31 * result + (entity != null ? entity.hashCode() : 0);
-        result = 31 * result + (headers != null ? headers.hashCode() : 0);
-        result = 31 * result + (properties != null ? properties.hashCode() : 0);
-        return result;
+        @Override
+        public PluginGatewayNotification build() {
+            return new PluginGatewayNotification(validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/payment/PluginPaymentMethodPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/api/payment/PluginPaymentMethodPlugin.java
@@ -20,91 +20,54 @@ package org.killbill.billing.plugin.api.payment;
 
 import java.util.List;
 import java.util.UUID;
-
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.killbill.billing.payment.api.PaymentMethodPlugin;
 import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.api.boilerplate.PaymentMethodPluginImp;
 
-public class PluginPaymentMethodPlugin implements PaymentMethodPlugin {
-
-    protected final UUID kbPaymentMethodId;
-    protected final String externalPaymentMethodId;
-    protected final boolean isDefaultPaymentMethod;
-    protected final List<PluginProperty> properties;
+@JsonDeserialize( builder = PluginPaymentMethodPlugin.Builder.class )
+public class PluginPaymentMethodPlugin extends PaymentMethodPluginImp {
 
     public PluginPaymentMethodPlugin(final UUID kbPaymentMethodId,
-                                     final String externalPaymentMethodId,
-                                     final boolean isDefaultPaymentMethod,
-                                     final List<PluginProperty> properties) {
-        this.kbPaymentMethodId = kbPaymentMethodId;
-        this.externalPaymentMethodId = externalPaymentMethodId;
-        this.isDefaultPaymentMethod = isDefaultPaymentMethod;
-        this.properties = properties;
+            final String externalPaymentMethodId,
+            final boolean isDefaultPaymentMethod,
+            final List<PluginProperty> properties) {
+
+        this(new Builder<>()
+                .withKbPaymentMethodId(kbPaymentMethodId)
+                .withExternalPaymentMethodId(externalPaymentMethodId)
+                .withIsDefaultPaymentMethod(isDefaultPaymentMethod)
+                .withProperties(properties)
+                .validate());
     }
 
-    @Override
-    public UUID getKbPaymentMethodId() {
-        return kbPaymentMethodId;
+    protected PluginPaymentMethodPlugin(final PluginPaymentMethodPlugin.Builder<?> builder) {
+        super(builder);
     }
 
-    @Override
-    public String getExternalPaymentMethodId() {
-        return externalPaymentMethodId;
+    public PluginPaymentMethodPlugin(final PluginPaymentMethodPlugin that) {
+        super(that);
     }
 
-    @Override
-    public boolean isDefaultPaymentMethod() {
-        return isDefaultPaymentMethod;
-    }
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginPaymentMethodPlugin.Builder<T>> 
+        extends PaymentMethodPluginImp.Builder<T> {
 
-    @Override
-    public List<PluginProperty> getProperties() {
-        return properties;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PluginPaymentMethodPlugin{");
-        sb.append("kbPaymentMethodId=").append(kbPaymentMethodId);
-        sb.append(", externalPaymentMethodId='").append(externalPaymentMethodId).append('\'');
-        sb.append(", isDefaultPaymentMethod=").append(isDefaultPaymentMethod);
-        sb.append(", properties=").append(properties);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+        public Builder() {
         }
 
-        final PluginPaymentMethodPlugin that = (PluginPaymentMethodPlugin) o;
-
-        if (isDefaultPaymentMethod != that.isDefaultPaymentMethod) {
-            return false;
-        }
-        if (externalPaymentMethodId != null ? !externalPaymentMethodId.equals(that.externalPaymentMethodId) : that.externalPaymentMethodId != null) {
-            return false;
-        }
-        if (kbPaymentMethodId != null ? !kbPaymentMethodId.equals(that.kbPaymentMethodId) : that.kbPaymentMethodId != null) {
-            return false;
-        }
-        if (properties != null ? !properties.equals(that.properties) : that.properties != null) {
-            return false;
+        public Builder(final Builder that) {
+            super(that);
         }
 
-        return true;
-    }
+        @Override
+        public Builder validate() {
+            return this;
+        }
 
-    @Override
-    public int hashCode() {
-        int result = kbPaymentMethodId != null ? kbPaymentMethodId.hashCode() : 0;
-        result = 31 * result + (externalPaymentMethodId != null ? externalPaymentMethodId.hashCode() : 0);
-        result = 31 * result + (isDefaultPaymentMethod ? 1 : 0);
-        result = 31 * result + (properties != null ? properties.hashCode() : 0);
-        return result;
+        @Override
+        public PluginPaymentMethodPlugin build() {
+            return new PluginPaymentMethodPlugin(this.validate());
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/api/payment/PluginPaymentTransactionInfoPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/api/payment/PluginPaymentTransactionInfoPlugin.java
@@ -19,58 +19,97 @@
 package org.killbill.billing.plugin.api.payment;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
-
 import org.joda.time.DateTime;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+import org.killbill.billing.payment.plugin.api.boilerplate.PaymentTransactionInfoPluginImp;
 
+@JsonDeserialize( builder = PluginPaymentTransactionInfoPlugin.Builder.class )
 public class PluginPaymentTransactionInfoPlugin implements PaymentTransactionInfoPlugin {
 
-    protected final UUID kbPaymentId;
-    protected final UUID kbTransactionPaymentPaymentId;
-    protected final TransactionType transactionType;
-    protected final BigDecimal amount;
-    protected final Currency currency;
-    protected final PaymentPluginStatus pluginStatus;
-    protected final String gatewayError;
-    protected final String gatewayErrorCode;
-    protected final String firstPaymentReferenceId;
-    protected final String secondPaymentReferenceId;
-    protected final DateTime createdDate;
-    protected final DateTime effectiveDate;
-    protected final List<PluginProperty> properties;
+    final protected UUID kbPaymentId;
+    final protected UUID kbTransactionPaymentPaymentId;   // non-conformant name, expected 'kbTransactionPaymentId'
+    final protected TransactionType transactionType;
+    final protected BigDecimal amount;
+    final protected Currency currency;
+    final protected PaymentPluginStatus pluginStatus;     // non-conformant name, expected 'status'
+    final protected String gatewayError;
+    final protected String gatewayErrorCode;
+    final protected String firstPaymentReferenceId;
+    final protected String secondPaymentReferenceId;
+    final protected DateTime createdDate;
+    final protected DateTime effectiveDate;
+    final protected List<PluginProperty> properties;
 
     public PluginPaymentTransactionInfoPlugin(final UUID kbPaymentId,
-                                              final UUID kbTransactionPaymentPaymentId,
-                                              final TransactionType transactionType,
-                                              final BigDecimal amount,
-                                              final Currency currency,
-                                              final PaymentPluginStatus pluginStatus,
-                                              final String gatewayError,
-                                              final String gatewayErrorCode,
-                                              final String firstPaymentReferenceId,
-                                              final String secondPaymentReferenceId,
-                                              final DateTime createdDate,
-                                              final DateTime effectiveDate,
-                                              final List<PluginProperty> properties) {
-        this.kbPaymentId = kbPaymentId;
-        this.kbTransactionPaymentPaymentId = kbTransactionPaymentPaymentId;
-        this.transactionType = transactionType;
-        this.amount = amount;
-        this.currency = currency;
-        this.pluginStatus = pluginStatus;
-        this.gatewayError = gatewayError;
-        this.gatewayErrorCode = gatewayErrorCode;
-        this.firstPaymentReferenceId = firstPaymentReferenceId;
-        this.secondPaymentReferenceId = secondPaymentReferenceId;
-        this.createdDate = createdDate;
-        this.effectiveDate = effectiveDate;
-        this.properties = properties;
+            final UUID kbTransactionPaymentPaymentId,
+            final TransactionType transactionType,
+            final BigDecimal amount,
+            final Currency currency,
+            final PaymentPluginStatus pluginStatus,
+            final String gatewayError,
+            final String gatewayErrorCode,
+            final String firstPaymentReferenceId,
+            final String secondPaymentReferenceId,
+            final DateTime createdDate,
+            final DateTime effectiveDate,
+            final List<PluginProperty> properties) {
+
+        this(new Builder<>()
+                .withKbPaymentId(kbPaymentId)
+                .withKbTransactionPaymentId(kbTransactionPaymentPaymentId)
+                .withTransactionType(transactionType)
+                .withAmount(amount)
+                .withCurrency(currency)
+                .withStatus(pluginStatus)
+                .withGatewayError(gatewayError)
+                .withGatewayErrorCode(gatewayErrorCode)
+                .withFirstPaymentReferenceId(firstPaymentReferenceId)
+                .withSecondPaymentReferenceId(secondPaymentReferenceId)
+                .withCreatedDate(createdDate)
+                .withEffectiveDate(effectiveDate)
+                .withProperties(properties)
+                .validate());
+    }
+
+    public PluginPaymentTransactionInfoPlugin(final PluginPaymentTransactionInfoPlugin that) {
+        this.amount = that.amount;
+        this.createdDate = that.createdDate;
+        this.currency = that.currency;
+        this.effectiveDate = that.effectiveDate;
+        this.firstPaymentReferenceId = that.firstPaymentReferenceId;
+        this.gatewayError = that.gatewayError;
+        this.gatewayErrorCode = that.gatewayErrorCode;
+        this.kbPaymentId = that.kbPaymentId;
+        this.kbTransactionPaymentPaymentId = that.kbTransactionPaymentPaymentId;
+        this.properties = that.properties;
+        this.secondPaymentReferenceId = that.secondPaymentReferenceId;
+        this.pluginStatus = that.pluginStatus;
+        this.transactionType = that.transactionType;
+    }
+
+    protected PluginPaymentTransactionInfoPlugin(final PluginPaymentTransactionInfoPlugin.Builder<?> builder) {
+        this.amount = builder.amount;
+        this.createdDate = builder.createdDate;
+        this.currency = builder.currency;
+        this.effectiveDate = builder.effectiveDate;
+        this.firstPaymentReferenceId = builder.firstPaymentReferenceId;
+        this.gatewayError = builder.gatewayError;
+        this.gatewayErrorCode = builder.gatewayErrorCode;
+        this.kbPaymentId = builder.kbPaymentId;
+        this.kbTransactionPaymentPaymentId = builder.kbTransactionPaymentId;
+        this.properties = builder.properties;
+        this.secondPaymentReferenceId = builder.secondPaymentReferenceId;
+        this.pluginStatus = builder.status;
+        this.transactionType = builder.transactionType;
     }
 
     @Override
@@ -138,6 +177,7 @@ public class PluginPaymentTransactionInfoPlugin implements PaymentTransactionInf
         return properties;
     }
 
+    /*
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("PluginPaymentTransactionInfoPlugin{");
@@ -166,7 +206,6 @@ public class PluginPaymentTransactionInfoPlugin implements PaymentTransactionInf
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         final PluginPaymentTransactionInfoPlugin that = (PluginPaymentTransactionInfoPlugin) o;
 
         if (amount != null ? !amount.equals(that.amount) : that.amount != null) {
@@ -229,4 +268,254 @@ public class PluginPaymentTransactionInfoPlugin implements PaymentTransactionInf
         result = 31 * result + (properties != null ? properties.hashCode() : 0);
         return result;
     }
+    */
+
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final PluginPaymentTransactionInfoPlugin that = (PluginPaymentTransactionInfoPlugin) o;
+        if( ( this.amount != null ) ? ( 0 != this.amount.compareTo(that.amount) ) : ( that.amount != null ) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.currency, that.currency) ) {
+            return false;
+        }
+        if( ( this.effectiveDate != null ) ? ( 0 != this.effectiveDate.compareTo(that.effectiveDate) ) : ( that.effectiveDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.firstPaymentReferenceId, that.firstPaymentReferenceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.gatewayError, that.gatewayError) ) {
+            return false;
+        }
+        if( !Objects.equals(this.gatewayErrorCode, that.gatewayErrorCode) ) {
+            return false;
+        }
+        if( !Objects.equals(this.kbPaymentId, that.kbPaymentId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.kbTransactionPaymentPaymentId, that.kbTransactionPaymentPaymentId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.properties, that.properties) ) {
+            return false;
+        }
+        if( !Objects.equals(this.secondPaymentReferenceId, that.secondPaymentReferenceId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginStatus, that.pluginStatus) ) {
+            return false;
+        }
+        if( !Objects.equals(this.transactionType, that.transactionType) ) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.currency);
+        result = ( 31 * result ) + Objects.hashCode(this.effectiveDate);
+        result = ( 31 * result ) + Objects.hashCode(this.firstPaymentReferenceId);
+        result = ( 31 * result ) + Objects.hashCode(this.gatewayError);
+        result = ( 31 * result ) + Objects.hashCode(this.gatewayErrorCode);
+        result = ( 31 * result ) + Objects.hashCode(this.kbPaymentId);
+        result = ( 31 * result ) + Objects.hashCode(this.kbTransactionPaymentPaymentId);
+        result = ( 31 * result ) + Objects.hashCode(this.properties);
+        result = ( 31 * result ) + Objects.hashCode(this.secondPaymentReferenceId);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginStatus);
+        result = ( 31 * result ) + Objects.hashCode(this.transactionType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("currency=").append(this.currency);
+        sb.append(", ");
+        sb.append("effectiveDate=").append(this.effectiveDate);
+        sb.append(", ");
+        sb.append("firstPaymentReferenceId=");
+        if( this.firstPaymentReferenceId == null ) {
+            sb.append(this.firstPaymentReferenceId);
+        }else{
+            sb.append("'").append(this.firstPaymentReferenceId).append("'");
+        }
+        sb.append(", ");
+        sb.append("gatewayError=");
+        if( this.gatewayError == null ) {
+            sb.append(this.gatewayError);
+        }else{
+            sb.append("'").append(this.gatewayError).append("'");
+        }
+        sb.append(", ");
+        sb.append("gatewayErrorCode=");
+        if( this.gatewayErrorCode == null ) {
+            sb.append(this.gatewayErrorCode);
+        }else{
+            sb.append("'").append(this.gatewayErrorCode).append("'");
+        }
+        sb.append(", ");
+        sb.append("kbPaymentId=").append(this.kbPaymentId);
+        sb.append(", ");
+        sb.append("kbTransactionPaymentId=").append(this.kbTransactionPaymentPaymentId);
+        sb.append(", ");
+        sb.append("properties=").append(this.properties);
+        sb.append(", ");
+        sb.append("secondPaymentReferenceId=");
+        if( this.secondPaymentReferenceId == null ) {
+            sb.append(this.secondPaymentReferenceId);
+        }else{
+            sb.append("'").append(this.secondPaymentReferenceId).append("'");
+        }
+        sb.append(", ");
+        sb.append("status=").append(this.pluginStatus);
+        sb.append(", ");
+        sb.append("transactionType=").append(this.transactionType);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends PluginPaymentTransactionInfoPlugin.Builder<T>> {
+
+        protected BigDecimal amount;
+        protected DateTime createdDate;
+        protected Currency currency;
+        protected DateTime effectiveDate;
+        protected String firstPaymentReferenceId;
+        protected String gatewayError;
+        protected String gatewayErrorCode;
+        protected UUID kbPaymentId;
+        protected UUID kbTransactionPaymentId;
+        protected List<PluginProperty> properties;
+        protected String secondPaymentReferenceId;
+        protected PaymentPluginStatus status;
+        protected TransactionType transactionType;
+
+        public Builder() { }
+
+        public Builder(final Builder that) {
+            this.amount = that.amount;
+            this.createdDate = that.createdDate;
+            this.currency = that.currency;
+            this.effectiveDate = that.effectiveDate;
+            this.firstPaymentReferenceId = that.firstPaymentReferenceId;
+            this.gatewayError = that.gatewayError;
+            this.gatewayErrorCode = that.gatewayErrorCode;
+            this.kbPaymentId = that.kbPaymentId;
+            this.kbTransactionPaymentId = that.kbTransactionPaymentId;
+            this.properties = that.properties;
+            this.secondPaymentReferenceId = that.secondPaymentReferenceId;
+            this.status = that.status;
+            this.transactionType = that.transactionType;
+        }
+
+        public T withAmount(final BigDecimal amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+
+        public T withCurrency(final Currency currency) {
+            this.currency = currency;
+            return (T) this;
+        }
+
+        public T withEffectiveDate(final DateTime effectiveDate) {
+            this.effectiveDate = effectiveDate;
+            return (T) this;
+        }
+
+        public T withFirstPaymentReferenceId(final String firstPaymentReferenceId) {
+            this.firstPaymentReferenceId = firstPaymentReferenceId;
+            return (T) this;
+        }
+
+        public T withGatewayError(final String gatewayError) {
+            this.gatewayError = gatewayError;
+            return (T) this;
+        }
+
+        public T withGatewayErrorCode(final String gatewayErrorCode) {
+            this.gatewayErrorCode = gatewayErrorCode;
+            return (T) this;
+        }
+
+        public T withKbPaymentId(final UUID kbPaymentId) {
+            this.kbPaymentId = kbPaymentId;
+            return (T) this;
+        }
+
+        public T withKbTransactionPaymentId(final UUID kbTransactionPaymentId) {
+            this.kbTransactionPaymentId = kbTransactionPaymentId;
+            return (T) this;
+        }
+
+        public T withProperties(final List<PluginProperty> properties) {
+            this.properties = properties;
+            return (T) this;
+        }
+
+        public T withSecondPaymentReferenceId(final String secondPaymentReferenceId) {
+            this.secondPaymentReferenceId = secondPaymentReferenceId;
+            return (T) this;
+        }
+
+        public T withStatus(final PaymentPluginStatus status) {
+            this.status = status;
+            return (T) this;
+        }
+
+        public T withTransactionType(final TransactionType transactionType) {
+            this.transactionType = transactionType;
+            return (T) this;
+        }
+
+        public T source(final PaymentTransactionInfoPlugin that) {
+            this.amount = that.getAmount();
+            this.createdDate = that.getCreatedDate();
+            this.currency = that.getCurrency();
+            this.effectiveDate = that.getEffectiveDate();
+            this.firstPaymentReferenceId = that.getFirstPaymentReferenceId();
+            this.gatewayError = that.getGatewayError();
+            this.gatewayErrorCode = that.getGatewayErrorCode();
+            this.kbPaymentId = that.getKbPaymentId();
+            this.kbTransactionPaymentId = that.getKbTransactionPaymentId();
+            this.properties = that.getProperties();
+            this.secondPaymentReferenceId = that.getSecondPaymentReferenceId();
+            this.status = that.getStatus();
+            this.transactionType = that.getTransactionType();
+            return (T) this;
+        }
+
+        protected Builder validate() {
+            return this;
+        }
+
+        public PluginPaymentTransactionInfoPlugin build() {
+            return new PluginPaymentTransactionInfoPlugin(this.validate());
+        }
+    }
+
 }

--- a/src/main/java/org/killbill/billing/security/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/security/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.security.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.security.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/security/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/security/api/boilerplate/Resolver.java
@@ -1,0 +1,27 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.security.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.security.api.SecurityApi;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(SecurityApi.class, SecurityApiImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/security/api/boilerplate/SecurityApiImp.java
+++ b/src/main/java/org/killbill/billing/security/api/boilerplate/SecurityApiImp.java
@@ -1,0 +1,154 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.security.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.killbill.billing.security.Logical;
+import org.killbill.billing.security.Permission;
+import org.killbill.billing.security.SecurityApiException;
+import org.killbill.billing.security.api.SecurityApi;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = SecurityApiImp.Builder.class )
+public class SecurityApiImp implements SecurityApi, Serializable {
+
+    private static final long serialVersionUID = 0x393376B2A663D474L;
+
+    protected boolean isSubjectAuthenticated;
+
+    public SecurityApiImp(final SecurityApiImp that) {
+        this.isSubjectAuthenticated = that.isSubjectAuthenticated;
+    }
+    protected SecurityApiImp(final SecurityApiImp.Builder<?> builder) {
+        this.isSubjectAuthenticated = builder.isSubjectAuthenticated;
+    }
+    protected SecurityApiImp() { }
+    @Override
+    @JsonGetter("isSubjectAuthenticated")
+    public boolean isSubjectAuthenticated() {
+        return this.isSubjectAuthenticated;
+    }
+    @Override
+    public void addUserRoles(final String username, final String clearPassword, final List<String> roles, final CallContext context) {
+        throw new UnsupportedOperationException("addUserRoles(java.lang.String, java.lang.String, java.util.List<java.lang.String>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void checkCurrentUserPermissions(final List<Permission> permissions, final Logical logical, final TenantContext context) {
+        throw new UnsupportedOperationException("checkCurrentUserPermissions(java.util.List<org.killbill.billing.security.Permission>, org.killbill.billing.security.Logical, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Set<String> getCurrentUserPermissions(final TenantContext context) {
+        throw new UnsupportedOperationException("getCurrentUserPermissions(org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void logout() {
+        throw new UnsupportedOperationException("logout() must be implemented.");
+    }
+    @Override
+    public void login(final Object principal, final Object credentials) {
+        throw new UnsupportedOperationException("login(java.lang.Object, java.lang.Object) must be implemented.");
+    }
+    @Override
+    public List<String> getRoleDefinition(final String role, final TenantContext tenantContext) {
+        throw new UnsupportedOperationException("getRoleDefinition(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void updateRoleDefinition(final String role, final List<String> permissions, final CallContext context) {
+        throw new UnsupportedOperationException("updateRoleDefinition(java.lang.String, java.util.List<java.lang.String>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<String> getUserRoles(final String username, final TenantContext tenantContext) {
+        throw new UnsupportedOperationException("getUserRoles(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void invalidateUser(final String username, final CallContext context) {
+        throw new UnsupportedOperationException("invalidateUser(java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void updateUserRoles(final String username, final List<String> roles, final CallContext context) {
+        throw new UnsupportedOperationException("updateUserRoles(java.lang.String, java.util.List<java.lang.String>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void addRoleDefinition(final String role, final List<String> permissions, final CallContext context) {
+        throw new UnsupportedOperationException("addRoleDefinition(java.lang.String, java.util.List<java.lang.String>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void updateUserPassword(final String username, final String clearPassword, final CallContext context) {
+        throw new UnsupportedOperationException("updateUserPassword(java.lang.String, java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final SecurityApiImp that = (SecurityApiImp) o;
+        if( this.isSubjectAuthenticated != that.isSubjectAuthenticated ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.isSubjectAuthenticated);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("isSubjectAuthenticated=").append(this.isSubjectAuthenticated);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends SecurityApiImp.Builder<T>> {
+
+        protected boolean isSubjectAuthenticated;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.isSubjectAuthenticated = that.isSubjectAuthenticated;
+        }
+        public T withIsSubjectAuthenticated(final boolean isSubjectAuthenticated) {
+            this.isSubjectAuthenticated = isSubjectAuthenticated;
+            return (T) this;
+        }
+        public T source(final SecurityApi that) {
+            this.isSubjectAuthenticated = that.isSubjectAuthenticated();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public SecurityApiImp build() {
+            return new SecurityApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/tenant/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/tenant/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.tenant.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.tenant.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/tenant/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/tenant/api/boilerplate/Resolver.java
@@ -1,0 +1,33 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.tenant.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.tenant.api.Tenant;
+import org.killbill.billing.tenant.api.TenantData;
+import org.killbill.billing.tenant.api.TenantKV;
+import org.killbill.billing.tenant.api.TenantUserApi;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(TenantData.class, TenantDataImp.class);
+        this.addMapping(Tenant.class, TenantImp.class);
+        this.addMapping(TenantKV.class, TenantKVImp.class);
+        this.addMapping(TenantUserApi.class, TenantUserApiImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/tenant/api/boilerplate/TenantDataImp.java
+++ b/src/main/java/org/killbill/billing/tenant/api/boilerplate/TenantDataImp.java
@@ -1,0 +1,153 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.tenant.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.tenant.api.TenantData;
+
+@JsonDeserialize( builder = TenantDataImp.Builder.class )
+public class TenantDataImp implements TenantData, Serializable {
+
+    private static final long serialVersionUID = 0x1646CA31F127A6ABL;
+
+    protected String apiKey;
+    protected String apiSecret;
+    protected String externalKey;
+
+    public TenantDataImp(final TenantDataImp that) {
+        this.apiKey = that.apiKey;
+        this.apiSecret = that.apiSecret;
+        this.externalKey = that.externalKey;
+    }
+    protected TenantDataImp(final TenantDataImp.Builder<?> builder) {
+        this.apiKey = builder.apiKey;
+        this.apiSecret = builder.apiSecret;
+        this.externalKey = builder.externalKey;
+    }
+    protected TenantDataImp() { }
+    @Override
+    public String getApiKey() {
+        return this.apiKey;
+    }
+    @Override
+    public String getApiSecret() {
+        return this.apiSecret;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TenantDataImp that = (TenantDataImp) o;
+        if( !Objects.equals(this.apiKey, that.apiKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.apiSecret, that.apiSecret) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.apiKey);
+        result = ( 31 * result ) + Objects.hashCode(this.apiSecret);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("apiKey=");
+        if( this.apiKey == null ) {
+            sb.append(this.apiKey);
+        }else{
+            sb.append("'").append(this.apiKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("apiSecret=");
+        if( this.apiSecret == null ) {
+            sb.append(this.apiSecret);
+        }else{
+            sb.append("'").append(this.apiSecret).append("'");
+        }
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TenantDataImp.Builder<T>> {
+
+        protected String apiKey;
+        protected String apiSecret;
+        protected String externalKey;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.apiKey = that.apiKey;
+            this.apiSecret = that.apiSecret;
+            this.externalKey = that.externalKey;
+        }
+        public T withApiKey(final String apiKey) {
+            this.apiKey = apiKey;
+            return (T) this;
+        }
+        public T withApiSecret(final String apiSecret) {
+            this.apiSecret = apiSecret;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T source(final TenantData that) {
+            this.apiKey = that.getApiKey();
+            this.apiSecret = that.getApiSecret();
+            this.externalKey = that.getExternalKey();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TenantDataImp build() {
+            return new TenantDataImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/tenant/api/boilerplate/TenantImp.java
+++ b/src/main/java/org/killbill/billing/tenant/api/boilerplate/TenantImp.java
@@ -1,0 +1,215 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.tenant.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.tenant.api.Tenant;
+
+@JsonDeserialize( builder = TenantImp.Builder.class )
+public class TenantImp implements Tenant, Serializable {
+
+    private static final long serialVersionUID = 0x498EFABC439B2F67L;
+
+    protected String apiKey;
+    protected String apiSecret;
+    protected DateTime createdDate;
+    protected String externalKey;
+    protected UUID id;
+    protected DateTime updatedDate;
+
+    public TenantImp(final TenantImp that) {
+        this.apiKey = that.apiKey;
+        this.apiSecret = that.apiSecret;
+        this.createdDate = that.createdDate;
+        this.externalKey = that.externalKey;
+        this.id = that.id;
+        this.updatedDate = that.updatedDate;
+    }
+    protected TenantImp(final TenantImp.Builder<?> builder) {
+        this.apiKey = builder.apiKey;
+        this.apiSecret = builder.apiSecret;
+        this.createdDate = builder.createdDate;
+        this.externalKey = builder.externalKey;
+        this.id = builder.id;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected TenantImp() { }
+    @Override
+    public String getApiKey() {
+        return this.apiKey;
+    }
+    @Override
+    public String getApiSecret() {
+        return this.apiSecret;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public String getExternalKey() {
+        return this.externalKey;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TenantImp that = (TenantImp) o;
+        if( !Objects.equals(this.apiKey, that.apiKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.apiSecret, that.apiSecret) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.externalKey, that.externalKey) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.apiKey);
+        result = ( 31 * result ) + Objects.hashCode(this.apiSecret);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.externalKey);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("apiKey=");
+        if( this.apiKey == null ) {
+            sb.append(this.apiKey);
+        }else{
+            sb.append("'").append(this.apiKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("apiSecret=");
+        if( this.apiSecret == null ) {
+            sb.append(this.apiSecret);
+        }else{
+            sb.append("'").append(this.apiSecret).append("'");
+        }
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("externalKey=");
+        if( this.externalKey == null ) {
+            sb.append(this.externalKey);
+        }else{
+            sb.append("'").append(this.externalKey).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TenantImp.Builder<T>> {
+
+        protected String apiKey;
+        protected String apiSecret;
+        protected DateTime createdDate;
+        protected String externalKey;
+        protected UUID id;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.apiKey = that.apiKey;
+            this.apiSecret = that.apiSecret;
+            this.createdDate = that.createdDate;
+            this.externalKey = that.externalKey;
+            this.id = that.id;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withApiKey(final String apiKey) {
+            this.apiKey = apiKey;
+            return (T) this;
+        }
+        public T withApiSecret(final String apiSecret) {
+            this.apiSecret = apiSecret;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withExternalKey(final String externalKey) {
+            this.externalKey = externalKey;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Tenant that) {
+            this.apiKey = that.getApiKey();
+            this.apiSecret = that.getApiSecret();
+            this.createdDate = that.getCreatedDate();
+            this.externalKey = that.getExternalKey();
+            this.id = that.getId();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TenantImp build() {
+            return new TenantImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/tenant/api/boilerplate/TenantKVImp.java
+++ b/src/main/java/org/killbill/billing/tenant/api/boilerplate/TenantKVImp.java
@@ -1,0 +1,190 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.tenant.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.tenant.api.TenantKV;
+
+@JsonDeserialize( builder = TenantKVImp.Builder.class )
+public class TenantKVImp implements TenantKV, Serializable {
+
+    private static final long serialVersionUID = 0x16584FF3DA31393BL;
+
+    protected DateTime createdDate;
+    protected UUID id;
+    protected String key;
+    protected DateTime updatedDate;
+    protected String value;
+
+    public TenantKVImp(final TenantKVImp that) {
+        this.createdDate = that.createdDate;
+        this.id = that.id;
+        this.key = that.key;
+        this.updatedDate = that.updatedDate;
+        this.value = that.value;
+    }
+    protected TenantKVImp(final TenantKVImp.Builder<?> builder) {
+        this.createdDate = builder.createdDate;
+        this.id = builder.id;
+        this.key = builder.key;
+        this.updatedDate = builder.updatedDate;
+        this.value = builder.value;
+    }
+    protected TenantKVImp() { }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public String getKey() {
+        return this.key;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TenantKVImp that = (TenantKVImp) o;
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.key, that.key) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.value, that.value) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.key);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.value);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("key=");
+        if( this.key == null ) {
+            sb.append(this.key);
+        }else{
+            sb.append("'").append(this.key).append("'");
+        }
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("value=");
+        if( this.value == null ) {
+            sb.append(this.value);
+        }else{
+            sb.append("'").append(this.value).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TenantKVImp.Builder<T>> {
+
+        protected DateTime createdDate;
+        protected UUID id;
+        protected String key;
+        protected DateTime updatedDate;
+        protected String value;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.createdDate = that.createdDate;
+            this.id = that.id;
+            this.key = that.key;
+            this.updatedDate = that.updatedDate;
+            this.value = that.value;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withKey(final String key) {
+            this.key = key;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T withValue(final String value) {
+            this.value = value;
+            return (T) this;
+        }
+        public T source(final TenantKV that) {
+            this.createdDate = that.getCreatedDate();
+            this.id = that.getId();
+            this.key = that.getKey();
+            this.updatedDate = that.getUpdatedDate();
+            this.value = that.getValue();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TenantKVImp build() {
+            return new TenantKVImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/tenant/api/boilerplate/TenantUserApiImp.java
+++ b/src/main/java/org/killbill/billing/tenant/api/boilerplate/TenantUserApiImp.java
@@ -1,0 +1,119 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.tenant.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.tenant.api.Tenant;
+import org.killbill.billing.tenant.api.TenantApiException;
+import org.killbill.billing.tenant.api.TenantData;
+import org.killbill.billing.tenant.api.TenantUserApi;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = TenantUserApiImp.Builder.class )
+public class TenantUserApiImp implements TenantUserApi, Serializable {
+
+    private static final long serialVersionUID = 0x59CEA9C2896AAEABL;
+
+
+    public TenantUserApiImp(final TenantUserApiImp that) {
+    }
+    protected TenantUserApiImp(final TenantUserApiImp.Builder<?> builder) {
+    }
+    protected TenantUserApiImp() { }
+    @Override
+    public void updateTenantKeyValue(final String key, final String value, final CallContext context) {
+        throw new UnsupportedOperationException("updateTenantKeyValue(java.lang.String, java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void addTenantKeyValue(final String key, final String value, final CallContext context) {
+        throw new UnsupportedOperationException("addTenantKeyValue(java.lang.String, java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void deleteTenantKey(final String key, final CallContext context) {
+        throw new UnsupportedOperationException("deleteTenantKey(java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Tenant createTenant(final TenantData data, final CallContext context) {
+        throw new UnsupportedOperationException("createTenant(org.killbill.billing.tenant.api.TenantData, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Tenant getTenantByApiKey(final String key) {
+        throw new UnsupportedOperationException("getTenantByApiKey(java.lang.String) must be implemented.");
+    }
+    @Override
+    public List<String> getTenantValuesForKey(final String key, final TenantContext context) {
+        throw new UnsupportedOperationException("getTenantValuesForKey(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Tenant getTenantById(final UUID tenantId) {
+        throw new UnsupportedOperationException("getTenantById(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public Map<String, List<String>> searchTenantKeyValues(final String searchKey, final TenantContext context) {
+        throw new UnsupportedOperationException("searchTenantKeyValues(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TenantUserApiImp that = (TenantUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TenantUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final TenantUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TenantUserApiImp build() {
+            return new TenantUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.usage.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.usage.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/RawUsageRecordImp.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/RawUsageRecordImp.java
@@ -1,0 +1,190 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.usage.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.usage.api.RawUsageRecord;
+
+@JsonDeserialize( builder = RawUsageRecordImp.Builder.class )
+public class RawUsageRecordImp implements RawUsageRecord, Serializable {
+
+    private static final long serialVersionUID = 0x2D20F369B815B918L;
+
+    protected Long amount;
+    protected LocalDate date;
+    protected UUID subscriptionId;
+    protected String trackingId;
+    protected String unitType;
+
+    public RawUsageRecordImp(final RawUsageRecordImp that) {
+        this.amount = that.amount;
+        this.date = that.date;
+        this.subscriptionId = that.subscriptionId;
+        this.trackingId = that.trackingId;
+        this.unitType = that.unitType;
+    }
+    protected RawUsageRecordImp(final RawUsageRecordImp.Builder<?> builder) {
+        this.amount = builder.amount;
+        this.date = builder.date;
+        this.subscriptionId = builder.subscriptionId;
+        this.trackingId = builder.trackingId;
+        this.unitType = builder.unitType;
+    }
+    protected RawUsageRecordImp() { }
+    @Override
+    public Long getAmount() {
+        return this.amount;
+    }
+    @Override
+    public LocalDate getDate() {
+        return this.date;
+    }
+    @Override
+    public UUID getSubscriptionId() {
+        return this.subscriptionId;
+    }
+    @Override
+    public String getTrackingId() {
+        return this.trackingId;
+    }
+    @Override
+    public String getUnitType() {
+        return this.unitType;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final RawUsageRecordImp that = (RawUsageRecordImp) o;
+        if( !Objects.equals(this.amount, that.amount) ) {
+            return false;
+        }
+        if( ( this.date != null ) ? ( 0 != this.date.compareTo(that.date) ) : ( that.date != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionId, that.subscriptionId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.trackingId, that.trackingId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.unitType, that.unitType) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.date);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionId);
+        result = ( 31 * result ) + Objects.hashCode(this.trackingId);
+        result = ( 31 * result ) + Objects.hashCode(this.unitType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("date=").append(this.date);
+        sb.append(", ");
+        sb.append("subscriptionId=").append(this.subscriptionId);
+        sb.append(", ");
+        sb.append("trackingId=");
+        if( this.trackingId == null ) {
+            sb.append(this.trackingId);
+        }else{
+            sb.append("'").append(this.trackingId).append("'");
+        }
+        sb.append(", ");
+        sb.append("unitType=");
+        if( this.unitType == null ) {
+            sb.append(this.unitType);
+        }else{
+            sb.append("'").append(this.unitType).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends RawUsageRecordImp.Builder<T>> {
+
+        protected Long amount;
+        protected LocalDate date;
+        protected UUID subscriptionId;
+        protected String trackingId;
+        protected String unitType;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.amount = that.amount;
+            this.date = that.date;
+            this.subscriptionId = that.subscriptionId;
+            this.trackingId = that.trackingId;
+            this.unitType = that.unitType;
+        }
+        public T withAmount(final Long amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withDate(final LocalDate date) {
+            this.date = date;
+            return (T) this;
+        }
+        public T withSubscriptionId(final UUID subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            return (T) this;
+        }
+        public T withTrackingId(final String trackingId) {
+            this.trackingId = trackingId;
+            return (T) this;
+        }
+        public T withUnitType(final String unitType) {
+            this.unitType = unitType;
+            return (T) this;
+        }
+        public T source(final RawUsageRecord that) {
+            this.amount = that.getAmount();
+            this.date = that.getDate();
+            this.subscriptionId = that.getSubscriptionId();
+            this.trackingId = that.getTrackingId();
+            this.unitType = that.getUnitType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public RawUsageRecordImp build() {
+            return new RawUsageRecordImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/Resolver.java
@@ -1,0 +1,33 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.usage.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.usage.api.RawUsageRecord;
+import org.killbill.billing.usage.api.RolledUpUnit;
+import org.killbill.billing.usage.api.RolledUpUsage;
+import org.killbill.billing.usage.api.UsageUserApi;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(RawUsageRecord.class, RawUsageRecordImp.class);
+        this.addMapping(RolledUpUnit.class, RolledUpUnitImp.class);
+        this.addMapping(RolledUpUsage.class, RolledUpUsageImp.class);
+        this.addMapping(UsageUserApi.class, UsageUserApiImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/RolledUpUnitImp.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/RolledUpUnitImp.java
@@ -1,0 +1,123 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.usage.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.usage.api.RolledUpUnit;
+
+@JsonDeserialize( builder = RolledUpUnitImp.Builder.class )
+public class RolledUpUnitImp implements RolledUpUnit, Serializable {
+
+    private static final long serialVersionUID = 0xCD9ED4CA8356C279L;
+
+    protected Long amount;
+    protected String unitType;
+
+    public RolledUpUnitImp(final RolledUpUnitImp that) {
+        this.amount = that.amount;
+        this.unitType = that.unitType;
+    }
+    protected RolledUpUnitImp(final RolledUpUnitImp.Builder<?> builder) {
+        this.amount = builder.amount;
+        this.unitType = builder.unitType;
+    }
+    protected RolledUpUnitImp() { }
+    @Override
+    public Long getAmount() {
+        return this.amount;
+    }
+    @Override
+    public String getUnitType() {
+        return this.unitType;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final RolledUpUnitImp that = (RolledUpUnitImp) o;
+        if( !Objects.equals(this.amount, that.amount) ) {
+            return false;
+        }
+        if( !Objects.equals(this.unitType, that.unitType) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.amount);
+        result = ( 31 * result ) + Objects.hashCode(this.unitType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("amount=").append(this.amount);
+        sb.append(", ");
+        sb.append("unitType=");
+        if( this.unitType == null ) {
+            sb.append(this.unitType);
+        }else{
+            sb.append("'").append(this.unitType).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends RolledUpUnitImp.Builder<T>> {
+
+        protected Long amount;
+        protected String unitType;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.amount = that.amount;
+            this.unitType = that.unitType;
+        }
+        public T withAmount(final Long amount) {
+            this.amount = amount;
+            return (T) this;
+        }
+        public T withUnitType(final String unitType) {
+            this.unitType = unitType;
+            return (T) this;
+        }
+        public T source(final RolledUpUnit that) {
+            this.amount = that.getAmount();
+            this.unitType = that.getUnitType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public RolledUpUnitImp build() {
+            return new RolledUpUnitImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/RolledUpUsageImp.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/RolledUpUsageImp.java
@@ -1,0 +1,162 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.usage.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.usage.api.RolledUpUnit;
+import org.killbill.billing.usage.api.RolledUpUsage;
+
+@JsonDeserialize( builder = RolledUpUsageImp.Builder.class )
+public class RolledUpUsageImp implements RolledUpUsage, Serializable {
+
+    private static final long serialVersionUID = 0x4A42500A5E79778BL;
+
+    protected LocalDate end;
+    protected List<RolledUpUnit> rolledUpUnits;
+    protected LocalDate start;
+    protected UUID subscriptionId;
+
+    public RolledUpUsageImp(final RolledUpUsageImp that) {
+        this.end = that.end;
+        this.rolledUpUnits = that.rolledUpUnits;
+        this.start = that.start;
+        this.subscriptionId = that.subscriptionId;
+    }
+    protected RolledUpUsageImp(final RolledUpUsageImp.Builder<?> builder) {
+        this.end = builder.end;
+        this.rolledUpUnits = builder.rolledUpUnits;
+        this.start = builder.start;
+        this.subscriptionId = builder.subscriptionId;
+    }
+    protected RolledUpUsageImp() { }
+    @Override
+    public LocalDate getEnd() {
+        return this.end;
+    }
+    @Override
+    public List<RolledUpUnit> getRolledUpUnits() {
+        return this.rolledUpUnits;
+    }
+    @Override
+    public LocalDate getStart() {
+        return this.start;
+    }
+    @Override
+    public UUID getSubscriptionId() {
+        return this.subscriptionId;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final RolledUpUsageImp that = (RolledUpUsageImp) o;
+        if( ( this.end != null ) ? ( 0 != this.end.compareTo(that.end) ) : ( that.end != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.rolledUpUnits, that.rolledUpUnits) ) {
+            return false;
+        }
+        if( ( this.start != null ) ? ( 0 != this.start.compareTo(that.start) ) : ( that.start != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.subscriptionId, that.subscriptionId) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.end);
+        result = ( 31 * result ) + Objects.hashCode(this.rolledUpUnits);
+        result = ( 31 * result ) + Objects.hashCode(this.start);
+        result = ( 31 * result ) + Objects.hashCode(this.subscriptionId);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("end=").append(this.end);
+        sb.append(", ");
+        sb.append("rolledUpUnits=").append(this.rolledUpUnits);
+        sb.append(", ");
+        sb.append("start=").append(this.start);
+        sb.append(", ");
+        sb.append("subscriptionId=").append(this.subscriptionId);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends RolledUpUsageImp.Builder<T>> {
+
+        protected LocalDate end;
+        protected List<RolledUpUnit> rolledUpUnits;
+        protected LocalDate start;
+        protected UUID subscriptionId;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.end = that.end;
+            this.rolledUpUnits = that.rolledUpUnits;
+            this.start = that.start;
+            this.subscriptionId = that.subscriptionId;
+        }
+        public T withEnd(final LocalDate end) {
+            this.end = end;
+            return (T) this;
+        }
+        public T withRolledUpUnits(final List<RolledUpUnit> rolledUpUnits) {
+            this.rolledUpUnits = rolledUpUnits;
+            return (T) this;
+        }
+        public T withStart(final LocalDate start) {
+            this.start = start;
+            return (T) this;
+        }
+        public T withSubscriptionId(final UUID subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            return (T) this;
+        }
+        public T source(final RolledUpUsage that) {
+            this.end = that.getEnd();
+            this.rolledUpUnits = that.getRolledUpUnits();
+            this.start = that.getStart();
+            this.subscriptionId = that.getSubscriptionId();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public RolledUpUsageImp build() {
+            return new RolledUpUsageImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/UsageUserApiImp.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/UsageUserApiImp.java
@@ -1,0 +1,99 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.usage.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.LocalDate;
+import org.killbill.billing.usage.api.RolledUpUsage;
+import org.killbill.billing.usage.api.SubscriptionUsageRecord;
+import org.killbill.billing.usage.api.UsageApiException;
+import org.killbill.billing.usage.api.UsageUserApi;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = UsageUserApiImp.Builder.class )
+public class UsageUserApiImp implements UsageUserApi, Serializable {
+
+    private static final long serialVersionUID = 0x2B306F9AF7276238L;
+
+
+    public UsageUserApiImp(final UsageUserApiImp that) {
+    }
+    protected UsageUserApiImp(final UsageUserApiImp.Builder<?> builder) {
+    }
+    protected UsageUserApiImp() { }
+    @Override
+    public void recordRolledUpUsage(final SubscriptionUsageRecord usage, final CallContext context) {
+        throw new UnsupportedOperationException("recordRolledUpUsage(org.killbill.billing.usage.api.SubscriptionUsageRecord, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<RolledUpUsage> getAllUsageForSubscription(final UUID subscriptionId, final List<LocalDate> transitionDates, final TenantContext context) {
+        throw new UnsupportedOperationException("getAllUsageForSubscription(java.util.UUID, java.util.List<org.joda.time.LocalDate>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public RolledUpUsage getUsageForSubscription(final UUID subscriptionId, final String unitType, final LocalDate startDate, final LocalDate endDate, final TenantContext context) {
+        throw new UnsupportedOperationException("getUsageForSubscription(java.util.UUID, java.lang.String, org.joda.time.LocalDate, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final UsageUserApiImp that = (UsageUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends UsageUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final UsageUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public UsageUserApiImp build() {
+            return new UsageUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/AuditUserApiImp.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/AuditUserApiImp.java
@@ -1,0 +1,99 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.api.AuditLevel;
+import org.killbill.billing.util.api.AuditUserApi;
+import org.killbill.billing.util.audit.AccountAuditLogs;
+import org.killbill.billing.util.audit.AccountAuditLogsForObjectType;
+import org.killbill.billing.util.audit.AuditLog;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = AuditUserApiImp.Builder.class )
+public class AuditUserApiImp implements AuditUserApi, Serializable {
+
+    private static final long serialVersionUID = 0x9B2F8E758C911760L;
+
+
+    public AuditUserApiImp(final AuditUserApiImp that) {
+    }
+    protected AuditUserApiImp(final AuditUserApiImp.Builder<?> builder) {
+    }
+    protected AuditUserApiImp() { }
+    @Override
+    public AccountAuditLogs getAccountAuditLogs(final UUID accountId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccountAuditLogs(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public AccountAuditLogsForObjectType getAccountAuditLogs(final UUID accountId, final ObjectType objectType, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getAccountAuditLogs(java.util.UUID, org.killbill.billing.ObjectType, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogs(final UUID objectId, final ObjectType objectType, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getAuditLogs(java.util.UUID, org.killbill.billing.ObjectType, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AuditUserApiImp that = (AuditUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AuditUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final AuditUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AuditUserApiImp build() {
+            return new AuditUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/ColumnInfoImp.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/ColumnInfoImp.java
@@ -1,0 +1,153 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.util.api.ColumnInfo;
+
+@JsonDeserialize( builder = ColumnInfoImp.Builder.class )
+public class ColumnInfoImp implements ColumnInfo, Serializable {
+
+    private static final long serialVersionUID = 0xECD150FD4BCA919L;
+
+    protected String columnName;
+    protected String dataType;
+    protected String tableName;
+
+    public ColumnInfoImp(final ColumnInfoImp that) {
+        this.columnName = that.columnName;
+        this.dataType = that.dataType;
+        this.tableName = that.tableName;
+    }
+    protected ColumnInfoImp(final ColumnInfoImp.Builder<?> builder) {
+        this.columnName = builder.columnName;
+        this.dataType = builder.dataType;
+        this.tableName = builder.tableName;
+    }
+    protected ColumnInfoImp() { }
+    @Override
+    public String getColumnName() {
+        return this.columnName;
+    }
+    @Override
+    public String getDataType() {
+        return this.dataType;
+    }
+    @Override
+    public String getTableName() {
+        return this.tableName;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final ColumnInfoImp that = (ColumnInfoImp) o;
+        if( !Objects.equals(this.columnName, that.columnName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.dataType, that.dataType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tableName, that.tableName) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.columnName);
+        result = ( 31 * result ) + Objects.hashCode(this.dataType);
+        result = ( 31 * result ) + Objects.hashCode(this.tableName);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("columnName=");
+        if( this.columnName == null ) {
+            sb.append(this.columnName);
+        }else{
+            sb.append("'").append(this.columnName).append("'");
+        }
+        sb.append(", ");
+        sb.append("dataType=");
+        if( this.dataType == null ) {
+            sb.append(this.dataType);
+        }else{
+            sb.append("'").append(this.dataType).append("'");
+        }
+        sb.append(", ");
+        sb.append("tableName=");
+        if( this.tableName == null ) {
+            sb.append(this.tableName);
+        }else{
+            sb.append("'").append(this.tableName).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends ColumnInfoImp.Builder<T>> {
+
+        protected String columnName;
+        protected String dataType;
+        protected String tableName;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.columnName = that.columnName;
+            this.dataType = that.dataType;
+            this.tableName = that.tableName;
+        }
+        public T withColumnName(final String columnName) {
+            this.columnName = columnName;
+            return (T) this;
+        }
+        public T withDataType(final String dataType) {
+            this.dataType = dataType;
+            return (T) this;
+        }
+        public T withTableName(final String tableName) {
+            this.tableName = tableName;
+            return (T) this;
+        }
+        public T source(final ColumnInfo that) {
+            this.columnName = that.getColumnName();
+            this.dataType = that.getDataType();
+            this.tableName = that.getTableName();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public ColumnInfoImp build() {
+            return new ColumnInfoImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/CustomFieldUserApiImp.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/CustomFieldUserApiImp.java
@@ -1,0 +1,133 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.api.AuditLevel;
+import org.killbill.billing.util.api.CustomFieldApiException;
+import org.killbill.billing.util.api.CustomFieldUserApi;
+import org.killbill.billing.util.audit.AuditLogWithHistory;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.customfield.CustomField;
+import org.killbill.billing.util.entity.Pagination;
+
+@JsonDeserialize( builder = CustomFieldUserApiImp.Builder.class )
+public class CustomFieldUserApiImp implements CustomFieldUserApi, Serializable {
+
+    private static final long serialVersionUID = 0xBDAF40CD5C888F3AL;
+
+
+    public CustomFieldUserApiImp(final CustomFieldUserApiImp that) {
+    }
+    protected CustomFieldUserApiImp(final CustomFieldUserApiImp.Builder<?> builder) {
+    }
+    protected CustomFieldUserApiImp() { }
+    @Override
+    public void addCustomFields(final List<CustomField> fields, final CallContext context) {
+        throw new UnsupportedOperationException("addCustomFields(java.util.List<org.killbill.billing.util.customfield.CustomField>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<CustomField> getCustomFieldsForAccount(final UUID accountId, final TenantContext context) {
+        throw new UnsupportedOperationException("getCustomFieldsForAccount(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getCustomFieldAuditLogsWithHistoryForId(final UUID customFieldId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getCustomFieldAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void removeCustomFields(final List<CustomField> fields, final CallContext context) {
+        throw new UnsupportedOperationException("removeCustomFields(java.util.List<org.killbill.billing.util.customfield.CustomField>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<CustomField> searchCustomFields(final String fieldName, final String fieldValue, final ObjectType objectType, final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("searchCustomFields(java.lang.String, java.lang.String, org.killbill.billing.ObjectType, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<CustomField> getCustomFieldsForAccountType(final UUID accountId, final ObjectType objectType, final TenantContext context) {
+        throw new UnsupportedOperationException("getCustomFieldsForAccountType(java.util.UUID, org.killbill.billing.ObjectType, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<CustomField> getCustomFieldsForObject(final UUID objectId, final ObjectType objectType, final TenantContext context) {
+        throw new UnsupportedOperationException("getCustomFieldsForObject(java.util.UUID, org.killbill.billing.ObjectType, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<CustomField> searchCustomFields(final String fieldName, final ObjectType objectType, final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("searchCustomFields(java.lang.String, org.killbill.billing.ObjectType, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void updateCustomFields(final List<CustomField> fields, final CallContext context) {
+        throw new UnsupportedOperationException("updateCustomFields(java.util.List<org.killbill.billing.util.customfield.CustomField>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public Pagination<CustomField> searchCustomFields(final String searchKey, final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("searchCustomFields(java.lang.String, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<CustomField> getCustomFields(final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("getCustomFields(java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CustomFieldUserApiImp that = (CustomFieldUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CustomFieldUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final CustomFieldUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CustomFieldUserApiImp build() {
+            return new CustomFieldUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/DatabaseExportOutputStreamImp.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/DatabaseExportOutputStreamImp.java
@@ -1,0 +1,91 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.killbill.billing.util.api.ColumnInfo;
+import org.killbill.billing.util.api.DatabaseExportOutputStream;
+
+@JsonDeserialize( builder = DatabaseExportOutputStreamImp.Builder.class )
+public class DatabaseExportOutputStreamImp implements DatabaseExportOutputStream, Serializable {
+
+    private static final long serialVersionUID = 0x400EFAC84C0DD8B3L;
+
+
+    public DatabaseExportOutputStreamImp(final DatabaseExportOutputStreamImp that) {
+    }
+    protected DatabaseExportOutputStreamImp(final DatabaseExportOutputStreamImp.Builder<?> builder) {
+    }
+    protected DatabaseExportOutputStreamImp() { }
+    @Override
+    public void newTable(final String tableName, final List<ColumnInfo> columnsForTable) {
+        throw new UnsupportedOperationException("newTable(java.lang.String, java.util.List<org.killbill.billing.util.api.ColumnInfo>) must be implemented.");
+    }
+    @Override
+    public void write(final Map<String, Object> row) {
+        throw new UnsupportedOperationException("write(java.util.Map<java.lang.String, java.lang.Object>) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final DatabaseExportOutputStreamImp that = (DatabaseExportOutputStreamImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends DatabaseExportOutputStreamImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final DatabaseExportOutputStream that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public DatabaseExportOutputStreamImp build() {
+            return new DatabaseExportOutputStreamImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/ExportUserApiImp.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/ExportUserApiImp.java
@@ -1,0 +1,91 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.util.api.DatabaseExportOutputStream;
+import org.killbill.billing.util.api.ExportUserApi;
+import org.killbill.billing.util.callcontext.CallContext;
+
+@JsonDeserialize( builder = ExportUserApiImp.Builder.class )
+public class ExportUserApiImp implements ExportUserApi, Serializable {
+
+    private static final long serialVersionUID = 0x34EA044484F07B17L;
+
+
+    public ExportUserApiImp(final ExportUserApiImp that) {
+    }
+    protected ExportUserApiImp(final ExportUserApiImp.Builder<?> builder) {
+    }
+    protected ExportUserApiImp() { }
+    @Override
+    public void exportDataAsCSVForAccount(final UUID accountId, final OutputStream out, final CallContext context) {
+        throw new UnsupportedOperationException("exportDataAsCSVForAccount(java.util.UUID, java.io.OutputStream, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void exportDataForAccount(final UUID accountId, final DatabaseExportOutputStream out, final CallContext context) {
+        throw new UnsupportedOperationException("exportDataForAccount(java.util.UUID, org.killbill.billing.util.api.DatabaseExportOutputStream, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final ExportUserApiImp that = (ExportUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends ExportUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final ExportUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public ExportUserApiImp build() {
+            return new ExportUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.util.api.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/RecordIdApiImp.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/RecordIdApiImp.java
@@ -1,0 +1,86 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.api.RecordIdApi;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = RecordIdApiImp.Builder.class )
+public class RecordIdApiImp implements RecordIdApi, Serializable {
+
+    private static final long serialVersionUID = 0xC0DB0004BC757D37L;
+
+
+    public RecordIdApiImp(final RecordIdApiImp that) {
+    }
+    protected RecordIdApiImp(final RecordIdApiImp.Builder<?> builder) {
+    }
+    protected RecordIdApiImp() { }
+    @Override
+    public Long getRecordId(final UUID objectId, final ObjectType objectType, final TenantContext tenantContext) {
+        throw new UnsupportedOperationException("getRecordId(java.util.UUID, org.killbill.billing.ObjectType, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final RecordIdApiImp that = (RecordIdApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends RecordIdApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final RecordIdApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public RecordIdApiImp build() {
+            return new RecordIdApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/Resolver.java
@@ -1,0 +1,39 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.util.api.AuditUserApi;
+import org.killbill.billing.util.api.ColumnInfo;
+import org.killbill.billing.util.api.CustomFieldUserApi;
+import org.killbill.billing.util.api.DatabaseExportOutputStream;
+import org.killbill.billing.util.api.ExportUserApi;
+import org.killbill.billing.util.api.RecordIdApi;
+import org.killbill.billing.util.api.TagUserApi;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(AuditUserApi.class, AuditUserApiImp.class);
+        this.addMapping(ColumnInfo.class, ColumnInfoImp.class);
+        this.addMapping(CustomFieldUserApi.class, CustomFieldUserApiImp.class);
+        this.addMapping(DatabaseExportOutputStream.class, DatabaseExportOutputStreamImp.class);
+        this.addMapping(ExportUserApi.class, ExportUserApiImp.class);
+        this.addMapping(RecordIdApi.class, RecordIdApiImp.class);
+        this.addMapping(TagUserApi.class, TagUserApiImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/util/api/boilerplate/TagUserApiImp.java
+++ b/src/main/java/org/killbill/billing/util/api/boilerplate/TagUserApiImp.java
@@ -1,0 +1,161 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.api.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.api.AuditLevel;
+import org.killbill.billing.util.api.TagApiException;
+import org.killbill.billing.util.api.TagDefinitionApiException;
+import org.killbill.billing.util.api.TagUserApi;
+import org.killbill.billing.util.audit.AuditLogWithHistory;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.entity.Pagination;
+import org.killbill.billing.util.tag.Tag;
+import org.killbill.billing.util.tag.TagDefinition;
+
+@JsonDeserialize( builder = TagUserApiImp.Builder.class )
+public class TagUserApiImp implements TagUserApi, Serializable {
+
+    private static final long serialVersionUID = 0xEDC141D1F9BD398AL;
+
+
+    public TagUserApiImp(final TagUserApiImp that) {
+    }
+    protected TagUserApiImp(final TagUserApiImp.Builder<?> builder) {
+    }
+    protected TagUserApiImp() { }
+    @Override
+    public void addTags(final UUID objectId, final ObjectType objectType, final Collection<UUID> tagDefinitionIds, final CallContext context) {
+        throw new UnsupportedOperationException("addTags(java.util.UUID, org.killbill.billing.ObjectType, java.util.Collection<java.util.UUID>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void removeTags(final UUID objectId, final ObjectType objectType, final Collection<UUID> tagDefinitions, final CallContext context) {
+        throw new UnsupportedOperationException("removeTags(java.util.UUID, org.killbill.billing.ObjectType, java.util.Collection<java.util.UUID>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<TagDefinition> getTagDefinitions(final TenantContext context) {
+        throw new UnsupportedOperationException("getTagDefinitions(org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Tag> searchTags(final String searchKey, final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("searchTags(java.lang.String, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<Tag> getTagsForObject(final UUID objectId, final ObjectType objectType, final boolean includedDeleted, final TenantContext context) {
+        throw new UnsupportedOperationException("getTagsForObject(java.util.UUID, org.killbill.billing.ObjectType, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<Tag> getTags(final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("getTags(java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<TagDefinition> getTagDefinitions(final Collection<UUID> tagDefinitionIds, final TenantContext context) {
+        throw new UnsupportedOperationException("getTagDefinitions(java.util.Collection<java.util.UUID>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public TagDefinition createTagDefinition(final String definitionName, final String description, final Set<ObjectType> applicableObjectTypes, final CallContext context) {
+        throw new UnsupportedOperationException("createTagDefinition(java.lang.String, java.lang.String, java.util.Set<org.killbill.billing.ObjectType>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public TagDefinition getTagDefinition(final UUID tagDefinitionId, final TenantContext context) {
+        throw new UnsupportedOperationException("getTagDefinition(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void deleteTagDefinition(final UUID tagDefinitionId, final CallContext context) {
+        throw new UnsupportedOperationException("deleteTagDefinition(java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public List<Tag> getTagsForAccount(final UUID accountId, final boolean includedDeleted, final TenantContext context) {
+        throw new UnsupportedOperationException("getTagsForAccount(java.util.UUID, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<Tag> getTagsForAccountType(final UUID accountId, final ObjectType objectType, final boolean includedDeleted, final TenantContext context) {
+        throw new UnsupportedOperationException("getTagsForAccountType(java.util.UUID, org.killbill.billing.ObjectType, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getTagAuditLogsWithHistoryForId(final UUID tagId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getTagAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void addTag(final UUID objectId, final ObjectType objectType, final UUID tagDefinitionId, final CallContext context) {
+        throw new UnsupportedOperationException("addTag(java.util.UUID, org.killbill.billing.ObjectType, java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public TagDefinition getTagDefinitionForName(final String tageDefinitionName, final TenantContext context) {
+        throw new UnsupportedOperationException("getTagDefinitionForName(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public List<AuditLogWithHistory> getTagDefinitionAuditLogsWithHistoryForId(final UUID tagDefinitionId, final AuditLevel auditLevel, final TenantContext context) {
+        throw new UnsupportedOperationException("getTagDefinitionAuditLogsWithHistoryForId(java.util.UUID, org.killbill.billing.util.api.AuditLevel, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public void removeTag(final UUID objectId, final ObjectType objectType, final UUID tagDefinitionId, final CallContext context) {
+        throw new UnsupportedOperationException("removeTag(java.util.UUID, org.killbill.billing.ObjectType, java.util.UUID, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TagUserApiImp that = (TagUserApiImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TagUserApiImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final TagUserApi that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TagUserApiImp build() {
+            return new TagUserApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/audit/boilerplate/AccountAuditLogsForObjectTypeImp.java
+++ b/src/main/java/org/killbill/billing/util/audit/boilerplate/AccountAuditLogsForObjectTypeImp.java
@@ -1,0 +1,86 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.audit.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.util.audit.AccountAuditLogsForObjectType;
+import org.killbill.billing.util.audit.AuditLog;
+
+@JsonDeserialize( builder = AccountAuditLogsForObjectTypeImp.Builder.class )
+public class AccountAuditLogsForObjectTypeImp implements AccountAuditLogsForObjectType, Serializable {
+
+    private static final long serialVersionUID = 0xB3553F1B265966FAL;
+
+
+    public AccountAuditLogsForObjectTypeImp(final AccountAuditLogsForObjectTypeImp that) {
+    }
+    protected AccountAuditLogsForObjectTypeImp(final AccountAuditLogsForObjectTypeImp.Builder<?> builder) {
+    }
+    protected AccountAuditLogsForObjectTypeImp() { }
+    @Override
+    public List<AuditLog> getAuditLogs(final UUID objectId) {
+        throw new UnsupportedOperationException("getAuditLogs(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AccountAuditLogsForObjectTypeImp that = (AccountAuditLogsForObjectTypeImp) o;
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AccountAuditLogsForObjectTypeImp.Builder<T>> {
+
+
+        public Builder() { }
+        public Builder(final Builder that) {
+        }
+        public T source(final AccountAuditLogsForObjectType that) {
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AccountAuditLogsForObjectTypeImp build() {
+            return new AccountAuditLogsForObjectTypeImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/audit/boilerplate/AccountAuditLogsImp.java
+++ b/src/main/java/org/killbill/billing/util/audit/boilerplate/AccountAuditLogsImp.java
@@ -1,0 +1,179 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.audit.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.audit.AccountAuditLogs;
+import org.killbill.billing.util.audit.AccountAuditLogsForObjectType;
+import org.killbill.billing.util.audit.AuditLog;
+
+@JsonDeserialize( builder = AccountAuditLogsImp.Builder.class )
+public class AccountAuditLogsImp implements AccountAuditLogs, Serializable {
+
+    private static final long serialVersionUID = 0xFBF3458749273B1CL;
+
+    protected List<AuditLog> auditLogs;
+    protected List<AuditLog> auditLogsForAccount;
+
+    public AccountAuditLogsImp(final AccountAuditLogsImp that) {
+        this.auditLogs = that.auditLogs;
+        this.auditLogsForAccount = that.auditLogsForAccount;
+    }
+    protected AccountAuditLogsImp(final AccountAuditLogsImp.Builder<?> builder) {
+        this.auditLogs = builder.auditLogs;
+        this.auditLogsForAccount = builder.auditLogsForAccount;
+    }
+    protected AccountAuditLogsImp() { }
+    @Override
+    public List<AuditLog> getAuditLogs() {
+        return this.auditLogs;
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForAccount() {
+        return this.auditLogsForAccount;
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForPaymentMethod(final UUID paymentMethodId) {
+        throw new UnsupportedOperationException("getAuditLogsForPaymentMethod(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForSubscriptionEvent(final UUID subscriptionEventId) {
+        throw new UnsupportedOperationException("getAuditLogsForSubscriptionEvent(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForBlockingState(final UUID blockingStateId) {
+        throw new UnsupportedOperationException("getAuditLogsForBlockingState(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForTag(final UUID tagId) {
+        throw new UnsupportedOperationException("getAuditLogsForTag(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForSubscription(final UUID subscriptionId) {
+        throw new UnsupportedOperationException("getAuditLogsForSubscription(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForCustomField(final UUID customFieldId) {
+        throw new UnsupportedOperationException("getAuditLogsForCustomField(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public AccountAuditLogsForObjectType getAuditLogs(final ObjectType objectType) {
+        throw new UnsupportedOperationException("getAuditLogs(org.killbill.billing.ObjectType) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForInvoiceItem(final UUID invoiceItemId) {
+        throw new UnsupportedOperationException("getAuditLogsForInvoiceItem(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForInvoicePayment(final UUID invoicePaymentId) {
+        throw new UnsupportedOperationException("getAuditLogsForInvoicePayment(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForPayment(final UUID paymentId) {
+        throw new UnsupportedOperationException("getAuditLogsForPayment(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForInvoice(final UUID invoiceId) {
+        throw new UnsupportedOperationException("getAuditLogsForInvoice(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForPaymentAttempt(final UUID paymentAttemptId) {
+        throw new UnsupportedOperationException("getAuditLogsForPaymentAttempt(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForBundle(final UUID bundleId) {
+        throw new UnsupportedOperationException("getAuditLogsForBundle(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public List<AuditLog> getAuditLogsForPaymentTransaction(final UUID paymentTransactionId) {
+        throw new UnsupportedOperationException("getAuditLogsForPaymentTransaction(java.util.UUID) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AccountAuditLogsImp that = (AccountAuditLogsImp) o;
+        if( !Objects.equals(this.auditLogs, that.auditLogs) ) {
+            return false;
+        }
+        if( !Objects.equals(this.auditLogsForAccount, that.auditLogsForAccount) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.auditLogs);
+        result = ( 31 * result ) + Objects.hashCode(this.auditLogsForAccount);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("auditLogs=").append(this.auditLogs);
+        sb.append(", ");
+        sb.append("auditLogsForAccount=").append(this.auditLogsForAccount);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AccountAuditLogsImp.Builder<T>> {
+
+        protected List<AuditLog> auditLogs;
+        protected List<AuditLog> auditLogsForAccount;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.auditLogs = that.auditLogs;
+            this.auditLogsForAccount = that.auditLogsForAccount;
+        }
+        public T withAuditLogs(final List<AuditLog> auditLogs) {
+            this.auditLogs = auditLogs;
+            return (T) this;
+        }
+        public T withAuditLogsForAccount(final List<AuditLog> auditLogsForAccount) {
+            this.auditLogsForAccount = auditLogsForAccount;
+            return (T) this;
+        }
+        public T source(final AccountAuditLogs that) {
+            this.auditLogs = that.getAuditLogs();
+            this.auditLogsForAccount = that.getAuditLogsForAccount();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AccountAuditLogsImp build() {
+            return new AccountAuditLogsImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/audit/boilerplate/AuditLogImp.java
+++ b/src/main/java/org/killbill/billing/util/audit/boilerplate/AuditLogImp.java
@@ -1,0 +1,302 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.audit.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.audit.AuditLog;
+import org.killbill.billing.util.audit.ChangeType;
+
+@JsonDeserialize( builder = AuditLogImp.Builder.class )
+public class AuditLogImp implements AuditLog, Serializable {
+
+    private static final long serialVersionUID = 0x16152909987F8908L;
+
+    protected UUID auditedEntityId;
+    protected ObjectType auditedObjectType;
+    protected ChangeType changeType;
+    protected String comment;
+    protected DateTime createdDate;
+    protected UUID id;
+    protected String reasonCode;
+    protected DateTime updatedDate;
+    protected String userName;
+    protected String userToken;
+
+    public AuditLogImp(final AuditLogImp that) {
+        this.auditedEntityId = that.auditedEntityId;
+        this.auditedObjectType = that.auditedObjectType;
+        this.changeType = that.changeType;
+        this.comment = that.comment;
+        this.createdDate = that.createdDate;
+        this.id = that.id;
+        this.reasonCode = that.reasonCode;
+        this.updatedDate = that.updatedDate;
+        this.userName = that.userName;
+        this.userToken = that.userToken;
+    }
+    protected AuditLogImp(final AuditLogImp.Builder<?> builder) {
+        this.auditedEntityId = builder.auditedEntityId;
+        this.auditedObjectType = builder.auditedObjectType;
+        this.changeType = builder.changeType;
+        this.comment = builder.comment;
+        this.createdDate = builder.createdDate;
+        this.id = builder.id;
+        this.reasonCode = builder.reasonCode;
+        this.updatedDate = builder.updatedDate;
+        this.userName = builder.userName;
+        this.userToken = builder.userToken;
+    }
+    protected AuditLogImp() { }
+    @Override
+    public UUID getAuditedEntityId() {
+        return this.auditedEntityId;
+    }
+    @Override
+    public ObjectType getAuditedObjectType() {
+        return this.auditedObjectType;
+    }
+    @Override
+    public ChangeType getChangeType() {
+        return this.changeType;
+    }
+    @Override
+    public String getComment() {
+        return this.comment;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public String getReasonCode() {
+        return this.reasonCode;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public String getUserName() {
+        return this.userName;
+    }
+    @Override
+    public String getUserToken() {
+        return this.userToken;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final AuditLogImp that = (AuditLogImp) o;
+        if( !Objects.equals(this.auditedEntityId, that.auditedEntityId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.auditedObjectType, that.auditedObjectType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.changeType, that.changeType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.comment, that.comment) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.reasonCode, that.reasonCode) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.userName, that.userName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.userToken, that.userToken) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.auditedEntityId);
+        result = ( 31 * result ) + Objects.hashCode(this.auditedObjectType);
+        result = ( 31 * result ) + Objects.hashCode(this.changeType);
+        result = ( 31 * result ) + Objects.hashCode(this.comment);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.reasonCode);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.userName);
+        result = ( 31 * result ) + Objects.hashCode(this.userToken);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("auditedEntityId=").append(this.auditedEntityId);
+        sb.append(", ");
+        sb.append("auditedObjectType=").append(this.auditedObjectType);
+        sb.append(", ");
+        sb.append("changeType=").append(this.changeType);
+        sb.append(", ");
+        sb.append("comment=");
+        if( this.comment == null ) {
+            sb.append(this.comment);
+        }else{
+            sb.append("'").append(this.comment).append("'");
+        }
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("reasonCode=");
+        if( this.reasonCode == null ) {
+            sb.append(this.reasonCode);
+        }else{
+            sb.append("'").append(this.reasonCode).append("'");
+        }
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("userName=");
+        if( this.userName == null ) {
+            sb.append(this.userName);
+        }else{
+            sb.append("'").append(this.userName).append("'");
+        }
+        sb.append(", ");
+        sb.append("userToken=");
+        if( this.userToken == null ) {
+            sb.append(this.userToken);
+        }else{
+            sb.append("'").append(this.userToken).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends AuditLogImp.Builder<T>> {
+
+        protected UUID auditedEntityId;
+        protected ObjectType auditedObjectType;
+        protected ChangeType changeType;
+        protected String comment;
+        protected DateTime createdDate;
+        protected UUID id;
+        protected String reasonCode;
+        protected DateTime updatedDate;
+        protected String userName;
+        protected String userToken;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.auditedEntityId = that.auditedEntityId;
+            this.auditedObjectType = that.auditedObjectType;
+            this.changeType = that.changeType;
+            this.comment = that.comment;
+            this.createdDate = that.createdDate;
+            this.id = that.id;
+            this.reasonCode = that.reasonCode;
+            this.updatedDate = that.updatedDate;
+            this.userName = that.userName;
+            this.userToken = that.userToken;
+        }
+        public T withAuditedEntityId(final UUID auditedEntityId) {
+            this.auditedEntityId = auditedEntityId;
+            return (T) this;
+        }
+        public T withAuditedObjectType(final ObjectType auditedObjectType) {
+            this.auditedObjectType = auditedObjectType;
+            return (T) this;
+        }
+        public T withChangeType(final ChangeType changeType) {
+            this.changeType = changeType;
+            return (T) this;
+        }
+        public T withComment(final String comment) {
+            this.comment = comment;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withReasonCode(final String reasonCode) {
+            this.reasonCode = reasonCode;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T withUserName(final String userName) {
+            this.userName = userName;
+            return (T) this;
+        }
+        public T withUserToken(final String userToken) {
+            this.userToken = userToken;
+            return (T) this;
+        }
+        public T source(final AuditLog that) {
+            this.auditedEntityId = that.getAuditedEntityId();
+            this.auditedObjectType = that.getAuditedObjectType();
+            this.changeType = that.getChangeType();
+            this.comment = that.getComment();
+            this.createdDate = that.getCreatedDate();
+            this.id = that.getId();
+            this.reasonCode = that.getReasonCode();
+            this.updatedDate = that.getUpdatedDate();
+            this.userName = that.getUserName();
+            this.userToken = that.getUserToken();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public AuditLogImp build() {
+            return new AuditLogImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/audit/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/util/audit/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.audit.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.util.audit.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/util/audit/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/util/audit/boilerplate/Resolver.java
@@ -1,0 +1,31 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.audit.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.util.audit.AccountAuditLogs;
+import org.killbill.billing.util.audit.AccountAuditLogsForObjectType;
+import org.killbill.billing.util.audit.AuditLog;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(AccountAuditLogsForObjectType.class, AccountAuditLogsForObjectTypeImp.class);
+        this.addMapping(AccountAuditLogs.class, AccountAuditLogsImp.class);
+        this.addMapping(AuditLog.class, AuditLogImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/util/callcontext/boilerplate/CallContextImp.java
+++ b/src/main/java/org/killbill/billing/util/callcontext/boilerplate/CallContextImp.java
@@ -1,0 +1,297 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.callcontext.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.CallOrigin;
+import org.killbill.billing.util.callcontext.UserType;
+
+@JsonDeserialize( builder = CallContextImp.Builder.class )
+public class CallContextImp implements CallContext, Serializable {
+
+    private static final long serialVersionUID = 0xC2DEFB0ADAB50F6AL;
+
+    protected UUID accountId;
+    protected CallOrigin callOrigin;
+    protected String comments;
+    protected DateTime createdDate;
+    protected String reasonCode;
+    protected UUID tenantId;
+    protected DateTime updatedDate;
+    protected String userName;
+    protected UUID userToken;
+    protected UserType userType;
+
+    public CallContextImp(final CallContextImp that) {
+        this.accountId = that.accountId;
+        this.callOrigin = that.callOrigin;
+        this.comments = that.comments;
+        this.createdDate = that.createdDate;
+        this.reasonCode = that.reasonCode;
+        this.tenantId = that.tenantId;
+        this.updatedDate = that.updatedDate;
+        this.userName = that.userName;
+        this.userToken = that.userToken;
+        this.userType = that.userType;
+    }
+    protected CallContextImp(final CallContextImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.callOrigin = builder.callOrigin;
+        this.comments = builder.comments;
+        this.createdDate = builder.createdDate;
+        this.reasonCode = builder.reasonCode;
+        this.tenantId = builder.tenantId;
+        this.updatedDate = builder.updatedDate;
+        this.userName = builder.userName;
+        this.userToken = builder.userToken;
+        this.userType = builder.userType;
+    }
+    protected CallContextImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public CallOrigin getCallOrigin() {
+        return this.callOrigin;
+    }
+    @Override
+    public String getComments() {
+        return this.comments;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public String getReasonCode() {
+        return this.reasonCode;
+    }
+    @Override
+    public UUID getTenantId() {
+        return this.tenantId;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public String getUserName() {
+        return this.userName;
+    }
+    @Override
+    public UUID getUserToken() {
+        return this.userToken;
+    }
+    @Override
+    public UserType getUserType() {
+        return this.userType;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CallContextImp that = (CallContextImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.callOrigin, that.callOrigin) ) {
+            return false;
+        }
+        if( !Objects.equals(this.comments, that.comments) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.reasonCode, that.reasonCode) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tenantId, that.tenantId) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.userName, that.userName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.userToken, that.userToken) ) {
+            return false;
+        }
+        if( !Objects.equals(this.userType, that.userType) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.callOrigin);
+        result = ( 31 * result ) + Objects.hashCode(this.comments);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.reasonCode);
+        result = ( 31 * result ) + Objects.hashCode(this.tenantId);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.userName);
+        result = ( 31 * result ) + Objects.hashCode(this.userToken);
+        result = ( 31 * result ) + Objects.hashCode(this.userType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("callOrigin=").append(this.callOrigin);
+        sb.append(", ");
+        sb.append("comments=");
+        if( this.comments == null ) {
+            sb.append(this.comments);
+        }else{
+            sb.append("'").append(this.comments).append("'");
+        }
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("reasonCode=");
+        if( this.reasonCode == null ) {
+            sb.append(this.reasonCode);
+        }else{
+            sb.append("'").append(this.reasonCode).append("'");
+        }
+        sb.append(", ");
+        sb.append("tenantId=").append(this.tenantId);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("userName=");
+        if( this.userName == null ) {
+            sb.append(this.userName);
+        }else{
+            sb.append("'").append(this.userName).append("'");
+        }
+        sb.append(", ");
+        sb.append("userToken=").append(this.userToken);
+        sb.append(", ");
+        sb.append("userType=").append(this.userType);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CallContextImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected CallOrigin callOrigin;
+        protected String comments;
+        protected DateTime createdDate;
+        protected String reasonCode;
+        protected UUID tenantId;
+        protected DateTime updatedDate;
+        protected String userName;
+        protected UUID userToken;
+        protected UserType userType;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.callOrigin = that.callOrigin;
+            this.comments = that.comments;
+            this.createdDate = that.createdDate;
+            this.reasonCode = that.reasonCode;
+            this.tenantId = that.tenantId;
+            this.updatedDate = that.updatedDate;
+            this.userName = that.userName;
+            this.userToken = that.userToken;
+            this.userType = that.userType;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withCallOrigin(final CallOrigin callOrigin) {
+            this.callOrigin = callOrigin;
+            return (T) this;
+        }
+        public T withComments(final String comments) {
+            this.comments = comments;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withReasonCode(final String reasonCode) {
+            this.reasonCode = reasonCode;
+            return (T) this;
+        }
+        public T withTenantId(final UUID tenantId) {
+            this.tenantId = tenantId;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T withUserName(final String userName) {
+            this.userName = userName;
+            return (T) this;
+        }
+        public T withUserToken(final UUID userToken) {
+            this.userToken = userToken;
+            return (T) this;
+        }
+        public T withUserType(final UserType userType) {
+            this.userType = userType;
+            return (T) this;
+        }
+        public T source(final CallContext that) {
+            this.accountId = that.getAccountId();
+            this.callOrigin = that.getCallOrigin();
+            this.comments = that.getComments();
+            this.createdDate = that.getCreatedDate();
+            this.reasonCode = that.getReasonCode();
+            this.tenantId = that.getTenantId();
+            this.updatedDate = that.getUpdatedDate();
+            this.userName = that.getUserName();
+            this.userToken = that.getUserToken();
+            this.userType = that.getUserType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CallContextImp build() {
+            return new CallContextImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/callcontext/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/util/callcontext/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.callcontext.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.util.callcontext.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/util/callcontext/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/util/callcontext/boilerplate/Resolver.java
@@ -1,0 +1,29 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.callcontext.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.util.callcontext.CallContext;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(CallContext.class, CallContextImp.class);
+        this.addMapping(TenantContext.class, TenantContextImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/util/callcontext/boilerplate/TenantContextImp.java
+++ b/src/main/java/org/killbill/billing/util/callcontext/boilerplate/TenantContextImp.java
@@ -1,0 +1,119 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.callcontext.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.killbill.billing.util.callcontext.TenantContext;
+
+@JsonDeserialize( builder = TenantContextImp.Builder.class )
+public class TenantContextImp implements TenantContext, Serializable {
+
+    private static final long serialVersionUID = 0x31D7DDF355CBD496L;
+
+    protected UUID accountId;
+    protected UUID tenantId;
+
+    public TenantContextImp(final TenantContextImp that) {
+        this.accountId = that.accountId;
+        this.tenantId = that.tenantId;
+    }
+    protected TenantContextImp(final TenantContextImp.Builder<?> builder) {
+        this.accountId = builder.accountId;
+        this.tenantId = builder.tenantId;
+    }
+    protected TenantContextImp() { }
+    @Override
+    public UUID getAccountId() {
+        return this.accountId;
+    }
+    @Override
+    public UUID getTenantId() {
+        return this.tenantId;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TenantContextImp that = (TenantContextImp) o;
+        if( !Objects.equals(this.accountId, that.accountId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tenantId, that.tenantId) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.accountId);
+        result = ( 31 * result ) + Objects.hashCode(this.tenantId);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("accountId=").append(this.accountId);
+        sb.append(", ");
+        sb.append("tenantId=").append(this.tenantId);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TenantContextImp.Builder<T>> {
+
+        protected UUID accountId;
+        protected UUID tenantId;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.accountId = that.accountId;
+            this.tenantId = that.tenantId;
+        }
+        public T withAccountId(final UUID accountId) {
+            this.accountId = accountId;
+            return (T) this;
+        }
+        public T withTenantId(final UUID tenantId) {
+            this.tenantId = tenantId;
+            return (T) this;
+        }
+        public T source(final TenantContext that) {
+            this.accountId = that.getAccountId();
+            this.tenantId = that.getTenantId();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TenantContextImp build() {
+            return new TenantContextImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/customfield/boilerplate/CustomFieldImp.java
+++ b/src/main/java/org/killbill/billing/util/customfield/boilerplate/CustomFieldImp.java
@@ -1,0 +1,231 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.customfield.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.customfield.CustomField;
+
+@JsonDeserialize( builder = CustomFieldImp.Builder.class )
+public class CustomFieldImp implements CustomField, Serializable {
+
+    private static final long serialVersionUID = 0x9E64A364C19AB705L;
+
+    protected DateTime createdDate;
+    protected String fieldName;
+    protected String fieldValue;
+    protected UUID id;
+    protected UUID objectId;
+    protected ObjectType objectType;
+    protected DateTime updatedDate;
+
+    public CustomFieldImp(final CustomFieldImp that) {
+        this.createdDate = that.createdDate;
+        this.fieldName = that.fieldName;
+        this.fieldValue = that.fieldValue;
+        this.id = that.id;
+        this.objectId = that.objectId;
+        this.objectType = that.objectType;
+        this.updatedDate = that.updatedDate;
+    }
+    protected CustomFieldImp(final CustomFieldImp.Builder<?> builder) {
+        this.createdDate = builder.createdDate;
+        this.fieldName = builder.fieldName;
+        this.fieldValue = builder.fieldValue;
+        this.id = builder.id;
+        this.objectId = builder.objectId;
+        this.objectType = builder.objectType;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected CustomFieldImp() { }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public String getFieldName() {
+        return this.fieldName;
+    }
+    @Override
+    public String getFieldValue() {
+        return this.fieldValue;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public UUID getObjectId() {
+        return this.objectId;
+    }
+    @Override
+    public ObjectType getObjectType() {
+        return this.objectType;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final CustomFieldImp that = (CustomFieldImp) o;
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fieldName, that.fieldName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.fieldValue, that.fieldValue) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.objectId, that.objectId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.objectType, that.objectType) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.fieldName);
+        result = ( 31 * result ) + Objects.hashCode(this.fieldValue);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.objectId);
+        result = ( 31 * result ) + Objects.hashCode(this.objectType);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("fieldName=");
+        if( this.fieldName == null ) {
+            sb.append(this.fieldName);
+        }else{
+            sb.append("'").append(this.fieldName).append("'");
+        }
+        sb.append(", ");
+        sb.append("fieldValue=");
+        if( this.fieldValue == null ) {
+            sb.append(this.fieldValue);
+        }else{
+            sb.append("'").append(this.fieldValue).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("objectId=").append(this.objectId);
+        sb.append(", ");
+        sb.append("objectType=").append(this.objectType);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends CustomFieldImp.Builder<T>> {
+
+        protected DateTime createdDate;
+        protected String fieldName;
+        protected String fieldValue;
+        protected UUID id;
+        protected UUID objectId;
+        protected ObjectType objectType;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.createdDate = that.createdDate;
+            this.fieldName = that.fieldName;
+            this.fieldValue = that.fieldValue;
+            this.id = that.id;
+            this.objectId = that.objectId;
+            this.objectType = that.objectType;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withFieldName(final String fieldName) {
+            this.fieldName = fieldName;
+            return (T) this;
+        }
+        public T withFieldValue(final String fieldValue) {
+            this.fieldValue = fieldValue;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withObjectId(final UUID objectId) {
+            this.objectId = objectId;
+            return (T) this;
+        }
+        public T withObjectType(final ObjectType objectType) {
+            this.objectType = objectType;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final CustomField that) {
+            this.createdDate = that.getCreatedDate();
+            this.fieldName = that.getFieldName();
+            this.fieldValue = that.getFieldValue();
+            this.id = that.getId();
+            this.objectId = that.getObjectId();
+            this.objectType = that.getObjectType();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public CustomFieldImp build() {
+            return new CustomFieldImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/customfield/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/util/customfield/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.customfield.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.util.customfield.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/util/customfield/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/util/customfield/boilerplate/Resolver.java
@@ -1,0 +1,27 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.customfield.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.util.customfield.CustomField;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(CustomField.class, CustomFieldImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/util/entity/boilerplate/EntityImp.java
+++ b/src/main/java/org/killbill/billing/util/entity/boilerplate/EntityImp.java
@@ -1,0 +1,140 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.entity.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.util.entity.Entity;
+
+@JsonDeserialize( builder = EntityImp.Builder.class )
+public class EntityImp implements Entity, Serializable {
+
+    private static final long serialVersionUID = 0x80416CA1F103FE6FL;
+
+    protected DateTime createdDate;
+    protected UUID id;
+    protected DateTime updatedDate;
+
+    public EntityImp(final EntityImp that) {
+        this.createdDate = that.createdDate;
+        this.id = that.id;
+        this.updatedDate = that.updatedDate;
+    }
+    protected EntityImp(final EntityImp.Builder<?> builder) {
+        this.createdDate = builder.createdDate;
+        this.id = builder.id;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected EntityImp() { }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final EntityImp that = (EntityImp) o;
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends EntityImp.Builder<T>> {
+
+        protected DateTime createdDate;
+        protected UUID id;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.createdDate = that.createdDate;
+            this.id = that.id;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Entity that) {
+            this.createdDate = that.getCreatedDate();
+            this.id = that.getId();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public EntityImp build() {
+            return new EntityImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/entity/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/util/entity/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.entity.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.util.entity.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/util/entity/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/util/entity/boilerplate/Resolver.java
@@ -1,0 +1,27 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.entity.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.util.entity.Entity;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(Entity.class, EntityImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/util/nodes/boilerplate/KillbillNodesApiImp.java
+++ b/src/main/java/org/killbill/billing/util/nodes/boilerplate/KillbillNodesApiImp.java
@@ -1,0 +1,129 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.nodes.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.osgi.api.PluginInfo;
+import org.killbill.billing.util.nodes.KillbillNodesApi;
+import org.killbill.billing.util.nodes.NodeCommand;
+import org.killbill.billing.util.nodes.NodeInfo;
+
+@JsonDeserialize( builder = KillbillNodesApiImp.Builder.class )
+public class KillbillNodesApiImp implements KillbillNodesApi, Serializable {
+
+    private static final long serialVersionUID = 0x8FC81437A4796EABL;
+
+    protected NodeInfo currentNodeInfo;
+    protected Iterable<NodeInfo> nodesInfo;
+
+    public KillbillNodesApiImp(final KillbillNodesApiImp that) {
+        this.currentNodeInfo = that.currentNodeInfo;
+        this.nodesInfo = that.nodesInfo;
+    }
+    protected KillbillNodesApiImp(final KillbillNodesApiImp.Builder<?> builder) {
+        this.currentNodeInfo = builder.currentNodeInfo;
+        this.nodesInfo = builder.nodesInfo;
+    }
+    protected KillbillNodesApiImp() { }
+    @Override
+    public NodeInfo getCurrentNodeInfo() {
+        return this.currentNodeInfo;
+    }
+    @Override
+    public Iterable<NodeInfo> getNodesInfo() {
+        return this.nodesInfo;
+    }
+    @Override
+    public void notifyPluginChanged(final PluginInfo plugin, final Iterable<PluginInfo> latestPlugins) {
+        throw new UnsupportedOperationException("notifyPluginChanged(org.killbill.billing.osgi.api.PluginInfo, java.lang.Iterable<org.killbill.billing.osgi.api.PluginInfo>) must be implemented.");
+    }
+    @Override
+    public void triggerNodeCommand(final NodeCommand nodeCommand, final boolean localNodeOnly) {
+        throw new UnsupportedOperationException("triggerNodeCommand(org.killbill.billing.util.nodes.NodeCommand, boolean) must be implemented.");
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final KillbillNodesApiImp that = (KillbillNodesApiImp) o;
+        if( !Objects.equals(this.currentNodeInfo, that.currentNodeInfo) ) {
+            return false;
+        }
+        if( !Objects.equals(this.nodesInfo, that.nodesInfo) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.currentNodeInfo);
+        result = ( 31 * result ) + Objects.hashCode(this.nodesInfo);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("currentNodeInfo=").append(this.currentNodeInfo);
+        sb.append(", ");
+        sb.append("nodesInfo=").append(this.nodesInfo);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends KillbillNodesApiImp.Builder<T>> {
+
+        protected NodeInfo currentNodeInfo;
+        protected Iterable<NodeInfo> nodesInfo;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.currentNodeInfo = that.currentNodeInfo;
+            this.nodesInfo = that.nodesInfo;
+        }
+        public T withCurrentNodeInfo(final NodeInfo currentNodeInfo) {
+            this.currentNodeInfo = currentNodeInfo;
+            return (T) this;
+        }
+        public T withNodesInfo(final Iterable<NodeInfo> nodesInfo) {
+            this.nodesInfo = nodesInfo;
+            return (T) this;
+        }
+        public T source(final KillbillNodesApi that) {
+            this.currentNodeInfo = that.getCurrentNodeInfo();
+            this.nodesInfo = that.getNodesInfo();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public KillbillNodesApiImp build() {
+            return new KillbillNodesApiImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/nodes/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/util/nodes/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.nodes.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.util.nodes.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/util/nodes/boilerplate/NodeCommandImp.java
+++ b/src/main/java/org/killbill/billing/util/nodes/boilerplate/NodeCommandImp.java
@@ -1,0 +1,145 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.nodes.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.killbill.billing.util.nodes.NodeCommand;
+import org.killbill.billing.util.nodes.NodeCommandMetadata;
+
+@JsonDeserialize( builder = NodeCommandImp.Builder.class )
+public class NodeCommandImp implements NodeCommand, Serializable {
+
+    private static final long serialVersionUID = 0xACC5A6CA0AF22EEFL;
+
+    protected boolean isSystemCommandType;
+    protected NodeCommandMetadata nodeCommandMetadata;
+    protected String nodeCommandType;
+
+    public NodeCommandImp(final NodeCommandImp that) {
+        this.isSystemCommandType = that.isSystemCommandType;
+        this.nodeCommandMetadata = that.nodeCommandMetadata;
+        this.nodeCommandType = that.nodeCommandType;
+    }
+    protected NodeCommandImp(final NodeCommandImp.Builder<?> builder) {
+        this.isSystemCommandType = builder.isSystemCommandType;
+        this.nodeCommandMetadata = builder.nodeCommandMetadata;
+        this.nodeCommandType = builder.nodeCommandType;
+    }
+    protected NodeCommandImp() { }
+    @Override
+    @JsonGetter("isSystemCommandType")
+    public boolean isSystemCommandType() {
+        return this.isSystemCommandType;
+    }
+    @Override
+    public NodeCommandMetadata getNodeCommandMetadata() {
+        return this.nodeCommandMetadata;
+    }
+    @Override
+    public String getNodeCommandType() {
+        return this.nodeCommandType;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final NodeCommandImp that = (NodeCommandImp) o;
+        if( this.isSystemCommandType != that.isSystemCommandType ) {
+            return false;
+        }
+        if( !Objects.equals(this.nodeCommandMetadata, that.nodeCommandMetadata) ) {
+            return false;
+        }
+        if( !Objects.equals(this.nodeCommandType, that.nodeCommandType) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.isSystemCommandType);
+        result = ( 31 * result ) + Objects.hashCode(this.nodeCommandMetadata);
+        result = ( 31 * result ) + Objects.hashCode(this.nodeCommandType);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("isSystemCommandType=").append(this.isSystemCommandType);
+        sb.append(", ");
+        sb.append("nodeCommandMetadata=").append(this.nodeCommandMetadata);
+        sb.append(", ");
+        sb.append("nodeCommandType=");
+        if( this.nodeCommandType == null ) {
+            sb.append(this.nodeCommandType);
+        }else{
+            sb.append("'").append(this.nodeCommandType).append("'");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends NodeCommandImp.Builder<T>> {
+
+        protected boolean isSystemCommandType;
+        protected NodeCommandMetadata nodeCommandMetadata;
+        protected String nodeCommandType;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.isSystemCommandType = that.isSystemCommandType;
+            this.nodeCommandMetadata = that.nodeCommandMetadata;
+            this.nodeCommandType = that.nodeCommandType;
+        }
+        public T withIsSystemCommandType(final boolean isSystemCommandType) {
+            this.isSystemCommandType = isSystemCommandType;
+            return (T) this;
+        }
+        public T withNodeCommandMetadata(final NodeCommandMetadata nodeCommandMetadata) {
+            this.nodeCommandMetadata = nodeCommandMetadata;
+            return (T) this;
+        }
+        public T withNodeCommandType(final String nodeCommandType) {
+            this.nodeCommandType = nodeCommandType;
+            return (T) this;
+        }
+        public T source(final NodeCommand that) {
+            this.isSystemCommandType = that.isSystemCommandType();
+            this.nodeCommandMetadata = that.getNodeCommandMetadata();
+            this.nodeCommandType = that.getNodeCommandType();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public NodeCommandImp build() {
+            return new NodeCommandImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/nodes/boilerplate/NodeCommandMetadataImp.java
+++ b/src/main/java/org/killbill/billing/util/nodes/boilerplate/NodeCommandMetadataImp.java
@@ -1,0 +1,100 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.nodes.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.killbill.billing.util.nodes.NodeCommandMetadata;
+import org.killbill.billing.util.nodes.NodeCommandProperty;
+
+@JsonDeserialize( builder = NodeCommandMetadataImp.Builder.class )
+public class NodeCommandMetadataImp implements NodeCommandMetadata, Serializable {
+
+    private static final long serialVersionUID = 0xD541D122123FD230L;
+
+    protected List<NodeCommandProperty> properties;
+
+    public NodeCommandMetadataImp(final NodeCommandMetadataImp that) {
+        this.properties = that.properties;
+    }
+    protected NodeCommandMetadataImp(final NodeCommandMetadataImp.Builder<?> builder) {
+        this.properties = builder.properties;
+    }
+    protected NodeCommandMetadataImp() { }
+    @Override
+    public List<NodeCommandProperty> getProperties() {
+        return this.properties;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final NodeCommandMetadataImp that = (NodeCommandMetadataImp) o;
+        if( !Objects.equals(this.properties, that.properties) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.properties);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("properties=").append(this.properties);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends NodeCommandMetadataImp.Builder<T>> {
+
+        protected List<NodeCommandProperty> properties;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.properties = that.properties;
+        }
+        public T withProperties(final List<NodeCommandProperty> properties) {
+            this.properties = properties;
+            return (T) this;
+        }
+        public T source(final NodeCommandMetadata that) {
+            this.properties = that.getProperties();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public NodeCommandMetadataImp build() {
+            return new NodeCommandMetadataImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/nodes/boilerplate/NodeInfoImp.java
+++ b/src/main/java/org/killbill/billing/util/nodes/boilerplate/NodeInfoImp.java
@@ -1,0 +1,290 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.nodes.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.joda.time.DateTime;
+import org.killbill.billing.osgi.api.PluginInfo;
+import org.killbill.billing.util.nodes.NodeInfo;
+
+@JsonDeserialize( builder = NodeInfoImp.Builder.class )
+public class NodeInfoImp implements NodeInfo, Serializable {
+
+    private static final long serialVersionUID = 0xF60FCF394C2541BBL;
+
+    protected String apiVersion;
+    protected DateTime bootTime;
+    protected String commonVersion;
+    protected String killbillVersion;
+    protected DateTime lastUpdatedDate;
+    protected String nodeName;
+    protected String platformVersion;
+    protected String pluginApiVersion;
+    protected Iterable<PluginInfo> pluginInfo;
+
+    public NodeInfoImp(final NodeInfoImp that) {
+        this.apiVersion = that.apiVersion;
+        this.bootTime = that.bootTime;
+        this.commonVersion = that.commonVersion;
+        this.killbillVersion = that.killbillVersion;
+        this.lastUpdatedDate = that.lastUpdatedDate;
+        this.nodeName = that.nodeName;
+        this.platformVersion = that.platformVersion;
+        this.pluginApiVersion = that.pluginApiVersion;
+        this.pluginInfo = that.pluginInfo;
+    }
+    protected NodeInfoImp(final NodeInfoImp.Builder<?> builder) {
+        this.apiVersion = builder.apiVersion;
+        this.bootTime = builder.bootTime;
+        this.commonVersion = builder.commonVersion;
+        this.killbillVersion = builder.killbillVersion;
+        this.lastUpdatedDate = builder.lastUpdatedDate;
+        this.nodeName = builder.nodeName;
+        this.platformVersion = builder.platformVersion;
+        this.pluginApiVersion = builder.pluginApiVersion;
+        this.pluginInfo = builder.pluginInfo;
+    }
+    protected NodeInfoImp() { }
+    @Override
+    public String getApiVersion() {
+        return this.apiVersion;
+    }
+    @Override
+    public DateTime getBootTime() {
+        return this.bootTime;
+    }
+    @Override
+    public String getCommonVersion() {
+        return this.commonVersion;
+    }
+    @Override
+    public String getKillbillVersion() {
+        return this.killbillVersion;
+    }
+    @Override
+    public DateTime getLastUpdatedDate() {
+        return this.lastUpdatedDate;
+    }
+    @Override
+    public String getNodeName() {
+        return this.nodeName;
+    }
+    @Override
+    public String getPlatformVersion() {
+        return this.platformVersion;
+    }
+    @Override
+    public String getPluginApiVersion() {
+        return this.pluginApiVersion;
+    }
+    @Override
+    public Iterable<PluginInfo> getPluginInfo() {
+        return this.pluginInfo;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final NodeInfoImp that = (NodeInfoImp) o;
+        if( !Objects.equals(this.apiVersion, that.apiVersion) ) {
+            return false;
+        }
+        if( ( this.bootTime != null ) ? ( 0 != this.bootTime.compareTo(that.bootTime) ) : ( that.bootTime != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.commonVersion, that.commonVersion) ) {
+            return false;
+        }
+        if( !Objects.equals(this.killbillVersion, that.killbillVersion) ) {
+            return false;
+        }
+        if( ( this.lastUpdatedDate != null ) ? ( 0 != this.lastUpdatedDate.compareTo(that.lastUpdatedDate) ) : ( that.lastUpdatedDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.nodeName, that.nodeName) ) {
+            return false;
+        }
+        if( !Objects.equals(this.platformVersion, that.platformVersion) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginApiVersion, that.pluginApiVersion) ) {
+            return false;
+        }
+        if( !Objects.equals(this.pluginInfo, that.pluginInfo) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.apiVersion);
+        result = ( 31 * result ) + Objects.hashCode(this.bootTime);
+        result = ( 31 * result ) + Objects.hashCode(this.commonVersion);
+        result = ( 31 * result ) + Objects.hashCode(this.killbillVersion);
+        result = ( 31 * result ) + Objects.hashCode(this.lastUpdatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.nodeName);
+        result = ( 31 * result ) + Objects.hashCode(this.platformVersion);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginApiVersion);
+        result = ( 31 * result ) + Objects.hashCode(this.pluginInfo);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("apiVersion=");
+        if( this.apiVersion == null ) {
+            sb.append(this.apiVersion);
+        }else{
+            sb.append("'").append(this.apiVersion).append("'");
+        }
+        sb.append(", ");
+        sb.append("bootTime=").append(this.bootTime);
+        sb.append(", ");
+        sb.append("commonVersion=");
+        if( this.commonVersion == null ) {
+            sb.append(this.commonVersion);
+        }else{
+            sb.append("'").append(this.commonVersion).append("'");
+        }
+        sb.append(", ");
+        sb.append("killbillVersion=");
+        if( this.killbillVersion == null ) {
+            sb.append(this.killbillVersion);
+        }else{
+            sb.append("'").append(this.killbillVersion).append("'");
+        }
+        sb.append(", ");
+        sb.append("lastUpdatedDate=").append(this.lastUpdatedDate);
+        sb.append(", ");
+        sb.append("nodeName=");
+        if( this.nodeName == null ) {
+            sb.append(this.nodeName);
+        }else{
+            sb.append("'").append(this.nodeName).append("'");
+        }
+        sb.append(", ");
+        sb.append("platformVersion=");
+        if( this.platformVersion == null ) {
+            sb.append(this.platformVersion);
+        }else{
+            sb.append("'").append(this.platformVersion).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginApiVersion=");
+        if( this.pluginApiVersion == null ) {
+            sb.append(this.pluginApiVersion);
+        }else{
+            sb.append("'").append(this.pluginApiVersion).append("'");
+        }
+        sb.append(", ");
+        sb.append("pluginInfo=").append(this.pluginInfo);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends NodeInfoImp.Builder<T>> {
+
+        protected String apiVersion;
+        protected DateTime bootTime;
+        protected String commonVersion;
+        protected String killbillVersion;
+        protected DateTime lastUpdatedDate;
+        protected String nodeName;
+        protected String platformVersion;
+        protected String pluginApiVersion;
+        protected Iterable<PluginInfo> pluginInfo;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.apiVersion = that.apiVersion;
+            this.bootTime = that.bootTime;
+            this.commonVersion = that.commonVersion;
+            this.killbillVersion = that.killbillVersion;
+            this.lastUpdatedDate = that.lastUpdatedDate;
+            this.nodeName = that.nodeName;
+            this.platformVersion = that.platformVersion;
+            this.pluginApiVersion = that.pluginApiVersion;
+            this.pluginInfo = that.pluginInfo;
+        }
+        public T withApiVersion(final String apiVersion) {
+            this.apiVersion = apiVersion;
+            return (T) this;
+        }
+        public T withBootTime(final DateTime bootTime) {
+            this.bootTime = bootTime;
+            return (T) this;
+        }
+        public T withCommonVersion(final String commonVersion) {
+            this.commonVersion = commonVersion;
+            return (T) this;
+        }
+        public T withKillbillVersion(final String killbillVersion) {
+            this.killbillVersion = killbillVersion;
+            return (T) this;
+        }
+        public T withLastUpdatedDate(final DateTime lastUpdatedDate) {
+            this.lastUpdatedDate = lastUpdatedDate;
+            return (T) this;
+        }
+        public T withNodeName(final String nodeName) {
+            this.nodeName = nodeName;
+            return (T) this;
+        }
+        public T withPlatformVersion(final String platformVersion) {
+            this.platformVersion = platformVersion;
+            return (T) this;
+        }
+        public T withPluginApiVersion(final String pluginApiVersion) {
+            this.pluginApiVersion = pluginApiVersion;
+            return (T) this;
+        }
+        public T withPluginInfo(final Iterable<PluginInfo> pluginInfo) {
+            this.pluginInfo = pluginInfo;
+            return (T) this;
+        }
+        public T source(final NodeInfo that) {
+            this.apiVersion = that.getApiVersion();
+            this.bootTime = that.getBootTime();
+            this.commonVersion = that.getCommonVersion();
+            this.killbillVersion = that.getKillbillVersion();
+            this.lastUpdatedDate = that.getLastUpdatedDate();
+            this.nodeName = that.getNodeName();
+            this.platformVersion = that.getPlatformVersion();
+            this.pluginApiVersion = that.getPluginApiVersion();
+            this.pluginInfo = that.getPluginInfo();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public NodeInfoImp build() {
+            return new NodeInfoImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/nodes/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/util/nodes/boilerplate/Resolver.java
@@ -1,0 +1,33 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.nodes.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.util.nodes.KillbillNodesApi;
+import org.killbill.billing.util.nodes.NodeCommand;
+import org.killbill.billing.util.nodes.NodeCommandMetadata;
+import org.killbill.billing.util.nodes.NodeInfo;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(KillbillNodesApi.class, KillbillNodesApiImp.class);
+        this.addMapping(NodeCommand.class, NodeCommandImp.class);
+        this.addMapping(NodeCommandMetadata.class, NodeCommandMetadataImp.class);
+        this.addMapping(NodeInfo.class, NodeInfoImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/util/tag/boilerplate/ControlTagImp.java
+++ b/src/main/java/org/killbill/billing/util/tag/boilerplate/ControlTagImp.java
@@ -1,0 +1,222 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.tag.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.tag.ControlTag;
+import org.killbill.billing.util.tag.ControlTagType;
+
+@JsonDeserialize( builder = ControlTagImp.Builder.class )
+public class ControlTagImp implements ControlTag, Serializable {
+
+    private static final long serialVersionUID = 0xEF4996C6C6B04CDDL;
+
+    protected ControlTagType controlTagType;
+    protected DateTime createdDate;
+    protected UUID id;
+    protected UUID objectId;
+    protected ObjectType objectType;
+    protected UUID tagDefinitionId;
+    protected DateTime updatedDate;
+
+    public ControlTagImp(final ControlTagImp that) {
+        this.controlTagType = that.controlTagType;
+        this.createdDate = that.createdDate;
+        this.id = that.id;
+        this.objectId = that.objectId;
+        this.objectType = that.objectType;
+        this.tagDefinitionId = that.tagDefinitionId;
+        this.updatedDate = that.updatedDate;
+    }
+    protected ControlTagImp(final ControlTagImp.Builder<?> builder) {
+        this.controlTagType = builder.controlTagType;
+        this.createdDate = builder.createdDate;
+        this.id = builder.id;
+        this.objectId = builder.objectId;
+        this.objectType = builder.objectType;
+        this.tagDefinitionId = builder.tagDefinitionId;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected ControlTagImp() { }
+    @Override
+    public ControlTagType getControlTagType() {
+        return this.controlTagType;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public UUID getObjectId() {
+        return this.objectId;
+    }
+    @Override
+    public ObjectType getObjectType() {
+        return this.objectType;
+    }
+    @Override
+    public UUID getTagDefinitionId() {
+        return this.tagDefinitionId;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final ControlTagImp that = (ControlTagImp) o;
+        if( !Objects.equals(this.controlTagType, that.controlTagType) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.objectId, that.objectId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.objectType, that.objectType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tagDefinitionId, that.tagDefinitionId) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.controlTagType);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.objectId);
+        result = ( 31 * result ) + Objects.hashCode(this.objectType);
+        result = ( 31 * result ) + Objects.hashCode(this.tagDefinitionId);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("controlTagType=").append(this.controlTagType);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("objectId=").append(this.objectId);
+        sb.append(", ");
+        sb.append("objectType=").append(this.objectType);
+        sb.append(", ");
+        sb.append("tagDefinitionId=").append(this.tagDefinitionId);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends ControlTagImp.Builder<T>> {
+
+        protected ControlTagType controlTagType;
+        protected DateTime createdDate;
+        protected UUID id;
+        protected UUID objectId;
+        protected ObjectType objectType;
+        protected UUID tagDefinitionId;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.controlTagType = that.controlTagType;
+            this.createdDate = that.createdDate;
+            this.id = that.id;
+            this.objectId = that.objectId;
+            this.objectType = that.objectType;
+            this.tagDefinitionId = that.tagDefinitionId;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withControlTagType(final ControlTagType controlTagType) {
+            this.controlTagType = controlTagType;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withObjectId(final UUID objectId) {
+            this.objectId = objectId;
+            return (T) this;
+        }
+        public T withObjectType(final ObjectType objectType) {
+            this.objectType = objectType;
+            return (T) this;
+        }
+        public T withTagDefinitionId(final UUID tagDefinitionId) {
+            this.tagDefinitionId = tagDefinitionId;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final ControlTag that) {
+            this.controlTagType = that.getControlTagType();
+            this.createdDate = that.getCreatedDate();
+            this.id = that.getId();
+            this.objectId = that.getObjectId();
+            this.objectType = that.getObjectType();
+            this.tagDefinitionId = that.getTagDefinitionId();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public ControlTagImp build() {
+            return new ControlTagImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/tag/boilerplate/Module.java
+++ b/src/main/java/org/killbill/billing/util/tag/boilerplate/Module.java
@@ -1,0 +1,30 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.tag.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class Module extends SimpleModule {
+    public Module(){
+        this.setAbstractTypes(new Resolver());
+    }
+    @Override
+    public String getModuleName(){
+        return "org.killbill.billing.util.tag.boilerplate";
+    }
+}

--- a/src/main/java/org/killbill/billing/util/tag/boilerplate/Resolver.java
+++ b/src/main/java/org/killbill/billing/util/tag/boilerplate/Resolver.java
@@ -1,0 +1,31 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.tag.boilerplate;
+
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
+import org.killbill.billing.util.tag.ControlTag;
+import org.killbill.billing.util.tag.Tag;
+import org.killbill.billing.util.tag.TagDefinition;
+
+public class Resolver extends SimpleAbstractTypeResolver {
+    public Resolver(){
+        this.addMapping(ControlTag.class, ControlTagImp.class);
+        this.addMapping(TagDefinition.class, TagDefinitionImp.class);
+        this.addMapping(Tag.class, TagImp.class);
+    }
+}

--- a/src/main/java/org/killbill/billing/util/tag/boilerplate/TagDefinitionImp.java
+++ b/src/main/java/org/killbill/billing/util/tag/boilerplate/TagDefinitionImp.java
@@ -1,0 +1,233 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.tag.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.tag.TagDefinition;
+
+@JsonDeserialize( builder = TagDefinitionImp.Builder.class )
+public class TagDefinitionImp implements TagDefinition, Serializable {
+
+    private static final long serialVersionUID = 0x1E675F37B641DBABL;
+
+    protected List<ObjectType> applicableObjectTypes;
+    protected DateTime createdDate;
+    protected String description;
+    protected UUID id;
+    protected Boolean isControlTag;
+    protected String name;
+    protected DateTime updatedDate;
+
+    public TagDefinitionImp(final TagDefinitionImp that) {
+        this.applicableObjectTypes = that.applicableObjectTypes;
+        this.createdDate = that.createdDate;
+        this.description = that.description;
+        this.id = that.id;
+        this.isControlTag = that.isControlTag;
+        this.name = that.name;
+        this.updatedDate = that.updatedDate;
+    }
+    protected TagDefinitionImp(final TagDefinitionImp.Builder<?> builder) {
+        this.applicableObjectTypes = builder.applicableObjectTypes;
+        this.createdDate = builder.createdDate;
+        this.description = builder.description;
+        this.id = builder.id;
+        this.isControlTag = builder.isControlTag;
+        this.name = builder.name;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected TagDefinitionImp() { }
+    @Override
+    public List<ObjectType> getApplicableObjectTypes() {
+        return this.applicableObjectTypes;
+    }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    @JsonGetter("isControlTag")
+    public Boolean isControlTag() {
+        return this.isControlTag;
+    }
+    @Override
+    public String getName() {
+        return this.name;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TagDefinitionImp that = (TagDefinitionImp) o;
+        if( !Objects.equals(this.applicableObjectTypes, that.applicableObjectTypes) ) {
+            return false;
+        }
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.description, that.description) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.isControlTag, that.isControlTag) ) {
+            return false;
+        }
+        if( !Objects.equals(this.name, that.name) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.applicableObjectTypes);
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.description);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.isControlTag);
+        result = ( 31 * result ) + Objects.hashCode(this.name);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("applicableObjectTypes=").append(this.applicableObjectTypes);
+        sb.append(", ");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("description=");
+        if( this.description == null ) {
+            sb.append(this.description);
+        }else{
+            sb.append("'").append(this.description).append("'");
+        }
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("isControlTag=").append(this.isControlTag);
+        sb.append(", ");
+        sb.append("name=");
+        if( this.name == null ) {
+            sb.append(this.name);
+        }else{
+            sb.append("'").append(this.name).append("'");
+        }
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TagDefinitionImp.Builder<T>> {
+
+        protected List<ObjectType> applicableObjectTypes;
+        protected DateTime createdDate;
+        protected String description;
+        protected UUID id;
+        protected Boolean isControlTag;
+        protected String name;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.applicableObjectTypes = that.applicableObjectTypes;
+            this.createdDate = that.createdDate;
+            this.description = that.description;
+            this.id = that.id;
+            this.isControlTag = that.isControlTag;
+            this.name = that.name;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withApplicableObjectTypes(final List<ObjectType> applicableObjectTypes) {
+            this.applicableObjectTypes = applicableObjectTypes;
+            return (T) this;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withDescription(final String description) {
+            this.description = description;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withIsControlTag(final Boolean isControlTag) {
+            this.isControlTag = isControlTag;
+            return (T) this;
+        }
+        public T withName(final String name) {
+            this.name = name;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final TagDefinition that) {
+            this.applicableObjectTypes = that.getApplicableObjectTypes();
+            this.createdDate = that.getCreatedDate();
+            this.description = that.getDescription();
+            this.id = that.getId();
+            this.isControlTag = that.isControlTag();
+            this.name = that.getName();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TagDefinitionImp build() {
+            return new TagDefinitionImp(this.validate());
+        }
+    }
+}

--- a/src/main/java/org/killbill/billing/util/tag/boilerplate/TagImp.java
+++ b/src/main/java/org/killbill/billing/util/tag/boilerplate/TagImp.java
@@ -1,0 +1,201 @@
+/* This is generated code, edit with caution! */
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.tag.boilerplate;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+import org.joda.time.DateTime;
+import org.killbill.billing.ObjectType;
+import org.killbill.billing.util.tag.Tag;
+
+@JsonDeserialize( builder = TagImp.Builder.class )
+public class TagImp implements Tag, Serializable {
+
+    private static final long serialVersionUID = 0x539F63B6FE1DFED5L;
+
+    protected DateTime createdDate;
+    protected UUID id;
+    protected UUID objectId;
+    protected ObjectType objectType;
+    protected UUID tagDefinitionId;
+    protected DateTime updatedDate;
+
+    public TagImp(final TagImp that) {
+        this.createdDate = that.createdDate;
+        this.id = that.id;
+        this.objectId = that.objectId;
+        this.objectType = that.objectType;
+        this.tagDefinitionId = that.tagDefinitionId;
+        this.updatedDate = that.updatedDate;
+    }
+    protected TagImp(final TagImp.Builder<?> builder) {
+        this.createdDate = builder.createdDate;
+        this.id = builder.id;
+        this.objectId = builder.objectId;
+        this.objectType = builder.objectType;
+        this.tagDefinitionId = builder.tagDefinitionId;
+        this.updatedDate = builder.updatedDate;
+    }
+    protected TagImp() { }
+    @Override
+    public DateTime getCreatedDate() {
+        return this.createdDate;
+    }
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+    @Override
+    public UUID getObjectId() {
+        return this.objectId;
+    }
+    @Override
+    public ObjectType getObjectType() {
+        return this.objectType;
+    }
+    @Override
+    public UUID getTagDefinitionId() {
+        return this.tagDefinitionId;
+    }
+    @Override
+    public DateTime getUpdatedDate() {
+        return this.updatedDate;
+    }
+    @Override
+    public boolean equals(final Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( ( o == null ) || ( this.getClass() != o.getClass() ) ) {
+            return false;
+        }
+        final TagImp that = (TagImp) o;
+        if( ( this.createdDate != null ) ? ( 0 != this.createdDate.compareTo(that.createdDate) ) : ( that.createdDate != null ) ) {
+            return false;
+        }
+        if( !Objects.equals(this.id, that.id) ) {
+            return false;
+        }
+        if( !Objects.equals(this.objectId, that.objectId) ) {
+            return false;
+        }
+        if( !Objects.equals(this.objectType, that.objectType) ) {
+            return false;
+        }
+        if( !Objects.equals(this.tagDefinitionId, that.tagDefinitionId) ) {
+            return false;
+        }
+        if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
+            return false;
+        }
+        return true;
+    }
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = ( 31 * result ) + Objects.hashCode(this.createdDate);
+        result = ( 31 * result ) + Objects.hashCode(this.id);
+        result = ( 31 * result ) + Objects.hashCode(this.objectId);
+        result = ( 31 * result ) + Objects.hashCode(this.objectType);
+        result = ( 31 * result ) + Objects.hashCode(this.tagDefinitionId);
+        result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        return result;
+    }
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer(this.getClass().getSimpleName());
+        sb.append("{");
+        sb.append("createdDate=").append(this.createdDate);
+        sb.append(", ");
+        sb.append("id=").append(this.id);
+        sb.append(", ");
+        sb.append("objectId=").append(this.objectId);
+        sb.append(", ");
+        sb.append("objectType=").append(this.objectType);
+        sb.append(", ");
+        sb.append("tagDefinitionId=").append(this.tagDefinitionId);
+        sb.append(", ");
+        sb.append("updatedDate=").append(this.updatedDate);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static class Builder<T extends TagImp.Builder<T>> {
+
+        protected DateTime createdDate;
+        protected UUID id;
+        protected UUID objectId;
+        protected ObjectType objectType;
+        protected UUID tagDefinitionId;
+        protected DateTime updatedDate;
+
+        public Builder() { }
+        public Builder(final Builder that) {
+            this.createdDate = that.createdDate;
+            this.id = that.id;
+            this.objectId = that.objectId;
+            this.objectType = that.objectType;
+            this.tagDefinitionId = that.tagDefinitionId;
+            this.updatedDate = that.updatedDate;
+        }
+        public T withCreatedDate(final DateTime createdDate) {
+            this.createdDate = createdDate;
+            return (T) this;
+        }
+        public T withId(final UUID id) {
+            this.id = id;
+            return (T) this;
+        }
+        public T withObjectId(final UUID objectId) {
+            this.objectId = objectId;
+            return (T) this;
+        }
+        public T withObjectType(final ObjectType objectType) {
+            this.objectType = objectType;
+            return (T) this;
+        }
+        public T withTagDefinitionId(final UUID tagDefinitionId) {
+            this.tagDefinitionId = tagDefinitionId;
+            return (T) this;
+        }
+        public T withUpdatedDate(final DateTime updatedDate) {
+            this.updatedDate = updatedDate;
+            return (T) this;
+        }
+        public T source(final Tag that) {
+            this.createdDate = that.getCreatedDate();
+            this.id = that.getId();
+            this.objectId = that.getObjectId();
+            this.objectType = that.getObjectType();
+            this.tagDefinitionId = that.getTagDefinitionId();
+            this.updatedDate = that.getUpdatedDate();
+            return (T) this;
+        }
+        protected Builder validate() {
+          return this;
+        }
+        public TagImp build() {
+            return new TagImp(this.validate());
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,0 +1,25 @@
+#This is generated code, edit with caution!
+org.killbill.billing.util.customfield.boilerplate.Module
+org.killbill.billing.security.api.boilerplate.Module
+org.killbill.billing.osgi.api.config.boilerplate.Module
+org.killbill.billing.invoice.api.boilerplate.Module
+org.killbill.billing.currency.api.boilerplate.Module
+org.killbill.billing.util.api.boilerplate.Module
+org.killbill.billing.invoice.api.formatters.boilerplate.Module
+org.killbill.billing.tenant.api.boilerplate.Module
+org.killbill.billing.boilerplate.Module
+org.killbill.billing.usage.api.boilerplate.Module
+org.killbill.billing.catalog.api.rules.boilerplate.Module
+org.killbill.billing.util.audit.boilerplate.Module
+org.killbill.billing.util.nodes.boilerplate.Module
+org.killbill.billing.payment.api.boilerplate.Module
+org.killbill.billing.account.api.boilerplate.Module
+org.killbill.billing.util.entity.boilerplate.Module
+org.killbill.billing.payment.plugin.api.boilerplate.Module
+org.killbill.billing.entitlement.api.boilerplate.Module
+org.killbill.billing.osgi.api.boilerplate.Module
+org.killbill.billing.util.callcontext.boilerplate.Module
+org.killbill.billing.util.tag.boilerplate.Module
+org.killbill.billing.overdue.api.boilerplate.Module
+org.killbill.billing.catalog.api.boilerplate.Module
+

--- a/src/test/java/org/killbill/billing/plugin/api/TestPluginCallContext.java
+++ b/src/test/java/org/killbill/billing/plugin/api/TestPluginCallContext.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import org.joda.time.DateTime;
+
+import org.killbill.billing.util.callcontext.CallOrigin;
+import org.killbill.billing.util.callcontext.UserType;
+
+@Test(groups = { "fast" })
+public class TestPluginCallContext {
+
+    private final UUID accountId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private final CallOrigin callOrigin = CallOrigin.INTERNAL;
+    private final String comments = "Test Comments";
+    private final DateTime createdDate = new DateTime("2011-11-11T11:11");
+    private final String reasonCode = "Testing";
+    private final UUID tenantId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private final DateTime updatedDate =  new DateTime("2011-11-11T11:11");
+    private final String userName = "TestUserName";
+    private final UUID userToken = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private final UserType userType = UserType.ADMIN;
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginCallContext a = new PluginCallContext.Builder<>()
+            .withUserToken(userToken)
+            .withUserName(userName)
+            .withCallOrigin(callOrigin)
+            .withUserType(userType)
+            .withReasonCode(reasonCode)
+            .withComments(comments)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .withAccountId(accountId)
+            .withTenantId(tenantId)
+            .build();
+
+        PluginCallContext b = new PluginCallContext(
+                userToken,
+                userName,
+                callOrigin,
+                userType,
+                reasonCode,
+                comments,
+                createdDate,
+                updatedDate,
+                accountId,
+                tenantId);
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginCallContext.Builder builder = new PluginCallContext.Builder<>()
+            .withUserToken(userToken)
+            .withUserName(userName)
+            .withCallOrigin(callOrigin)
+            .withUserType(userType)
+            .withReasonCode(reasonCode)
+            .withComments(comments)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .withAccountId(accountId)
+            .withTenantId(tenantId);
+
+        Assert.assertNotEquals(builder.build(), builder.withUserName("DifferentTestUserName").build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginCallContext a = new PluginCallContext.Builder<>()
+            .withUserToken(userToken)
+            .withUserName(userName)
+            .withCallOrigin(callOrigin)
+            .withUserType(userType)
+            .withReasonCode(reasonCode)
+            .withComments(comments)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .withAccountId(accountId)
+            .withTenantId(tenantId)
+            .build();
+
+        Assert.assertEquals(a.getUserToken(), userToken);
+        Assert.assertEquals(a.getUserName(), userName);
+        Assert.assertEquals(a.getCallOrigin(), callOrigin);
+        Assert.assertEquals(a.getUserType(), userType);
+        Assert.assertEquals(a.getReasonCode(), reasonCode);
+        Assert.assertEquals(a.getComments(), comments);
+        Assert.assertEquals(a.getCreatedDate(), createdDate);
+        Assert.assertEquals(a.getUpdatedDate(), updatedDate);
+        Assert.assertEquals(a.getAccountId(), accountId);
+        Assert.assertEquals(a.getTenantId(), tenantId);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginCallContext a = new PluginCallContext.Builder<>()
+            .withUserToken(userToken)
+            .withUserName(userName)
+            .withCallOrigin(callOrigin)
+            .withUserType(userType)
+            .withReasonCode(reasonCode)
+            .withComments(comments)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .withAccountId(accountId)
+            .withTenantId(tenantId)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginCallContext b = mapper.readValue(json, PluginCallContext.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/core/TestPluginAccountData.java
+++ b/src/test/java/org/killbill/billing/plugin/api/core/TestPluginAccountData.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import org.killbill.billing.catalog.api.Currency;
+
+@Test(groups = { "fast" })
+public class TestPluginAccountData {
+
+    final private String address1 = "TestAddress1'";
+    final private String address2 = "TestAddress2";
+    final private Integer billCycleDayLocal = 1;
+    final private String city = "TestCity";
+    final private String companyName = "TestCompanyName";
+    final private String country = "US";
+    final private Currency currency = Currency.USD;
+    final private String email = "Tester@nowhere.com";
+    final private String externalKey = "TestExternalKey";
+    final private Integer firstNameLength = 1;
+    final private Boolean isMigrated = false;
+    final private Boolean isPaymentDelegatedToParent = false;
+    final private String locale=  Locale.US.toString();
+    final private String name = "TestName";
+    final private String notes = "TestNote";
+    final private UUID parentAccountId =  UUID.fromString("00000000-0000-0000-0000-000000000001");
+    final private UUID paymentMethodId =  UUID.fromString("00000000-0000-0000-0000-000000000002");
+    final private String phone = "111-111-1111";
+    final private String postalCode = "54321";
+    final private DateTime referenceTime =  new DateTime("2011-11-11T11:11");
+    final private String stateOrProvince = "TestProvince";
+    final private DateTimeZone timeZone =  DateTimeZone.UTC;
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginAccountData a = new PluginAccountData.Builder<>()
+            .withExternalKey(externalKey)
+            .withEmail(email)
+            .withName(name)
+            .withFirstNameLength(firstNameLength)
+            .withCurrency(currency)
+            .withParentAccountId(parentAccountId)
+            .withIsPaymentDelegatedToParent(isPaymentDelegatedToParent)
+            .withBillCycleDayLocal(billCycleDayLocal)
+            .withPaymentMethodId(paymentMethodId)
+            .withReferenceTime(referenceTime)
+            .withTimeZone(timeZone)
+            .withLocale(locale)
+            .withAddress1(address1)
+            .withAddress2(address2)
+            .withCompanyName(companyName)
+            .withCity(city)
+            .withStateOrProvince(stateOrProvince)
+            .withPostalCode(postalCode)
+            .withCountry(country)
+            .withPhone(phone)
+            .withNotes(notes)
+            .withIsMigrated(isMigrated)
+            .build();
+
+        PluginAccountData b = new PluginAccountData(externalKey,
+                email,
+                name,
+                firstNameLength,
+                currency,
+                parentAccountId,
+                isPaymentDelegatedToParent,
+                billCycleDayLocal,
+                paymentMethodId,
+                referenceTime,
+                timeZone,
+                locale,
+                address1,
+                address2,
+                companyName,
+                city,
+                stateOrProvince,
+                country,
+                postalCode,
+                phone,
+                notes,
+                isMigrated,
+                false) ;
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+     PluginAccountData.Builder builder = new PluginAccountData.Builder<>()
+            .withExternalKey(externalKey)
+            .withEmail(email)
+            .withName(name)
+            .withFirstNameLength(firstNameLength)
+            .withCurrency(currency)
+            .withParentAccountId(parentAccountId)
+            .withIsPaymentDelegatedToParent(isPaymentDelegatedToParent)
+            .withBillCycleDayLocal(billCycleDayLocal)
+            .withPaymentMethodId(paymentMethodId)
+            .withReferenceTime(referenceTime)
+            .withTimeZone(timeZone)
+            .withLocale(locale)
+            .withAddress1(address1)
+            .withAddress2(address2)
+            .withCompanyName(companyName)
+            .withCity(city)
+            .withStateOrProvince(stateOrProvince)
+            .withPostalCode(postalCode)
+            .withCountry(country)
+            .withPhone(phone)
+            .withNotes(notes)
+            .withIsMigrated(isMigrated);
+
+        Assert.assertNotEquals(builder.build(), builder.withName("DifferentTestName").build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginAccountData a = new PluginAccountData.Builder<>()
+            .withExternalKey(externalKey)
+            .withEmail(email)
+            .withName(name)
+            .withFirstNameLength(firstNameLength)
+            .withCurrency(currency)
+            .withParentAccountId(parentAccountId)
+            .withIsPaymentDelegatedToParent(isPaymentDelegatedToParent)
+            .withBillCycleDayLocal(billCycleDayLocal)
+            .withPaymentMethodId(paymentMethodId)
+            .withReferenceTime(referenceTime)
+            .withTimeZone(timeZone)
+            .withLocale(locale)
+            .withAddress1(address1)
+            .withAddress2(address2)
+            .withCompanyName(companyName)
+            .withCity(city)
+            .withStateOrProvince(stateOrProvince)
+            .withPostalCode(postalCode)
+            .withCountry(country)
+            .withPhone(phone)
+            .withNotes(notes)
+            .withIsMigrated(isMigrated)
+            .build();
+
+        Assert.assertEquals(a.getExternalKey(), externalKey);
+        Assert.assertEquals(a.getEmail(), email);
+        Assert.assertEquals(a.getName(), name);
+        Assert.assertEquals(a.getFirstNameLength(), firstNameLength);
+        Assert.assertEquals(a.getCurrency(), currency);
+        Assert.assertEquals(a.getParentAccountId(), parentAccountId);
+        Assert.assertEquals(a.isPaymentDelegatedToParent(), isPaymentDelegatedToParent);
+        Assert.assertEquals(a.getBillCycleDayLocal(), billCycleDayLocal);
+        Assert.assertEquals(a.getPaymentMethodId(), paymentMethodId);
+        Assert.assertEquals(a.getReferenceTime(), referenceTime);
+        Assert.assertEquals(a.getTimeZone(), timeZone);
+        Assert.assertEquals(a.getLocale(), locale);
+        Assert.assertEquals(a.getAddress1(), address1);
+        Assert.assertEquals(a.getAddress2(), address2);
+        Assert.assertEquals(a.getCompanyName(), companyName);
+        Assert.assertEquals(a.getCity(), city);
+        Assert.assertEquals(a.getStateOrProvince(), stateOrProvince);
+        Assert.assertEquals(a.getPostalCode(), postalCode);
+        Assert.assertEquals(a.getCountry(), country);
+        Assert.assertEquals(a.getPhone(), phone);
+        Assert.assertEquals(a.getNotes(), notes);
+        Assert.assertEquals(a.isMigrated(), isMigrated);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginAccountData a = new PluginAccountData.Builder<>()
+            .withExternalKey(externalKey)
+            .withEmail(email)
+            .withName(name)
+            .withFirstNameLength(firstNameLength)
+            .withCurrency(currency)
+            .withParentAccountId(parentAccountId)
+            .withIsPaymentDelegatedToParent(isPaymentDelegatedToParent)
+            .withBillCycleDayLocal(billCycleDayLocal)
+            .withPaymentMethodId(paymentMethodId)
+            .withReferenceTime(referenceTime)
+            .withTimeZone(timeZone)
+            .withLocale(locale)
+            .withAddress1(address1)
+            .withAddress2(address2)
+            .withCompanyName(companyName)
+            .withCity(city)
+            .withStateOrProvince(stateOrProvince)
+            .withPostalCode(postalCode)
+            .withCountry(country)
+            .withPhone(phone)
+            .withNotes(notes)
+            .withIsMigrated(isMigrated)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginAccountData b = mapper.readValue(json, PluginAccountData.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/core/TestPluginCustomField.java
+++ b/src/test/java/org/killbill/billing/plugin/api/core/TestPluginCustomField.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import org.joda.time.DateTime;
+import org.killbill.billing.ObjectType;
+
+@Test(groups = { "fast" })
+public class TestPluginCustomField {
+
+    final private DateTime createdDate = new DateTime("2011-11-11T11:11");
+    final private String fieldName = "TestFieldName";
+    final private String fieldValue = "TestFieldValue";
+    final private UUID id = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    final private UUID objectId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    final private ObjectType objectType = ObjectType.INVOICE;
+    final private DateTime updatedDate = new DateTime("2011-11-11T11:11");
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginCustomField a = new PluginCustomField.Builder<>()
+            .withObjectId(objectId)
+            .withObjectType(objectType)
+            .withFieldName(fieldName)
+            .withFieldValue(fieldValue)
+            .withId(id)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        PluginCustomField b = new PluginCustomField(
+                objectId,
+                objectType,
+                fieldName,
+                fieldValue,
+                id,
+                createdDate,
+                updatedDate);
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginCustomField.Builder builder = new PluginCustomField.Builder<>()
+            .withObjectId(objectId)
+            .withObjectType(objectType)
+            .withFieldName(fieldName)
+            .withFieldValue(fieldValue)
+            .withId(id)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate);
+
+        Assert.assertNotEquals(builder.build(), builder.withFieldName("DifferentTestFieldName").build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginCustomField a = new PluginCustomField.Builder<>()
+            .withObjectId(objectId)
+            .withObjectType(objectType)
+            .withFieldName(fieldName)
+            .withFieldValue(fieldValue)
+            .withId(id)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        Assert.assertEquals(a.getObjectId(), objectId);
+        Assert.assertEquals(a.getObjectType(), objectType);
+        Assert.assertEquals(a.getFieldName(), fieldName);
+        Assert.assertEquals(a.getFieldValue(), fieldValue);
+        Assert.assertEquals(a.getId(), id);
+        Assert.assertEquals(a.getCreatedDate(), createdDate);
+        Assert.assertEquals(a.getUpdatedDate(), updatedDate);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginCustomField a = new PluginCustomField.Builder<>()
+            .withObjectId(objectId)
+            .withObjectType(objectType)
+            .withFieldName(fieldName)
+            .withFieldValue(fieldValue)
+            .withId(id)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginCustomField b = mapper.readValue(json, PluginCustomField.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/core/TestPluginDryRunArguments.java
+++ b/src/test/java/org/killbill/billing/plugin/api/core/TestPluginDryRunArguments.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.BillingActionPolicy;
+import org.killbill.billing.entitlement.api.EntitlementSpecifier;
+import org.killbill.billing.entitlement.api.SubscriptionEventType;
+import org.killbill.billing.invoice.api.DryRunType;
+
+@Test(groups = { "fast" })
+public class TestPluginDryRunArguments {
+
+    final private SubscriptionEventType action = SubscriptionEventType.START_BILLING;
+    final private BillingActionPolicy billingActionPolicy =  BillingActionPolicy.IMMEDIATE;
+    final private UUID bundleId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    final private DryRunType dryRunType = DryRunType.UPCOMING_INVOICE;
+    final private LocalDate effectiveDate = new LocalDate("2011-11-11");
+    final private EntitlementSpecifier entitlementSpecifier = null;
+    final private UUID subscriptionId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginDryRunArguments a = new PluginDryRunArguments.Builder<>()
+            .withDryRunType(dryRunType)
+            .withEntitlementSpecifier(entitlementSpecifier)
+            .withAction(action)
+            .withSubscriptionId(subscriptionId)
+            .withEffectiveDate(effectiveDate)
+            .withBundleId(bundleId)
+            .withBillingActionPolicy(billingActionPolicy)
+            .build();
+
+        PluginDryRunArguments b = new PluginDryRunArguments(
+                dryRunType,
+                entitlementSpecifier,
+                action,
+                subscriptionId,
+                effectiveDate,
+                bundleId,
+                billingActionPolicy);
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginDryRunArguments.Builder builder = new PluginDryRunArguments.Builder<>()
+            .withDryRunType(dryRunType)
+            .withEntitlementSpecifier(entitlementSpecifier)
+            .withAction(action)
+            .withSubscriptionId(subscriptionId)
+            .withEffectiveDate(effectiveDate)
+            .withBundleId(bundleId)
+            .withBillingActionPolicy(billingActionPolicy);
+
+
+        Assert.assertNotEquals(builder.build(), builder.withDryRunType(DryRunType.TARGET_DATE).build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginDryRunArguments a = new PluginDryRunArguments.Builder<>()
+            .withDryRunType(dryRunType)
+            .withEntitlementSpecifier(entitlementSpecifier)
+            .withAction(action)
+            .withSubscriptionId(subscriptionId)
+            .withEffectiveDate(effectiveDate)
+            .withBundleId(bundleId)
+            .withBillingActionPolicy(billingActionPolicy)
+            .build();
+
+        Assert.assertEquals(a.getDryRunType(), dryRunType);
+        Assert.assertEquals(a.getEntitlementSpecifier(), entitlementSpecifier);
+        Assert.assertEquals(a.getAction(), action);
+        Assert.assertEquals(a.getSubscriptionId(), subscriptionId);
+        Assert.assertEquals(a.getEffectiveDate(), effectiveDate);
+        Assert.assertEquals(a.getBundleId(), bundleId);
+        Assert.assertEquals(a.getBillingActionPolicy(), billingActionPolicy);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginDryRunArguments a = new PluginDryRunArguments.Builder<>()
+            .withDryRunType(dryRunType)
+            .withEntitlementSpecifier(entitlementSpecifier)
+            .withAction(action)
+            .withSubscriptionId(subscriptionId)
+            .withEffectiveDate(effectiveDate)
+            .withBundleId(bundleId)
+            .withBillingActionPolicy(billingActionPolicy)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginDryRunArguments b = mapper.readValue(json, PluginDryRunArguments.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/core/TestPluginEntitlementSpecifier.java
+++ b/src/test/java/org/killbill/billing/plugin/api/core/TestPluginEntitlementSpecifier.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.collect.ImmutableList;
+import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+
+@Test(groups = { "fast" })
+public class TestPluginEntitlementSpecifier {
+
+    final private Integer billCycleDay = 1;
+    final private String externalKey = "TestExternalKey";
+    final private List<PlanPhasePriceOverride> overrides = ImmutableList.<PlanPhasePriceOverride>of();
+    final private PlanPhaseSpecifier planPhaseSpecifier = null;
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginEntitlementSpecifier a = new PluginEntitlementSpecifier.Builder<>()
+            .withPlanPhaseSpecifier(planPhaseSpecifier)
+            .withBillCycleDay(billCycleDay)
+            .withExternalKey(externalKey)
+            .withOverrides(overrides)
+            .build();
+
+        PluginEntitlementSpecifier b = new PluginEntitlementSpecifier(
+                planPhaseSpecifier,
+                billCycleDay,
+                externalKey,
+                overrides) ;
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginEntitlementSpecifier.Builder builder = new PluginEntitlementSpecifier.Builder<>()
+            .withPlanPhaseSpecifier(planPhaseSpecifier)
+            .withBillCycleDay(billCycleDay)
+            .withExternalKey(externalKey)
+            .withOverrides(overrides);
+
+        Assert.assertNotEquals(builder.build(), builder.withBillCycleDay(15).build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginEntitlementSpecifier a = new PluginEntitlementSpecifier.Builder<>()
+            .withPlanPhaseSpecifier(planPhaseSpecifier)
+            .withBillCycleDay(billCycleDay)
+            .withExternalKey(externalKey)
+            .withOverrides(overrides)
+            .build();
+
+            Assert.assertEquals(a.getPlanPhaseSpecifier(), planPhaseSpecifier);
+            Assert.assertEquals(a.getBillCycleDay(), billCycleDay);
+            Assert.assertEquals(a.getExternalKey(), externalKey);
+            Assert.assertEquals(a.getOverrides(), overrides);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginEntitlementSpecifier a = new PluginEntitlementSpecifier.Builder<>()
+            .withPlanPhaseSpecifier(planPhaseSpecifier)
+            .withBillCycleDay(billCycleDay)
+            .withExternalKey(externalKey)
+            .withOverrides(overrides)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginEntitlementSpecifier b = mapper.readValue(json, PluginEntitlementSpecifier.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/core/TestPluginPaymentOptions.java
+++ b/src/test/java/org/killbill/billing/plugin/api/core/TestPluginPaymentOptions.java
@@ -14,35 +14,35 @@
  * under the License.
  */
 
-package org.killbill.billing.plugin.api;
+package org.killbill.billing.plugin.api.core;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.UUID;
-import javax.annotation.Nullable;
+import java.util.List;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.collect.ImmutableList;
 
 @Test(groups = { "fast" })
-public class TestPluginTenantContext {
+public class TestPluginPaymentOptions {
 
-    final private UUID accountId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-    final private UUID tenantId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    final private boolean isExternalPayment = true;
+    final private List<String> paymentControlPluginNames = ImmutableList.<String>of();
 
     @Test
     void builderIsEquivalentToConstructor() {
 
-        PluginTenantContext a = new PluginTenantContext.Builder<>()
-            .withAccountId(accountId)
-            .withTenantId(tenantId)
+        PluginPaymentOptions a = new PluginPaymentOptions.Builder<>()
+            .withIsExternalPayment(isExternalPayment)
+            .withPaymentControlPluginNames(paymentControlPluginNames)
             .build();
 
-        PluginTenantContext b = new PluginTenantContext(accountId, tenantId) ;
+        PluginPaymentOptions b = new PluginPaymentOptions(isExternalPayment, paymentControlPluginNames);
 
         Assert.assertTrue(a.equals(b));
     }
@@ -50,24 +50,23 @@ public class TestPluginTenantContext {
     @Test
     void differentInstances() {
 
-        PluginTenantContext.Builder builder = new PluginTenantContext.Builder<>()
-            .withAccountId(accountId)
-            .withTenantId(tenantId);
+        PluginPaymentOptions.Builder builder = new PluginPaymentOptions.Builder<>()
+            .withIsExternalPayment(isExternalPayment)
+            .withPaymentControlPluginNames(paymentControlPluginNames);
 
-            Assert.assertNotEquals(builder.build(), 
-                    builder.withAccountId(UUID.fromString("00000000-0000-0000-0000-000000000003")).build());
+        Assert.assertNotEquals(builder.build(), builder.withIsExternalPayment(false).build());
     }
 
     @Test
     void callAllGetters() {
 
-        PluginTenantContext a = new PluginTenantContext.Builder<>()
-            .withAccountId(accountId)
-            .withTenantId(tenantId)
+        PluginPaymentOptions a = new PluginPaymentOptions.Builder<>()
+            .withIsExternalPayment(isExternalPayment)
+            .withPaymentControlPluginNames(paymentControlPluginNames)
             .build();
 
-        Assert.assertEquals(a.getAccountId(), accountId);
-        Assert.assertEquals(a.getTenantId(), tenantId);
+        Assert.assertEquals(a.isExternalPayment(), isExternalPayment);
+        Assert.assertEquals(a.getPaymentControlPluginNames(), paymentControlPluginNames);
     }
 
     @Test 
@@ -79,13 +78,13 @@ public class TestPluginTenantContext {
         mapper.registerModule(new JodaModule());
         mapper.findAndRegisterModules();
 
-        PluginTenantContext a = new PluginTenantContext.Builder<>()
-            .withAccountId(accountId)
-            .withTenantId(tenantId)
+        PluginPaymentOptions a = new PluginPaymentOptions.Builder<>()
+            .withIsExternalPayment(isExternalPayment)
+            .withPaymentControlPluginNames(paymentControlPluginNames)
             .build();
 
         String json =  mapper.writeValueAsString(a);;
-        PluginTenantContext b = mapper.readValue(json, PluginTenantContext.class);
+        PluginPaymentOptions b = mapper.readValue(json, PluginPaymentOptions.class);
 
         Assert.assertTrue(a.equals(b));
     }

--- a/src/test/java/org/killbill/billing/plugin/api/core/TestPluginPlanPhasePriceOverride.java
+++ b/src/test/java/org/killbill/billing/plugin/api/core/TestPluginPlanPhasePriceOverride.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.killbill.billing.plugin.api.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.collect.ImmutableList;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
+import org.killbill.billing.catalog.api.UsagePriceOverride;
+
+@Test(groups = { "fast" })
+public class TestPluginPlanPhasePriceOverride {
+
+    protected Currency currency = Currency.USD;
+    protected BigDecimal fixedPrice = new BigDecimal("100000");
+    protected String phaseName = "TestPhaseName";
+    protected PlanPhaseSpecifier planPhaseSpecifier = null;
+    protected BigDecimal recurringPrice = new BigDecimal("200000");
+    protected List<UsagePriceOverride> usagePriceOverrides = ImmutableList.<UsagePriceOverride>of();
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginPlanPhasePriceOverride a = new PluginPlanPhasePriceOverride.Builder<>()
+            .withPhaseName(phaseName)
+            .withPlanPhaseSpecifier(planPhaseSpecifier)
+            .withCurrency(currency)
+            .withFixedPrice(fixedPrice)
+            .withRecurringPrice(recurringPrice)
+            .withUsagePriceOverrides(usagePriceOverrides)
+            .build();
+
+        PluginPlanPhasePriceOverride b = new PluginPlanPhasePriceOverride(
+                phaseName,
+                planPhaseSpecifier,
+                currency,
+                fixedPrice,
+                recurringPrice,
+                usagePriceOverrides);
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginPlanPhasePriceOverride.Builder builder = new PluginPlanPhasePriceOverride.Builder<>()
+            .withPhaseName(phaseName)
+            .withPlanPhaseSpecifier(planPhaseSpecifier)
+            .withCurrency(currency)
+            .withFixedPrice(fixedPrice)
+            .withRecurringPrice(recurringPrice)
+            .withUsagePriceOverrides(usagePriceOverrides);
+
+        Assert.assertNotEquals(builder.build(), builder.withCurrency(Currency.JPY).build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginPlanPhasePriceOverride a = new PluginPlanPhasePriceOverride.Builder<>()
+            .withPhaseName(phaseName)
+            .withPlanPhaseSpecifier(planPhaseSpecifier)
+            .withCurrency(currency)
+            .withFixedPrice(fixedPrice)
+            .withRecurringPrice(recurringPrice)
+            .withUsagePriceOverrides(usagePriceOverrides)
+            .build();
+
+        Assert.assertEquals(a.getPhaseName(), phaseName);
+        Assert.assertEquals(a.getPlanPhaseSpecifier(), planPhaseSpecifier);
+        Assert.assertEquals(a.getCurrency(), currency);
+        Assert.assertEquals(a.getFixedPrice(), fixedPrice);
+        Assert.assertEquals(a.getRecurringPrice(), recurringPrice);
+        Assert.assertEquals(a.getUsagePriceOverrides(), usagePriceOverrides);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginPlanPhasePriceOverride a = new PluginPlanPhasePriceOverride.Builder<>()
+            .withPhaseName(phaseName)
+            .withPlanPhaseSpecifier(planPhaseSpecifier)
+            .withCurrency(currency)
+            .withFixedPrice(fixedPrice)
+            .withRecurringPrice(recurringPrice)
+            .withUsagePriceOverrides(usagePriceOverrides)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginPlanPhasePriceOverride b = mapper.readValue(json, PluginPlanPhasePriceOverride.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/core/TestPluginTag.java
+++ b/src/test/java/org/killbill/billing/plugin/api/core/TestPluginTag.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.core;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import org.joda.time.DateTime;
+import org.killbill.billing.ObjectType;
+
+@Test(groups = { "fast" })
+public class TestPluginTag {
+
+    protected DateTime createdDate = new DateTime("2011-11-11T11:11");
+    protected UUID id = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    protected UUID objectId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    protected ObjectType objectType =  ObjectType.INVOICE;
+    protected UUID tagDefinitionId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    protected DateTime updatedDate = new DateTime("2011-11-11T11:11");
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginTag a = new PluginTag.Builder<>()
+            .withObjectId(objectId)
+            .withObjectType(objectType)
+            .withTagDefinitionId(tagDefinitionId)
+            .withId(id)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        PluginTag b = new PluginTag(
+                objectId,
+                objectType,
+                tagDefinitionId,
+                id,
+                createdDate,
+                updatedDate);
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginTag.Builder builder = new PluginTag.Builder<>()
+            .withObjectId(objectId)
+            .withObjectType(objectType)
+            .withTagDefinitionId(tagDefinitionId)
+            .withId(id)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate);
+
+            Assert.assertNotEquals(builder.build(), builder.withObjectType(ObjectType.PAYMENT).build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginTag a = new PluginTag.Builder<>()
+            .withObjectId(objectId)
+            .withObjectType(objectType)
+            .withTagDefinitionId(tagDefinitionId)
+            .withId(id)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        Assert.assertEquals(a.getObjectId(), objectId);
+        Assert.assertEquals(a.getObjectType(), objectType);
+        Assert.assertEquals(a.getTagDefinitionId(), tagDefinitionId);
+        Assert.assertEquals(a.getId(), id);
+        Assert.assertEquals(a.getCreatedDate(), createdDate);
+        Assert.assertEquals(a.getUpdatedDate(), updatedDate);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginTag a = new PluginTag.Builder<>()
+            .withObjectId(objectId)
+            .withObjectType(objectType)
+            .withTagDefinitionId(tagDefinitionId)
+            .withId(id)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginTag b = mapper.readValue(json, PluginTag.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/invoice/TestPluginInvoiceItem.java
+++ b/src/test/java/org/killbill/billing/plugin/api/invoice/TestPluginInvoiceItem.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2014-2020 Groupon, Inc
- * Copyright 2020-2020 Equinix, Inc
- * Copyright 2014-2020 The Billing Project, LLC
+ * Copyright 2022-2022 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -15,58 +13,258 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package org.killbill.billing.plugin.api.invoice;
 
-import java.math.BigDecimal;
-
-import org.killbill.billing.account.api.Account;
-import org.killbill.billing.catalog.api.Currency;
-import org.killbill.billing.invoice.api.Invoice;
-import org.killbill.billing.invoice.api.InvoiceItem;
-import org.killbill.billing.invoice.api.InvoiceItemType;
-import org.killbill.billing.plugin.TestUtils;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import java.math.BigDecimal;
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.invoice.api.InvoiceItemType;
 
+@Test(groups = { "fast" })
 public class TestPluginInvoiceItem {
 
-    private Account account;
-    private Invoice invoice1;
-    private InvoiceItem invoice1TaxableItem;
-    private InvoiceItem invoice1TaxItem;
+    private final UUID accountId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private final BigDecimal amount = new BigDecimal("100000");
+    private final UUID bundleId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private final DateTime catalogEffectiveDate = new DateTime("2011-11-11T11:11");
+    private final UUID childAccountId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    private final DateTime createdDate = new DateTime("2011-11-11T11:11");
+    private final Currency currency = Currency.USD;
+    private final String description = "TestDescription";
+    private final LocalDate endDate = new LocalDate("2022-11-11");
+    private final UUID id = UUID.fromString("00000000-0000-0000-0000-000000000004");
+    private final UUID invoiceId = UUID.fromString("00000000-0000-0000-0000-000000000005");
+    private final InvoiceItemType invoiceItemType =  InvoiceItemType.FIXED;
+    private final String itemDetails = "TestItemDetails";
+    private final UUID linkedItemId = UUID.fromString("00000000-0000-0000-0000-000000000006");
+    private final String phaseName = "TestPhaseName";
+    private final String planName = "TestPlanName";
+    private final String prettyPhaseName ="TestPrettyPhaseName";
+    private final String prettyPlanName = "TestPrettyPlanName";
+    private final String prettyProductName = "TestPrettyProductName";
+    private final String prettyUsageName = "TestPrettyUsageName";
+    private final String productName = "TestProductName";
+    private final Integer quantity = 1;
+    private final BigDecimal rate = new BigDecimal("4.2");
+    private final LocalDate startDate = new LocalDate("2011-11-11");
+    private final UUID subscriptionId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private final DateTime updatedDate = new DateTime("2011-11-11T11:11");
+    private final String usageName = "TestUsageName";
 
-    @BeforeMethod(groups = "fast")
-    public void setUp() throws Exception {
-        account = TestUtils.buildAccount(Currency.BTC, "US");
+    @Test
+    void builderIsEquivalentToConstructor() {
 
-        invoice1 = TestUtils.buildInvoice(account);
-        invoice1TaxableItem = TestUtils.buildInvoiceItem(invoice1, InvoiceItemType.EXTERNAL_CHARGE, BigDecimal.TEN, null);
-        invoice1TaxItem = PluginInvoiceItem.createTaxItem(invoice1TaxableItem, invoice1.getId(), BigDecimal.ONE, "TestNG tax");
-        invoice1.getInvoiceItems().add(invoice1TaxableItem);
-        invoice1.getInvoiceItems().add(invoice1TaxItem);
+        PluginInvoiceItem a = new PluginInvoiceItem.Builder<>()
+            .withId(id)
+            .withInvoiceItemType(invoiceItemType)
+            .withInvoiceId(invoiceId)
+            .withAccountId(accountId)
+            .withChildAccountId(childAccountId)
+            .withStartDate(startDate)
+            .withEndDate(endDate)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withDescription(description)
+            .withSubscriptionId(subscriptionId)
+            .withBundleId(bundleId)
+            .withCatalogEffectiveDate(catalogEffectiveDate)
+            .withProductName(productName)
+            .withPrettyProductName(prettyProductName)
+            .withPlanName(planName)
+            .withPrettyPlanName(prettyPlanName)
+            .withPhaseName(phaseName)
+            .withPrettyPhaseName(prettyPhaseName)
+            .withRate(rate)
+            .withLinkedItemId(linkedItemId)
+            .withUsageName(usageName)
+            .withPrettyUsageName(prettyUsageName)
+            .withQuantity(quantity)
+            .withItemDetails(itemDetails)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        PluginInvoiceItem b = new PluginInvoiceItem(
+                id,
+                invoiceItemType,
+                invoiceId,
+                accountId,
+                childAccountId,
+                startDate,
+                endDate,
+                amount,
+                currency,
+                description,
+                subscriptionId,
+                bundleId,
+                catalogEffectiveDate,
+                productName,
+                prettyProductName,
+                planName,
+                prettyPlanName,
+                phaseName,
+                prettyPhaseName,
+                rate,
+                linkedItemId,
+                usageName,
+                prettyUsageName,
+                quantity,
+                itemDetails,
+                createdDate,
+                updatedDate);
+
+        Assert.assertTrue(a.equals(b));
     }
 
-    @Test(groups = "fast")
-    public void testBuildTaxItem() throws Exception {
-        // Overrides
-        Assert.assertEquals(invoice1TaxItem.getInvoiceItemType(), InvoiceItemType.TAX);
-        Assert.assertEquals(invoice1TaxItem.getStartDate(), invoice1TaxableItem.getStartDate());
-        Assert.assertNull(invoice1TaxItem.getEndDate());
-        Assert.assertEquals(invoice1TaxItem.getAmount().compareTo(BigDecimal.ONE), 0);
-        Assert.assertEquals(invoice1TaxItem.getDescription(), "TestNG tax");
-        Assert.assertEquals(invoice1TaxItem.getLinkedItemId(), invoice1TaxableItem.getId());
-        Assert.assertNull(invoice1TaxItem.getRate());
+    @Test
+    void differentInstances() {
 
-        // Copies
-        Assert.assertEquals(invoice1TaxItem.getInvoiceId(), invoice1TaxableItem.getInvoiceId());
-        Assert.assertEquals(invoice1TaxItem.getAccountId(), invoice1TaxableItem.getAccountId());
-        Assert.assertEquals(invoice1TaxItem.getCurrency(), invoice1TaxableItem.getCurrency());
-        Assert.assertEquals(invoice1TaxItem.getBundleId(), invoice1TaxableItem.getBundleId());
-        Assert.assertEquals(invoice1TaxItem.getSubscriptionId(), invoice1TaxableItem.getSubscriptionId());
-        Assert.assertEquals(invoice1TaxItem.getPlanName(), invoice1TaxableItem.getPlanName());
-        Assert.assertEquals(invoice1TaxItem.getPhaseName(), invoice1TaxableItem.getPhaseName());
-        Assert.assertEquals(invoice1TaxItem.getUsageName(), invoice1TaxableItem.getUsageName());
+        PluginInvoiceItem.Builder builder = new PluginInvoiceItem.Builder<>()
+            .withId(id)
+            .withInvoiceItemType(invoiceItemType)
+            .withInvoiceId(invoiceId)
+            .withAccountId(accountId)
+            .withChildAccountId(childAccountId)
+            .withStartDate(startDate)
+            .withEndDate(endDate)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withDescription(description)
+            .withSubscriptionId(subscriptionId)
+            .withBundleId(bundleId)
+            .withCatalogEffectiveDate(catalogEffectiveDate)
+            .withProductName(productName)
+            .withPrettyProductName(prettyProductName)
+            .withPlanName(planName)
+            .withPrettyPlanName(prettyPlanName)
+            .withPhaseName(phaseName)
+            .withPrettyPhaseName(prettyPhaseName)
+            .withRate(rate)
+            .withLinkedItemId(linkedItemId)
+            .withUsageName(usageName)
+            .withPrettyUsageName(prettyUsageName)
+            .withQuantity(quantity)
+            .withItemDetails(itemDetails)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate);
+
+        Assert.assertNotEquals(builder.build(), builder.withCurrency(Currency.JPY).build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginInvoiceItem a = new PluginInvoiceItem.Builder<>()
+            .withId(id)
+            .withInvoiceItemType(invoiceItemType)
+            .withInvoiceId(invoiceId)
+            .withAccountId(accountId)
+            .withChildAccountId(childAccountId)
+            .withStartDate(startDate)
+            .withEndDate(endDate)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withDescription(description)
+            .withSubscriptionId(subscriptionId)
+            .withBundleId(bundleId)
+            .withCatalogEffectiveDate(catalogEffectiveDate)
+            .withProductName(productName)
+            .withPrettyProductName(prettyProductName)
+            .withPlanName(planName)
+            .withPrettyPlanName(prettyPlanName)
+            .withPhaseName(phaseName)
+            .withPrettyPhaseName(prettyPhaseName)
+            .withRate(rate)
+            .withLinkedItemId(linkedItemId)
+            .withUsageName(usageName)
+            .withPrettyUsageName(prettyUsageName)
+            .withQuantity(quantity)
+            .withItemDetails(itemDetails)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        Assert.assertEquals(a.getId(), id);
+        Assert.assertEquals(a.getInvoiceItemType(), invoiceItemType);
+        Assert.assertEquals(a.getInvoiceId(), invoiceId);
+        Assert.assertEquals(a.getAccountId(), accountId);
+        Assert.assertEquals(a.getChildAccountId(), childAccountId);
+        Assert.assertEquals(a.getStartDate(), startDate);
+        Assert.assertEquals(a.getEndDate(), endDate);
+        Assert.assertEquals(a.getAmount(), amount);
+        Assert.assertEquals(a.getCurrency(), currency);
+        Assert.assertEquals(a.getDescription(), description);
+        Assert.assertEquals(a.getSubscriptionId(), subscriptionId);
+        Assert.assertEquals(a.getBundleId(), bundleId);
+        Assert.assertEquals(a.getCatalogEffectiveDate(), catalogEffectiveDate);
+        Assert.assertEquals(a.getProductName(), productName);
+        Assert.assertEquals(a.getPrettyProductName(), prettyProductName);
+        Assert.assertEquals(a.getPlanName(), planName);
+        Assert.assertEquals(a.getPrettyPlanName(), prettyPlanName);
+        Assert.assertEquals(a.getPhaseName(), phaseName);
+        Assert.assertEquals(a.getPrettyPhaseName(), prettyPhaseName);
+        Assert.assertEquals(a.getRate(), rate);
+        Assert.assertEquals(a.getLinkedItemId(), linkedItemId);
+        Assert.assertEquals(a.getUsageName(), usageName);
+        Assert.assertEquals(a.getPrettyUsageName(), prettyUsageName);
+        Assert.assertEquals(a.getQuantity(), quantity);
+        Assert.assertEquals(a.getItemDetails(), itemDetails);
+        Assert.assertEquals(a.getCreatedDate(), createdDate);
+        Assert.assertEquals(a.getUpdatedDate(), updatedDate);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginInvoiceItem a = new PluginInvoiceItem.Builder<>()
+            .withId(id)
+            .withInvoiceItemType(invoiceItemType)
+            .withInvoiceId(invoiceId)
+            .withAccountId(accountId)
+            .withChildAccountId(childAccountId)
+            .withStartDate(startDate)
+            .withEndDate(endDate)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withDescription(description)
+            .withSubscriptionId(subscriptionId)
+            .withBundleId(bundleId)
+            .withCatalogEffectiveDate(catalogEffectiveDate)
+            .withProductName(productName)
+            .withPrettyProductName(prettyProductName)
+            .withPlanName(planName)
+            .withPrettyPlanName(prettyPlanName)
+            .withPhaseName(phaseName)
+            .withPrettyPhaseName(prettyPhaseName)
+            .withRate(rate)
+            .withLinkedItemId(linkedItemId)
+            .withUsageName(usageName)
+            .withPrettyUsageName(prettyUsageName)
+            .withQuantity(quantity)
+            .withItemDetails(itemDetails)
+            .withCreatedDate(createdDate)
+            .withUpdatedDate(updatedDate)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginInvoiceItem b = mapper.readValue(json, PluginInvoiceItem.class);
+
+        Assert.assertTrue(a.equals(b));
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/api/payment/TestPluginGatewayNotification.java
+++ b/src/test/java/org/killbill/billing/plugin/api/payment/TestPluginGatewayNotification.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.payment;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.killbill.billing.payment.api.PluginProperty;
+
+@Test(groups = { "fast" })
+public class TestPluginGatewayNotification {
+
+    private final String entity = "TestEntity";
+    private final Map<String, List<String>> headers =  ImmutableMap.<String, List<String>>of();
+    private final UUID kbPaymentId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private final List<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+    private final int status = 400;
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginGatewayNotification a = new PluginGatewayNotification.Builder<>()
+            .withKbPaymentId(kbPaymentId)
+            .withStatus(status)
+            .withEntity(entity)
+            .withHeaders(headers)
+            .withProperties(properties)
+            .build();
+
+        PluginGatewayNotification b = new PluginGatewayNotification(
+                kbPaymentId,
+                status,
+                entity,
+                headers,
+                properties);
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+        PluginGatewayNotification.Builder builder = new PluginGatewayNotification.Builder<>()
+            .withKbPaymentId(kbPaymentId)
+            .withStatus(status)
+            .withEntity(entity)
+            .withHeaders(headers)
+            .withProperties(properties);
+        Assert.assertNotEquals(builder.build(), builder.withStatus(404).build());
+    }
+
+    @Test
+    void callAllGetters() {
+        PluginGatewayNotification a = new PluginGatewayNotification.Builder<>()
+            .withKbPaymentId(kbPaymentId)
+            .withStatus(status)
+            .withEntity(entity)
+            .withHeaders(headers)
+            .withProperties(properties)
+            .build();
+
+        Assert.assertEquals(a.getKbPaymentId(), kbPaymentId);
+        Assert.assertEquals(a.getStatus(), status);
+        Assert.assertEquals(a.getEntity(), entity);
+        Assert.assertEquals(a.getHeaders(), headers);
+        Assert.assertEquals(a.getProperties(), properties);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginGatewayNotification a = new PluginGatewayNotification.Builder<>()
+            .withKbPaymentId(kbPaymentId)
+            .withStatus(status)
+            .withEntity(entity)
+            .withHeaders(headers)
+            .withProperties(properties)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginGatewayNotification b = mapper.readValue(json, PluginGatewayNotification.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/payment/TestPluginHostedPaymentPageFormDescriptor.java
+++ b/src/test/java/org/killbill/billing/plugin/api/payment/TestPluginHostedPaymentPageFormDescriptor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.payment;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.collect.ImmutableList;
+import org.killbill.billing.payment.api.PluginProperty;
+
+public class TestPluginHostedPaymentPageFormDescriptor {
+
+    private final List<PluginProperty> formFields = ImmutableList.<PluginProperty>of();
+    private final String formMethod = PluginHostedPaymentPageFormDescriptor.POST;
+    private final String formUrl = "https://www.nowhere.com/target";
+    private final UUID kbAccountId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private final List<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginHostedPaymentPageFormDescriptor a = new PluginHostedPaymentPageFormDescriptor.Builder<>()
+            .withKbAccountId(kbAccountId)
+            .withFormMethod(formMethod)
+            .withFormUrl(formUrl)
+            .withFormFields(formFields)
+            .withProperties(properties)
+            .build();
+
+        PluginHostedPaymentPageFormDescriptor b = new PluginHostedPaymentPageFormDescriptor(
+                kbAccountId,
+                formMethod,
+                formUrl,
+                formFields,
+                properties);
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginHostedPaymentPageFormDescriptor.Builder builder = new PluginHostedPaymentPageFormDescriptor.Builder<>()
+            .withKbAccountId(kbAccountId)
+            .withFormMethod(formMethod)
+            .withFormUrl(formUrl)
+            .withFormFields(formFields)
+            .withProperties(properties);
+
+        Assert.assertNotEquals(builder.build(), builder.withFormMethod(PluginHostedPaymentPageFormDescriptor.GET).build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginHostedPaymentPageFormDescriptor a = new PluginHostedPaymentPageFormDescriptor.Builder<>()
+            .withKbAccountId(kbAccountId)
+            .withFormMethod(formMethod)
+            .withFormUrl(formUrl)
+            .withFormFields(formFields)
+            .withProperties(properties)
+            .build();
+
+        Assert.assertEquals(a.getKbAccountId(), kbAccountId);
+        Assert.assertEquals(a.getFormMethod(), formMethod);
+        Assert.assertEquals(a.getFormUrl(), formUrl);
+        Assert.assertEquals(a.getFormFields(), formFields);
+        Assert.assertEquals(a.getProperties(), properties);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginHostedPaymentPageFormDescriptor a = new PluginHostedPaymentPageFormDescriptor.Builder<>()
+            .withKbAccountId(kbAccountId)
+            .withFormMethod(formMethod)
+            .withFormUrl(formUrl)
+            .withFormFields(formFields)
+            .withProperties(properties)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginHostedPaymentPageFormDescriptor b = mapper.readValue(json, PluginHostedPaymentPageFormDescriptor.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}
+

--- a/src/test/java/org/killbill/billing/plugin/api/payment/TestPluginPaymentMethodPlugin.java
+++ b/src/test/java/org/killbill/billing/plugin/api/payment/TestPluginPaymentMethodPlugin.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.payment;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.collect.ImmutableList;
+import org.killbill.billing.payment.api.PluginProperty;
+
+@Test(groups = { "fast" })
+public class TestPluginPaymentMethodPlugin {
+
+    private final String externalPaymentMethodId = "TestExternalPaymentMethodId";
+    private final boolean isDefaultPaymentMethod = true;
+    private final UUID kbPaymentMethodId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private final List<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginPaymentMethodPlugin a = new PluginPaymentMethodPlugin.Builder<>()
+            .withKbPaymentMethodId(kbPaymentMethodId)
+            .withExternalPaymentMethodId(externalPaymentMethodId)
+            .withIsDefaultPaymentMethod(isDefaultPaymentMethod)
+            .withProperties(properties)
+            .build();
+
+        PluginPaymentMethodPlugin b = new PluginPaymentMethodPlugin(
+                kbPaymentMethodId,
+                externalPaymentMethodId,
+                isDefaultPaymentMethod,
+                properties) ;
+
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginPaymentMethodPlugin.Builder builder = new PluginPaymentMethodPlugin.Builder<>()
+            .withKbPaymentMethodId(kbPaymentMethodId)
+            .withExternalPaymentMethodId(externalPaymentMethodId)
+            .withIsDefaultPaymentMethod(isDefaultPaymentMethod)
+            .withProperties(properties);
+
+        Assert.assertNotEquals(builder.build(), builder.withIsDefaultPaymentMethod(false).build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginPaymentMethodPlugin a = new PluginPaymentMethodPlugin.Builder<>()
+            .withKbPaymentMethodId(kbPaymentMethodId)
+            .withExternalPaymentMethodId(externalPaymentMethodId)
+            .withIsDefaultPaymentMethod(isDefaultPaymentMethod)
+            .withProperties(properties)
+            .build();
+
+            Assert.assertEquals(a.getKbPaymentMethodId(), kbPaymentMethodId);
+            Assert.assertEquals(a.getExternalPaymentMethodId(), externalPaymentMethodId);
+            Assert.assertEquals(a.isDefaultPaymentMethod(), isDefaultPaymentMethod);
+            Assert.assertEquals(a.getProperties(), properties);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginPaymentMethodPlugin a = new PluginPaymentMethodPlugin.Builder<>()
+            .withKbPaymentMethodId(kbPaymentMethodId)
+            .withExternalPaymentMethodId(externalPaymentMethodId)
+            .withIsDefaultPaymentMethod(isDefaultPaymentMethod)
+            .withProperties(properties)
+            .build();
+
+        String json =  mapper.writeValueAsString(a);;
+        PluginPaymentMethodPlugin b = mapper.readValue(json, PluginPaymentMethodPlugin.class);
+
+        Assert.assertTrue(a.equals(b));
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/api/payment/TestPluginPaymentTransactionInfoPlugin.java
+++ b/src/test/java/org/killbill/billing/plugin/api/payment/TestPluginPaymentTransactionInfoPlugin.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2022-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.payment;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.collect.ImmutableList;
+import org.joda.time.DateTime;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.api.TransactionType;
+import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
+
+@Test(groups = { "fast" })
+public class TestPluginPaymentTransactionInfoPlugin {
+
+    private final BigDecimal amount = new BigDecimal("100000");
+    private final DateTime createdDate = new DateTime("2011-11-11T11:11"); 
+    private final Currency currency = Currency.USD;
+    private final DateTime effectiveDate = new DateTime("2011-11-11T11:11"); 
+    private final String firstPaymentReferenceId = "TestFirstPaymentReferenceId";
+    private final String gatewayError = "TestGatewayError";
+    private final String gatewayErrorCode = "TestGatewayErrorCode";
+    private final UUID kbPaymentId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private final UUID kbTransactionPaymentId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private final List<PluginProperty> properties = ImmutableList.<PluginProperty>of();
+    private final String secondPaymentReferenceId = "TestSecondPaymentReferenceId";
+    private final PaymentPluginStatus status = PaymentPluginStatus.PENDING;
+    private final TransactionType transactionType  = TransactionType.CHARGEBACK;
+
+    @Test
+    void builderIsEquivalentToConstructor() {
+
+        PluginPaymentTransactionInfoPlugin a = new PluginPaymentTransactionInfoPlugin.Builder<>()
+            .withKbPaymentId(kbPaymentId)
+            .withKbTransactionPaymentId(kbTransactionPaymentId)
+            .withTransactionType(transactionType)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withStatus(status)
+            .withGatewayError(gatewayError)
+            .withGatewayErrorCode(gatewayErrorCode)
+            .withFirstPaymentReferenceId(firstPaymentReferenceId)
+            .withSecondPaymentReferenceId(secondPaymentReferenceId)
+            .withCreatedDate(createdDate)
+            .withEffectiveDate(effectiveDate)
+            .withProperties(properties)
+            .build();
+
+        PluginPaymentTransactionInfoPlugin b = new PluginPaymentTransactionInfoPlugin(
+                kbPaymentId,
+                kbTransactionPaymentId,
+                transactionType,
+                amount,
+                currency,
+                status,
+                gatewayError,
+                gatewayErrorCode,
+                firstPaymentReferenceId,
+                secondPaymentReferenceId,
+                createdDate,
+                effectiveDate,
+                properties) ;
+
+        Assert.assertTrue(a.equals(b));
+    }
+
+    @Test
+    void differentInstances() {
+
+        PluginPaymentTransactionInfoPlugin.Builder builder = new PluginPaymentTransactionInfoPlugin.Builder<>()
+            .withKbPaymentId(kbPaymentId)
+            .withKbTransactionPaymentId(kbTransactionPaymentId)
+            .withTransactionType(transactionType)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withStatus(status)
+            .withGatewayError(gatewayError)
+            .withGatewayErrorCode(gatewayErrorCode)
+            .withFirstPaymentReferenceId(firstPaymentReferenceId)
+            .withSecondPaymentReferenceId(secondPaymentReferenceId)
+            .withCreatedDate(createdDate)
+            .withEffectiveDate(effectiveDate)
+            .withProperties(properties);
+
+        Assert.assertNotEquals(builder.build(), builder.withStatus(PaymentPluginStatus.ERROR).build());
+    }
+
+    @Test
+    void callAllGetters() {
+
+        PluginPaymentTransactionInfoPlugin a = new PluginPaymentTransactionInfoPlugin.Builder<>()
+            .withKbPaymentId(kbPaymentId)
+            .withKbTransactionPaymentId(kbTransactionPaymentId)
+            .withTransactionType(transactionType)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withStatus(status)
+            .withGatewayError(gatewayError)
+            .withGatewayErrorCode(gatewayErrorCode)
+            .withFirstPaymentReferenceId(firstPaymentReferenceId)
+            .withSecondPaymentReferenceId(secondPaymentReferenceId)
+            .withCreatedDate(createdDate)
+            .withEffectiveDate(effectiveDate)
+            .withProperties(properties)
+            .build();
+
+        Assert.assertEquals(a.getKbPaymentId(), kbPaymentId);
+        Assert.assertEquals(a.getKbTransactionPaymentId(), kbTransactionPaymentId);
+        Assert.assertEquals(a.getTransactionType(), transactionType);
+        Assert.assertEquals(a.getAmount(), amount);
+        Assert.assertEquals(a.getCurrency(), currency);
+        Assert.assertEquals(a.getStatus(), status);
+        Assert.assertEquals(a.getGatewayError(), gatewayError);
+        Assert.assertEquals(a.getGatewayErrorCode(), gatewayErrorCode);
+        Assert.assertEquals(a.getFirstPaymentReferenceId(), firstPaymentReferenceId);
+        Assert.assertEquals(a.getSecondPaymentReferenceId(), secondPaymentReferenceId);
+        Assert.assertEquals(a.getCreatedDate(), createdDate);
+        Assert.assertEquals(a.getEffectiveDate(), effectiveDate);
+        Assert.assertEquals(a.getProperties(), properties);
+    }
+
+    @Test 
+    void roundTripJson() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+        mapper.registerModule(new JodaModule());
+        mapper.findAndRegisterModules();
+
+        PluginPaymentTransactionInfoPlugin a = new PluginPaymentTransactionInfoPlugin.Builder<>()
+            .withKbPaymentId(kbPaymentId)
+            .withKbTransactionPaymentId(kbTransactionPaymentId)
+            .withTransactionType(transactionType)
+            .withAmount(amount)
+            .withCurrency(currency)
+            .withStatus(status)
+            .withGatewayError(gatewayError)
+            .withGatewayErrorCode(gatewayErrorCode)
+            .withFirstPaymentReferenceId(firstPaymentReferenceId)
+            .withSecondPaymentReferenceId(secondPaymentReferenceId)
+            .withCreatedDate(createdDate)
+            .withEffectiveDate(effectiveDate)
+            .withProperties(properties)
+            .build();
+
+        String json = mapper.writeValueAsString(a);
+        PluginPaymentTransactionInfoPlugin b = mapper.readValue(json, PluginPaymentTransactionInfoPlugin.class);
+        Assert.assertTrue(a.equals(b));
+    }
+}


### PR DESCRIPTION
The pojos are generated from the top level interfaces in the following
packages of `killbill/killbill-api`.

- org.killbill.billing
- org.killbill.billing.tenant
- org.killbill.billing.tenant.api
- org.killbill.billing.util
- org.killbill.billing.util.customfield
- org.killbill.billing.util.nodes
- org.killbill.billing.util.entity
- org.killbill.billing.util.audit
- org.killbill.billing.util.queue
- org.killbill.billing.util.callcontext
- org.killbill.billing.util.api
- org.killbill.billing.util.tag
- org.killbill.billing.security
- org.killbill.billing.security.api
- org.killbill.billing.payment
- org.killbill.billing.payment.plugin
- org.killbill.billing.payment.plugin.api
- org.killbill.billing.payment.api
- org.killbill.billing.catalog
- org.killbill.billing.catalog.api
- org.killbill.billing.catalog.api.rules
- org.killbill.billing.osgi
- org.killbill.billing.osgi.api
- org.killbill.billing.osgi.api.config
- org.killbill.billing.usage
- org.killbill.billing.usage.api
- org.killbill.billing.account
- org.killbill.billing.account.api
- org.killbill.billing.entitlement
- org.killbill.billing.entitlement.api
- org.killbill.billing.currency
- org.killbill.billing.currency.api
- org.killbill.billing.overdue
- org.killbill.billing.overdue.api
- org.killbill.billing.invoice
- org.killbill.billing.invoice.api
- org.killbill.billing.invoice.api.formatters