### PR TITLE
Use parent killbill api and fix compile error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
     <properties>
         <check.fail-spotbugs>true</check.fail-spotbugs>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
-        <killbill-api.version>0.54.0-a0d09d2-SNAPSHOT</killbill-api.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <properties>
         <check.fail-spotbugs>true</check.fail-spotbugs>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
+        <killbill-api.version>0.54.0-19db89f-SNAPSHOT</killbill-api.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/org/killbill/billing/catalog/api/boilerplate/CatalogUserApiImp.java
+++ b/src/main/java/org/killbill/billing/catalog/api/boilerplate/CatalogUserApiImp.java
@@ -18,10 +18,7 @@
 
 package org.killbill.billing.catalog.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Arrays;
-import java.util.Objects;
 import org.joda.time.DateTime;
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.catalog.api.CatalogUserApi;
@@ -64,6 +61,12 @@ public class CatalogUserApiImp implements CatalogUserApi {
     public void uploadCatalog(final String catalogXML, final CallContext context) {
         throw new UnsupportedOperationException("uploadCatalog(java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
+
+    @Override
+    public void validateCatalog(final String catalogXML, final CallContext context) throws CatalogApiException {
+        throw new UnsupportedOperationException("validateCatalog(java.lang.String, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+
     @Override
     public boolean equals(final Object o) {
         if ( this == o ) {

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BaseEntitlementWithAddOnsSpecifierImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BaseEntitlementWithAddOnsSpecifierImp.java
@@ -20,20 +20,20 @@ package org.killbill.billing.entitlement.api.boilerplate;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
-import org.joda.time.LocalDate;
+
+import org.joda.time.DateTime;
 import org.killbill.billing.entitlement.api.BaseEntitlementWithAddOnsSpecifier;
 import org.killbill.billing.entitlement.api.EntitlementSpecifier;
 
 @JsonDeserialize( builder = BaseEntitlementWithAddOnsSpecifierImp.Builder.class )
 public class BaseEntitlementWithAddOnsSpecifierImp implements BaseEntitlementWithAddOnsSpecifier {
 
-    protected LocalDate billingEffectiveDate;
+    protected DateTime billingEffectiveDate;
     protected String bundleExternalKey;
     protected UUID bundleId;
-    protected LocalDate entitlementEffectiveDate;
+    protected DateTime entitlementEffectiveDate;
     protected Iterable<EntitlementSpecifier> entitlementSpecifier;
     protected boolean isMigrated;
 
@@ -55,7 +55,7 @@ public class BaseEntitlementWithAddOnsSpecifierImp implements BaseEntitlementWit
     }
     protected BaseEntitlementWithAddOnsSpecifierImp() { }
     @Override
-    public LocalDate getBillingEffectiveDate() {
+    public DateTime getBillingEffectiveDate() {
         return this.billingEffectiveDate;
     }
     @Override
@@ -67,7 +67,7 @@ public class BaseEntitlementWithAddOnsSpecifierImp implements BaseEntitlementWit
         return this.bundleId;
     }
     @Override
-    public LocalDate getEntitlementEffectiveDate() {
+    public DateTime getEntitlementEffectiveDate() {
         return this.entitlementEffectiveDate;
     }
     @Override
@@ -146,10 +146,10 @@ public class BaseEntitlementWithAddOnsSpecifierImp implements BaseEntitlementWit
     @SuppressWarnings("unchecked")
     public static class Builder<T extends BaseEntitlementWithAddOnsSpecifierImp.Builder<T>> {
 
-        protected LocalDate billingEffectiveDate;
+        protected DateTime billingEffectiveDate;
         protected String bundleExternalKey;
         protected UUID bundleId;
-        protected LocalDate entitlementEffectiveDate;
+        protected DateTime entitlementEffectiveDate;
         protected Iterable<EntitlementSpecifier> entitlementSpecifier;
         protected boolean isMigrated;
 
@@ -162,7 +162,7 @@ public class BaseEntitlementWithAddOnsSpecifierImp implements BaseEntitlementWit
             this.entitlementSpecifier = that.entitlementSpecifier;
             this.isMigrated = that.isMigrated;
         }
-        public T withBillingEffectiveDate(final LocalDate billingEffectiveDate) {
+        public T withBillingEffectiveDate(final DateTime billingEffectiveDate) {
             this.billingEffectiveDate = billingEffectiveDate;
             return (T) this;
         }
@@ -174,7 +174,7 @@ public class BaseEntitlementWithAddOnsSpecifierImp implements BaseEntitlementWit
             this.bundleId = bundleId;
             return (T) this;
         }
-        public T withEntitlementEffectiveDate(final LocalDate entitlementEffectiveDate) {
+        public T withEntitlementEffectiveDate(final DateTime entitlementEffectiveDate) {
             this.entitlementEffectiveDate = entitlementEffectiveDate;
             return (T) this;
         }

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BlockingStateImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/BlockingStateImp.java
@@ -42,6 +42,7 @@ public class BlockingStateImp implements BlockingState {
     protected String stateName;
     protected BlockingStateType type;
     protected DateTime updatedDate;
+    protected boolean active;
 
     public BlockingStateImp(final BlockingStateImp that) {
         this.blockedId = that.blockedId;
@@ -56,6 +57,7 @@ public class BlockingStateImp implements BlockingState {
         this.stateName = that.stateName;
         this.type = that.type;
         this.updatedDate = that.updatedDate;
+        this.active = that.active;
     }
     protected BlockingStateImp(final BlockingStateImp.Builder<?> builder) {
         this.blockedId = builder.blockedId;
@@ -70,6 +72,7 @@ public class BlockingStateImp implements BlockingState {
         this.stateName = builder.stateName;
         this.type = builder.type;
         this.updatedDate = builder.updatedDate;
+        this.active = builder.active;
     }
     protected BlockingStateImp() { }
     @Override
@@ -124,6 +127,10 @@ public class BlockingStateImp implements BlockingState {
         return this.updatedDate;
     }
     @Override
+    public boolean isActive() {
+        return active;
+    }
+    @Override
     public int compareTo(final BlockingState arg0) {
         throw new UnsupportedOperationException("compareTo(org.killbill.billing.entitlement.api.BlockingState) must be implemented.");
     }
@@ -172,6 +179,9 @@ public class BlockingStateImp implements BlockingState {
         if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
             return false;
         }
+        if( !Objects.equals(this.active, that.active) ) {
+            return false;
+        }
         return true;
     }
     @Override
@@ -189,6 +199,7 @@ public class BlockingStateImp implements BlockingState {
         result = ( 31 * result ) + Objects.hashCode(this.stateName);
         result = ( 31 * result ) + Objects.hashCode(this.type);
         result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.active);
         return result;
     }
     @Override
@@ -233,6 +244,8 @@ public class BlockingStateImp implements BlockingState {
         sb.append("type=").append(this.type);
         sb.append(", ");
         sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("active=").append(this.active);
         sb.append("}");
         return sb.toString();
     }
@@ -252,6 +265,7 @@ public class BlockingStateImp implements BlockingState {
         protected String stateName;
         protected BlockingStateType type;
         protected DateTime updatedDate;
+        protected boolean active;
 
         public Builder() { }
         public Builder(final Builder that) {
@@ -267,6 +281,7 @@ public class BlockingStateImp implements BlockingState {
             this.stateName = that.stateName;
             this.type = that.type;
             this.updatedDate = that.updatedDate;
+            this.active = that.active;
         }
         public T withBlockedId(final UUID blockedId) {
             this.blockedId = blockedId;
@@ -316,6 +331,10 @@ public class BlockingStateImp implements BlockingState {
             this.updatedDate = updatedDate;
             return (T) this;
         }
+        public T withActive(final boolean active) {
+            this.active = active;
+            return (T) this;
+        }
         public T source(final BlockingState that) {
             this.blockedId = that.getBlockedId();
             this.createdDate = that.getCreatedDate();
@@ -329,6 +348,7 @@ public class BlockingStateImp implements BlockingState {
             this.stateName = that.getStateName();
             this.type = that.getType();
             this.updatedDate = that.getUpdatedDate();
+            this.active = that.isActive();
             return (T) this;
         }
         protected Builder validate() {

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementApiImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementApiImp.java
@@ -18,11 +18,9 @@
 
 package org.killbill.billing.entitlement.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.UUID;
 import org.joda.time.LocalDate;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
@@ -30,7 +28,6 @@ import org.killbill.billing.entitlement.api.BaseEntitlementWithAddOnsSpecifier;
 import org.killbill.billing.entitlement.api.Entitlement;
 import org.killbill.billing.entitlement.api.EntitlementAOStatusDryRun;
 import org.killbill.billing.entitlement.api.EntitlementApi;
-import org.killbill.billing.entitlement.api.EntitlementApiException;
 import org.killbill.billing.entitlement.api.EntitlementSpecifier;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.util.callcontext.CallContext;
@@ -54,8 +51,8 @@ public class EntitlementApiImp implements EntitlementApi {
         throw new UnsupportedOperationException("getAllEntitlementsForBundle(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
-    public Entitlement getEntitlementForId(final UUID id, final TenantContext context) {
-        throw new UnsupportedOperationException("getEntitlementForId(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    public Entitlement getEntitlementForId(final UUID id, final boolean includeDeletedEvents, final TenantContext context) {
+        throw new UnsupportedOperationException("getEntitlementForId(java.util.UUID, java.lang.Boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
     public void resume(final UUID bundleId, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
@@ -70,12 +67,12 @@ public class EntitlementApiImp implements EntitlementApi {
         throw new UnsupportedOperationException("pause(java.util.UUID, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
     @Override
-    public UUID transferEntitlements(final UUID sourceAccountId, final UUID destAccountId, final String bundleExternalKey, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
-        throw new UnsupportedOperationException("transferEntitlements(java.util.UUID, java.util.UUID, java.lang.String, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    public UUID transferEntitlements(final UUID sourceAccountId, final UUID destAccountId, final String bundleExternalKey, final LocalDate effectiveDate, final Map<UUID, String> subExtKeys, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("transferEntitlements(java.util.UUID, java.util.UUID, java.lang.String, org.joda.time.LocalDate, java.util.Map<java.util.UUID, java.lang.String>, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
     @Override
-    public UUID transferEntitlementsOverrideBillingPolicy(final UUID sourceAccountId, final UUID destAccountId, final String bundleExternalKey, final LocalDate effectiveDate, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
-        throw new UnsupportedOperationException("transferEntitlementsOverrideBillingPolicy(java.util.UUID, java.util.UUID, java.lang.String, org.joda.time.LocalDate, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    public UUID transferEntitlementsOverrideBillingPolicy(final UUID sourceAccountId, final UUID destAccountId, final String bundleExternalKey, final LocalDate effectiveDate, final Map<UUID, String> subExtKeys, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final CallContext context) {
+        throw new UnsupportedOperationException("transferEntitlementsOverrideBillingPolicy(java.util.UUID, java.util.UUID, java.lang.String, org.joda.time.LocalDate, java.util.Map<java.util.UUID, java.lang.String>, org.killbill.billing.catalog.api.BillingActionPolicy, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
     @Override
     public List<Entitlement> getAllEntitlementsForAccountIdAndBundleExternalKey(final UUID accountId, final String bundleExternalKey, final TenantContext context) {

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementImp.java
@@ -58,6 +58,7 @@ public class EntitlementImp implements Entitlement {
     protected Entitlement.EntitlementSourceType sourceType;
     protected Entitlement.EntitlementState state;
     protected DateTime updatedDate;
+    protected Integer quantity;
 
     public EntitlementImp(final EntitlementImp that) {
         this.accountId = that.accountId;
@@ -78,6 +79,7 @@ public class EntitlementImp implements Entitlement {
         this.sourceType = that.sourceType;
         this.state = that.state;
         this.updatedDate = that.updatedDate;
+        this.quantity = that.quantity;
     }
     protected EntitlementImp(final EntitlementImp.Builder<?> builder) {
         this.accountId = builder.accountId;
@@ -98,6 +100,7 @@ public class EntitlementImp implements Entitlement {
         this.sourceType = builder.sourceType;
         this.state = builder.state;
         this.updatedDate = builder.updatedDate;
+        this.quantity = builder.quantity;
     }
     protected EntitlementImp() { }
     @Override
@@ -173,6 +176,10 @@ public class EntitlementImp implements Entitlement {
         return this.updatedDate;
     }
     @Override
+    public Integer getQuantity() {
+        return quantity;
+    }
+    @Override
     public void uncancelEntitlement(final Iterable<PluginProperty> properties, final CallContext context) {
         throw new UnsupportedOperationException("uncancelEntitlement(java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
@@ -216,6 +223,12 @@ public class EntitlementImp implements Entitlement {
     public void updateBCD(final int bcd, final LocalDate effectiveFromDate, final CallContext context) {
         throw new UnsupportedOperationException("updateBCD(int, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
+
+    @Override
+    public void updateQuantity(final int quantity, final LocalDate effectiveFromDate, final CallContext context) throws EntitlementApiException {
+        throw new UnsupportedOperationException("updateQuantity(int, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+
     @Override
     public Entitlement changePlanWithDate(final EntitlementSpecifier spec, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
         throw new UnsupportedOperationException("changePlanWithDate(org.killbill.billing.entitlement.api.EntitlementSpecifier, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
@@ -283,6 +296,9 @@ public class EntitlementImp implements Entitlement {
         if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
             return false;
         }
+        if( !Objects.equals(this.quantity, that.quantity) ) {
+            return false;
+        }
         return true;
     }
     @Override
@@ -306,6 +322,7 @@ public class EntitlementImp implements Entitlement {
         result = ( 31 * result ) + Objects.hashCode(this.sourceType);
         result = ( 31 * result ) + Objects.hashCode(this.state);
         result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.quantity);
         return result;
     }
     @Override
@@ -357,6 +374,8 @@ public class EntitlementImp implements Entitlement {
         sb.append("state=").append(this.state);
         sb.append(", ");
         sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("quantity=").append(this.quantity);
         sb.append("}");
         return sb.toString();
     }
@@ -382,6 +401,7 @@ public class EntitlementImp implements Entitlement {
         protected Entitlement.EntitlementSourceType sourceType;
         protected Entitlement.EntitlementState state;
         protected DateTime updatedDate;
+        protected Integer quantity;
 
         public Builder() { }
         public Builder(final Builder that) {
@@ -403,6 +423,7 @@ public class EntitlementImp implements Entitlement {
             this.sourceType = that.sourceType;
             this.state = that.state;
             this.updatedDate = that.updatedDate;
+            this.quantity = that.quantity;
         }
         public T withAccountId(final UUID accountId) {
             this.accountId = accountId;
@@ -476,6 +497,10 @@ public class EntitlementImp implements Entitlement {
             this.updatedDate = updatedDate;
             return (T) this;
         }
+        public T withQuantity(final Integer quantity) {
+            this.quantity = quantity;
+            return (T) this;
+        }
         public T source(final Entitlement that) {
             this.accountId = that.getAccountId();
             this.baseEntitlementId = that.getBaseEntitlementId();
@@ -495,6 +520,7 @@ public class EntitlementImp implements Entitlement {
             this.sourceType = that.getSourceType();
             this.state = that.getState();
             this.updatedDate = that.getUpdatedDate();
+            this.quantity = that.getQuantity();
             return (T) this;
         }
         protected Builder validate() {

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementSpecifierImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/EntitlementSpecifierImp.java
@@ -18,9 +18,7 @@
 
 package org.killbill.billing.entitlement.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
@@ -34,18 +32,21 @@ public class EntitlementSpecifierImp implements EntitlementSpecifier {
     protected String externalKey;
     protected List<PlanPhasePriceOverride> overrides;
     protected PlanPhaseSpecifier planPhaseSpecifier;
+    protected Integer quantity;
 
     public EntitlementSpecifierImp(final EntitlementSpecifierImp that) {
         this.billCycleDay = that.billCycleDay;
         this.externalKey = that.externalKey;
         this.overrides = that.overrides;
         this.planPhaseSpecifier = that.planPhaseSpecifier;
+        this.quantity = that.quantity;
     }
     protected EntitlementSpecifierImp(final EntitlementSpecifierImp.Builder<?> builder) {
         this.billCycleDay = builder.billCycleDay;
         this.externalKey = builder.externalKey;
         this.overrides = builder.overrides;
         this.planPhaseSpecifier = builder.planPhaseSpecifier;
+        this.quantity = builder.quantity;
     }
     protected EntitlementSpecifierImp() { }
     @Override
@@ -63,6 +64,10 @@ public class EntitlementSpecifierImp implements EntitlementSpecifier {
     @Override
     public PlanPhaseSpecifier getPlanPhaseSpecifier() {
         return this.planPhaseSpecifier;
+    }
+    @Override
+    public Integer getQuantity() {
+        return quantity;
     }
     @Override
     public boolean equals(final Object o) {
@@ -85,6 +90,9 @@ public class EntitlementSpecifierImp implements EntitlementSpecifier {
         if( !Objects.equals(this.planPhaseSpecifier, that.planPhaseSpecifier) ) {
             return false;
         }
+        if( !Objects.equals(this.quantity, that.quantity) ) {
+            return false;
+        }
         return true;
     }
     @Override
@@ -94,6 +102,7 @@ public class EntitlementSpecifierImp implements EntitlementSpecifier {
         result = ( 31 * result ) + Objects.hashCode(this.externalKey);
         result = ( 31 * result ) + Objects.hashCode(this.overrides);
         result = ( 31 * result ) + Objects.hashCode(this.planPhaseSpecifier);
+        result = ( 31 * result ) + Objects.hashCode(this.quantity);
         return result;
     }
     @Override
@@ -112,6 +121,8 @@ public class EntitlementSpecifierImp implements EntitlementSpecifier {
         sb.append("overrides=").append(this.overrides);
         sb.append(", ");
         sb.append("planPhaseSpecifier=").append(this.planPhaseSpecifier);
+        sb.append(", ");
+        sb.append("quantity=").append(this.quantity);
         sb.append("}");
         return sb.toString();
     }
@@ -123,6 +134,7 @@ public class EntitlementSpecifierImp implements EntitlementSpecifier {
         protected String externalKey;
         protected List<PlanPhasePriceOverride> overrides;
         protected PlanPhaseSpecifier planPhaseSpecifier;
+        protected Integer quantity;
 
         public Builder() { }
         public Builder(final Builder that) {
@@ -130,6 +142,7 @@ public class EntitlementSpecifierImp implements EntitlementSpecifier {
             this.externalKey = that.externalKey;
             this.overrides = that.overrides;
             this.planPhaseSpecifier = that.planPhaseSpecifier;
+            this.quantity = that.quantity;
         }
         public T withBillCycleDay(final Integer billCycleDay) {
             this.billCycleDay = billCycleDay;
@@ -147,11 +160,16 @@ public class EntitlementSpecifierImp implements EntitlementSpecifier {
             this.planPhaseSpecifier = planPhaseSpecifier;
             return (T) this;
         }
+        public T withQuantity(final Integer quantity) {
+            this.quantity = quantity;
+            return (T) this;
+        }
         public T source(final EntitlementSpecifier that) {
             this.billCycleDay = that.getBillCycleDay();
             this.externalKey = that.getExternalKey();
             this.overrides = that.getOverrides();
             this.planPhaseSpecifier = that.getPlanPhaseSpecifier();
+            this.quantity = that.getQuantity();
             return (T) this;
         }
         protected Builder validate() {

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionApiImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionApiImp.java
@@ -18,18 +18,14 @@
 
 package org.killbill.billing.entitlement.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.OrderingType;
 import org.killbill.billing.entitlement.api.BlockingState;
 import org.killbill.billing.entitlement.api.BlockingStateType;
-import org.killbill.billing.entitlement.api.EntitlementApiException;
 import org.killbill.billing.entitlement.api.Subscription;
 import org.killbill.billing.entitlement.api.SubscriptionApi;
 import org.killbill.billing.entitlement.api.SubscriptionApiException;
@@ -45,9 +41,9 @@ import org.killbill.billing.util.entity.Pagination;
 public class SubscriptionApiImp implements SubscriptionApi {
 
 
-    public SubscriptionApiImp(final SubscriptionApiImp that) {
+    public SubscriptionApiImp(final SubscriptionApiImp ignored) {
     }
-    protected SubscriptionApiImp(final SubscriptionApiImp.Builder<?> builder) {
+    protected SubscriptionApiImp(final SubscriptionApiImp.Builder<?> ignored) {
     }
     protected SubscriptionApiImp() { }
     @Override
@@ -59,8 +55,8 @@ public class SubscriptionApiImp implements SubscriptionApi {
         throw new UnsupportedOperationException("searchSubscriptionBundles(java.lang.String, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
-    public Subscription getSubscriptionForEntitlementId(final UUID entitlementId, final TenantContext context) {
-        throw new UnsupportedOperationException("getSubscriptionForEntitlementId(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    public Subscription getSubscriptionForEntitlementId(final UUID entitlementId, final boolean includeDeletedEvents, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionForEntitlementId(java.util.UUID, java.lang.Boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
     public SubscriptionBundle getActiveSubscriptionBundleForExternalKey(final String externalKey, final TenantContext context) {
@@ -75,8 +71,8 @@ public class SubscriptionApiImp implements SubscriptionApi {
         throw new UnsupportedOperationException("getSubscriptionBundlesForExternalKey(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
-    public Subscription getSubscriptionForExternalKey(final String externalKey, final TenantContext context) {
-        throw new UnsupportedOperationException("getSubscriptionForExternalKey(java.lang.String, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    public Subscription getSubscriptionForExternalKey(final String externalKey, final boolean includeDeletedEvents, final TenantContext context) {
+        throw new UnsupportedOperationException("getSubscriptionForExternalKey(java.lang.String, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
     public void addBlockingState(final BlockingState blockingState, final DateTime effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
@@ -93,6 +89,10 @@ public class SubscriptionApiImp implements SubscriptionApi {
     @Override
     public List<SubscriptionBundle> getSubscriptionBundlesForAccountId(final UUID accountId, final TenantContext context) {
         throw new UnsupportedOperationException("getSubscriptionBundlesForAccountId(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+    @Override
+    public Pagination<SubscriptionBundle> getSubscriptionBundlesForAccountId(final UUID accountId, final Long offset, final Long limit, final TenantContext context) throws SubscriptionApiException {
+        throw new UnsupportedOperationException("getSubscriptionBundlesForAccountId(java.util.UUID, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
     public List<AuditLogWithHistory> getBlockingStateAuditLogsWithHistoryForId(final UUID blockingId, final AuditLevel auditLevel, final TenantContext context) {

--- a/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionImp.java
+++ b/src/main/java/org/killbill/billing/entitlement/api/boilerplate/SubscriptionImp.java
@@ -18,9 +18,7 @@
 
 package org.killbill.billing.entitlement.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -65,6 +63,7 @@ public class SubscriptionImp implements Subscription {
     protected Entitlement.EntitlementState state;
     protected List<SubscriptionEvent> subscriptionEvents;
     protected DateTime updatedDate;
+    protected Integer quantity;
 
     public SubscriptionImp(final SubscriptionImp that) {
         this.accountId = that.accountId;
@@ -89,6 +88,7 @@ public class SubscriptionImp implements Subscription {
         this.state = that.state;
         this.subscriptionEvents = that.subscriptionEvents;
         this.updatedDate = that.updatedDate;
+        this.quantity = that.quantity;
     }
     protected SubscriptionImp(final SubscriptionImp.Builder<?> builder) {
         this.accountId = builder.accountId;
@@ -113,6 +113,7 @@ public class SubscriptionImp implements Subscription {
         this.state = builder.state;
         this.subscriptionEvents = builder.subscriptionEvents;
         this.updatedDate = builder.updatedDate;
+        this.quantity = builder.quantity;
     }
     protected SubscriptionImp() { }
     @Override
@@ -204,6 +205,10 @@ public class SubscriptionImp implements Subscription {
         return this.updatedDate;
     }
     @Override
+    public Integer getQuantity() {
+        return quantity;
+    }
+    @Override
     public void uncancelEntitlement(final Iterable<PluginProperty> properties, final CallContext context) {
         throw new UnsupportedOperationException("uncancelEntitlement(java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
@@ -246,6 +251,10 @@ public class SubscriptionImp implements Subscription {
     @Override
     public void updateBCD(final int bcd, final LocalDate effectiveFromDate, final CallContext context) {
         throw new UnsupportedOperationException("updateBCD(int, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
+    }
+    @Override
+    public void updateQuantity(final int quantity, final LocalDate effectiveFromDate, final CallContext context) throws EntitlementApiException {
+        throw new UnsupportedOperationException("updateQuantity(int, org.joda.time.LocalDate, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
     @Override
     public Entitlement changePlanWithDate(final EntitlementSpecifier spec, final LocalDate effectiveDate, final Iterable<PluginProperty> properties, final CallContext context) {
@@ -326,6 +335,9 @@ public class SubscriptionImp implements Subscription {
         if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
             return false;
         }
+        if( !Objects.equals(this.quantity, that.quantity) ) {
+            return false;
+        }
         return true;
     }
     @Override
@@ -353,6 +365,7 @@ public class SubscriptionImp implements Subscription {
         result = ( 31 * result ) + Objects.hashCode(this.state);
         result = ( 31 * result ) + Objects.hashCode(this.subscriptionEvents);
         result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.quantity);
         return result;
     }
     @Override
@@ -412,6 +425,8 @@ public class SubscriptionImp implements Subscription {
         sb.append("subscriptionEvents=").append(this.subscriptionEvents);
         sb.append(", ");
         sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("quantity=").append(this.quantity);
         sb.append("}");
         return sb.toString();
     }
@@ -441,6 +456,7 @@ public class SubscriptionImp implements Subscription {
         protected Entitlement.EntitlementState state;
         protected List<SubscriptionEvent> subscriptionEvents;
         protected DateTime updatedDate;
+        protected Integer quantity;
 
         public Builder() { }
         public Builder(final Builder that) {
@@ -466,6 +482,7 @@ public class SubscriptionImp implements Subscription {
             this.state = that.state;
             this.subscriptionEvents = that.subscriptionEvents;
             this.updatedDate = that.updatedDate;
+            this.quantity = that.quantity;
         }
         public T withAccountId(final UUID accountId) {
             this.accountId = accountId;
@@ -555,6 +572,10 @@ public class SubscriptionImp implements Subscription {
             this.updatedDate = updatedDate;
             return (T) this;
         }
+        public T withQuantity(final Integer qty) {
+            this.quantity = qty;
+            return (T) this;
+        }
         public T source(final Subscription that) {
             this.accountId = that.getAccountId();
             this.baseEntitlementId = that.getBaseEntitlementId();
@@ -578,6 +599,7 @@ public class SubscriptionImp implements Subscription {
             this.state = that.getState();
             this.subscriptionEvents = that.getSubscriptionEvents();
             this.updatedDate = that.getUpdatedDate();
+            this.quantity = that.getQuantity();
             return (T) this;
         }
         protected Builder validate() {

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoicePaymentImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoicePaymentImp.java
@@ -18,15 +18,14 @@
 
 package org.killbill.billing.invoice.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
 import org.joda.time.DateTime;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.InvoicePayment;
+import org.killbill.billing.invoice.api.InvoicePaymentStatus;
 import org.killbill.billing.invoice.api.InvoicePaymentType;
 
 @JsonDeserialize( builder = InvoicePaymentImp.Builder.class )
@@ -37,7 +36,6 @@ public class InvoicePaymentImp implements InvoicePayment {
     protected Currency currency;
     protected UUID id;
     protected UUID invoiceId;
-    protected Boolean isSuccess;
     protected UUID linkedInvoicePaymentId;
     protected String paymentCookieId;
     protected DateTime paymentDate;
@@ -45,6 +43,7 @@ public class InvoicePaymentImp implements InvoicePayment {
     protected Currency processedCurrency;
     protected InvoicePaymentType type;
     protected DateTime updatedDate;
+    protected InvoicePaymentStatus invoicePaymentStatus;
 
     public InvoicePaymentImp(final InvoicePaymentImp that) {
         this.amount = that.amount;
@@ -52,7 +51,6 @@ public class InvoicePaymentImp implements InvoicePayment {
         this.currency = that.currency;
         this.id = that.id;
         this.invoiceId = that.invoiceId;
-        this.isSuccess = that.isSuccess;
         this.linkedInvoicePaymentId = that.linkedInvoicePaymentId;
         this.paymentCookieId = that.paymentCookieId;
         this.paymentDate = that.paymentDate;
@@ -60,6 +58,7 @@ public class InvoicePaymentImp implements InvoicePayment {
         this.processedCurrency = that.processedCurrency;
         this.type = that.type;
         this.updatedDate = that.updatedDate;
+        this.invoicePaymentStatus = that.invoicePaymentStatus;
     }
     protected InvoicePaymentImp(final InvoicePaymentImp.Builder<?> builder) {
         this.amount = builder.amount;
@@ -67,7 +66,6 @@ public class InvoicePaymentImp implements InvoicePayment {
         this.currency = builder.currency;
         this.id = builder.id;
         this.invoiceId = builder.invoiceId;
-        this.isSuccess = builder.isSuccess;
         this.linkedInvoicePaymentId = builder.linkedInvoicePaymentId;
         this.paymentCookieId = builder.paymentCookieId;
         this.paymentDate = builder.paymentDate;
@@ -75,6 +73,7 @@ public class InvoicePaymentImp implements InvoicePayment {
         this.processedCurrency = builder.processedCurrency;
         this.type = builder.type;
         this.updatedDate = builder.updatedDate;
+        this.invoicePaymentStatus = builder.invoicePaymentStatus;
     }
     protected InvoicePaymentImp() { }
     @Override
@@ -98,11 +97,6 @@ public class InvoicePaymentImp implements InvoicePayment {
         return this.invoiceId;
     }
     @Override
-    @JsonGetter("isSuccess")
-    public Boolean isSuccess() {
-        return this.isSuccess;
-    }
-    @Override
     public UUID getLinkedInvoicePaymentId() {
         return this.linkedInvoicePaymentId;
     }
@@ -122,6 +116,12 @@ public class InvoicePaymentImp implements InvoicePayment {
     public Currency getProcessedCurrency() {
         return this.processedCurrency;
     }
+
+    @Override
+    public InvoicePaymentStatus getStatus() {
+        return invoicePaymentStatus;
+    }
+
     @Override
     public InvoicePaymentType getType() {
         return this.type;
@@ -154,9 +154,6 @@ public class InvoicePaymentImp implements InvoicePayment {
         if( !Objects.equals(this.invoiceId, that.invoiceId) ) {
             return false;
         }
-        if( !Objects.equals(this.isSuccess, that.isSuccess) ) {
-            return false;
-        }
         if( !Objects.equals(this.linkedInvoicePaymentId, that.linkedInvoicePaymentId) ) {
             return false;
         }
@@ -178,6 +175,9 @@ public class InvoicePaymentImp implements InvoicePayment {
         if( ( this.updatedDate != null ) ? ( 0 != this.updatedDate.compareTo(that.updatedDate) ) : ( that.updatedDate != null ) ) {
             return false;
         }
+        if ( !Objects.equals(this.invoicePaymentStatus, that.invoicePaymentStatus) ) {
+            return false;
+        }
         return true;
     }
     @Override
@@ -188,7 +188,6 @@ public class InvoicePaymentImp implements InvoicePayment {
         result = ( 31 * result ) + Objects.hashCode(this.currency);
         result = ( 31 * result ) + Objects.hashCode(this.id);
         result = ( 31 * result ) + Objects.hashCode(this.invoiceId);
-        result = ( 31 * result ) + Objects.hashCode(this.isSuccess);
         result = ( 31 * result ) + Objects.hashCode(this.linkedInvoicePaymentId);
         result = ( 31 * result ) + Objects.hashCode(this.paymentCookieId);
         result = ( 31 * result ) + Objects.hashCode(this.paymentDate);
@@ -196,6 +195,7 @@ public class InvoicePaymentImp implements InvoicePayment {
         result = ( 31 * result ) + Objects.hashCode(this.processedCurrency);
         result = ( 31 * result ) + Objects.hashCode(this.type);
         result = ( 31 * result ) + Objects.hashCode(this.updatedDate);
+        result = ( 31 * result ) + Objects.hashCode(this.invoicePaymentStatus);
         return result;
     }
     @Override
@@ -212,7 +212,6 @@ public class InvoicePaymentImp implements InvoicePayment {
         sb.append(", ");
         sb.append("invoiceId=").append(this.invoiceId);
         sb.append(", ");
-        sb.append("isSuccess=").append(this.isSuccess);
         sb.append(", ");
         sb.append("linkedInvoicePaymentId=").append(this.linkedInvoicePaymentId);
         sb.append(", ");
@@ -232,6 +231,8 @@ public class InvoicePaymentImp implements InvoicePayment {
         sb.append("type=").append(this.type);
         sb.append(", ");
         sb.append("updatedDate=").append(this.updatedDate);
+        sb.append(", ");
+        sb.append("invoicePaymentStatus=").append(this.invoicePaymentStatus);
         sb.append("}");
         return sb.toString();
     }
@@ -244,7 +245,6 @@ public class InvoicePaymentImp implements InvoicePayment {
         protected Currency currency;
         protected UUID id;
         protected UUID invoiceId;
-        protected Boolean isSuccess;
         protected UUID linkedInvoicePaymentId;
         protected String paymentCookieId;
         protected DateTime paymentDate;
@@ -252,15 +252,15 @@ public class InvoicePaymentImp implements InvoicePayment {
         protected Currency processedCurrency;
         protected InvoicePaymentType type;
         protected DateTime updatedDate;
+        public InvoicePaymentStatus invoicePaymentStatus;
 
         public Builder() { }
-        public Builder(final Builder that) {
+        public Builder(final Builder<?> that) {
             this.amount = that.amount;
             this.createdDate = that.createdDate;
             this.currency = that.currency;
             this.id = that.id;
             this.invoiceId = that.invoiceId;
-            this.isSuccess = that.isSuccess;
             this.linkedInvoicePaymentId = that.linkedInvoicePaymentId;
             this.paymentCookieId = that.paymentCookieId;
             this.paymentDate = that.paymentDate;
@@ -268,6 +268,7 @@ public class InvoicePaymentImp implements InvoicePayment {
             this.processedCurrency = that.processedCurrency;
             this.type = that.type;
             this.updatedDate = that.updatedDate;
+            this.invoicePaymentStatus = that.invoicePaymentStatus;
         }
         public T withAmount(final BigDecimal amount) {
             this.amount = amount;
@@ -287,10 +288,6 @@ public class InvoicePaymentImp implements InvoicePayment {
         }
         public T withInvoiceId(final UUID invoiceId) {
             this.invoiceId = invoiceId;
-            return (T) this;
-        }
-        public T withIsSuccess(final Boolean isSuccess) {
-            this.isSuccess = isSuccess;
             return (T) this;
         }
         public T withLinkedInvoicePaymentId(final UUID linkedInvoicePaymentId) {
@@ -321,13 +318,16 @@ public class InvoicePaymentImp implements InvoicePayment {
             this.updatedDate = updatedDate;
             return (T) this;
         }
+        public T withInvoicePaymentStatus(final InvoicePaymentStatus status) {
+            this.invoicePaymentStatus = status;
+            return (T) this;
+        }
         public T source(final InvoicePayment that) {
             this.amount = that.getAmount();
             this.createdDate = that.getCreatedDate();
             this.currency = that.getCurrency();
             this.id = that.getId();
             this.invoiceId = that.getInvoiceId();
-            this.isSuccess = that.isSuccess();
             this.linkedInvoicePaymentId = that.getLinkedInvoicePaymentId();
             this.paymentCookieId = that.getPaymentCookieId();
             this.paymentDate = that.getPaymentDate();
@@ -335,6 +335,7 @@ public class InvoicePaymentImp implements InvoicePayment {
             this.processedCurrency = that.getProcessedCurrency();
             this.type = that.getType();
             this.updatedDate = that.getUpdatedDate();
+            this.invoicePaymentStatus = that.getStatus();
             return (T) this;
         }
         protected Builder validate() {

--- a/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceUserApiImp.java
+++ b/src/main/java/org/killbill/billing/invoice/api/boilerplate/InvoiceUserApiImp.java
@@ -18,26 +18,19 @@
 
 package org.killbill.billing.invoice.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import org.joda.time.LocalDate;
-import org.killbill.billing.account.api.AccountApiException;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.invoice.api.DryRunArguments;
 import org.killbill.billing.invoice.api.Invoice;
-import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceUserApi;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.util.api.AuditLevel;
-import org.killbill.billing.util.api.TagApiException;
 import org.killbill.billing.util.audit.AuditLogWithHistory;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
@@ -73,9 +66,15 @@ public class InvoiceUserApiImp implements InvoiceUserApi {
         throw new UnsupportedOperationException("getInvoiceAsHTML(java.util.UUID, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
-    public List<Invoice> getInvoicesByAccount(final UUID accountId, final boolean includesMigrated, final boolean includeVoidedInvoices, final TenantContext context) {
-        throw new UnsupportedOperationException("getInvoicesByAccount(java.util.UUID, boolean, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    public List<Invoice> getInvoicesByAccount(final UUID accountId, final boolean includesMigrated, final boolean includeVoidedInvoices, final boolean includeInvoiceComponents, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicesByAccount(java.util.UUID, boolean, boolean, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
+
+    @Override
+    public Pagination<Invoice> getInvoicesByAccount(final UUID accountId, final Long offset, final Long limit, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicesByAccount(java.util.UUID, java.lang.Long, java.lang.Long, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    }
+
     @Override
     public UUID createMigrationInvoice(final UUID accountId, final LocalDate invoiceDate, final Iterable<InvoiceItem> items, final CallContext context) {
         throw new UnsupportedOperationException("createMigrationInvoice(java.util.UUID, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.invoice.api.InvoiceItem>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
@@ -157,8 +156,8 @@ public class InvoiceUserApiImp implements InvoiceUserApi {
         throw new UnsupportedOperationException("triggerDryRunInvoiceGeneration(java.util.UUID, org.joda.time.LocalDate, org.killbill.billing.invoice.api.DryRunArguments, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
     @Override
-    public List<Invoice> getInvoicesByAccount(final UUID accountId, final LocalDate fromDate, final LocalDate upToDate, final boolean includeVoidedInvoices, final TenantContext context) {
-        throw new UnsupportedOperationException("getInvoicesByAccount(java.util.UUID, org.joda.time.LocalDate, org.joda.time.LocalDate, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    public List<Invoice> getInvoicesByAccount(final UUID accountId, final LocalDate fromDate, final LocalDate upToDate, final boolean includeVoidedInvoices, final boolean includeInvoiceComponents, final TenantContext context) {
+        throw new UnsupportedOperationException("getInvoicesByAccount(java.util.UUID, org.joda.time.LocalDate, org.joda.time.LocalDate, boolean, boolean, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
     public List<AuditLogWithHistory> getInvoiceAuditLogsWithHistoryForId(final UUID invoiceId, final AuditLevel auditLevel, final TenantContext context) {

--- a/src/main/java/org/killbill/billing/plugin/api/PluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/api/PluginApi.java
@@ -309,7 +309,7 @@ public abstract class PluginApi {
 
     protected Collection<Invoice> getInvoicesByAccountId(final UUID accountId, final TenantContext context) throws OSGIServiceNotAvailable {
         final InvoiceUserApi invoiceUserApi = getInvoiceUserApi();
-        return invoiceUserApi.getInvoicesByAccount(accountId, false, false, context);
+        return invoiceUserApi.getInvoicesByAccount(accountId, false, false, false, context);
     }
 
     protected BigDecimal getAccountBalance(final UUID accountId, final TenantContext context) throws OSGIServiceNotAvailable {

--- a/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoicePluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoicePluginApi.java
@@ -18,10 +18,7 @@
 
 package org.killbill.billing.plugin.api.invoice;
 
-import java.util.List;
-
 import org.killbill.billing.invoice.api.Invoice;
-import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.plugin.api.AdditionalItemsResult;
 import org.killbill.billing.invoice.plugin.api.InvoiceContext;
 import org.killbill.billing.invoice.plugin.api.InvoiceGroupingResult;
@@ -35,8 +32,6 @@ import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.plugin.api.PluginApi;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.clock.Clock;
-
-import com.google.common.collect.ImmutableList;
 
 public class PluginInvoicePluginApi extends PluginApi implements InvoicePluginApi {
 

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/RawUsageRecordImp.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/RawUsageRecordImp.java
@@ -18,20 +18,19 @@
 
 package org.killbill.billing.usage.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
-import org.joda.time.LocalDate;
+
+import org.joda.time.DateTime;
 import org.killbill.billing.usage.api.RawUsageRecord;
 
 @JsonDeserialize( builder = RawUsageRecordImp.Builder.class )
 public class RawUsageRecordImp implements RawUsageRecord {
 
     protected BigDecimal amount;
-    protected LocalDate date;
+    protected DateTime date;
     protected UUID subscriptionId;
     protected String trackingId;
     protected String unitType;
@@ -56,7 +55,7 @@ public class RawUsageRecordImp implements RawUsageRecord {
         return this.amount;
     }
     @Override
-    public LocalDate getDate() {
+    public DateTime getDate() {
         return this.date;
     }
     @Override
@@ -138,7 +137,7 @@ public class RawUsageRecordImp implements RawUsageRecord {
     public static class Builder<T extends RawUsageRecordImp.Builder<T>> {
 
         protected BigDecimal amount;
-        protected LocalDate date;
+        protected DateTime date;
         protected UUID subscriptionId;
         protected String trackingId;
         protected String unitType;
@@ -155,7 +154,7 @@ public class RawUsageRecordImp implements RawUsageRecord {
             this.amount = amount;
             return (T) this;
         }
-        public T withDate(final LocalDate date) {
+        public T withDate(final DateTime date) {
             this.date = date;
             return (T) this;
         }

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/RolledUpUnitImp.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/RolledUpUnitImp.java
@@ -18,10 +18,8 @@
 
 package org.killbill.billing.usage.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Objects;
 import org.killbill.billing.usage.api.RolledUpUnit;
 

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/RolledUpUsageImp.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/RolledUpUsageImp.java
@@ -18,22 +18,21 @@
 
 package org.killbill.billing.usage.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import org.joda.time.LocalDate;
+
+import org.joda.time.DateTime;
 import org.killbill.billing.usage.api.RolledUpUnit;
 import org.killbill.billing.usage.api.RolledUpUsage;
 
 @JsonDeserialize( builder = RolledUpUsageImp.Builder.class )
 public class RolledUpUsageImp implements RolledUpUsage {
 
-    protected LocalDate end;
+    protected DateTime end;
     protected List<RolledUpUnit> rolledUpUnits;
-    protected LocalDate start;
+    protected DateTime start;
     protected UUID subscriptionId;
 
     public RolledUpUsageImp(final RolledUpUsageImp that) {
@@ -50,7 +49,7 @@ public class RolledUpUsageImp implements RolledUpUsage {
     }
     protected RolledUpUsageImp() { }
     @Override
-    public LocalDate getEnd() {
+    public DateTime getEnd() {
         return this.end;
     }
     @Override
@@ -58,7 +57,7 @@ public class RolledUpUsageImp implements RolledUpUsage {
         return this.rolledUpUnits;
     }
     @Override
-    public LocalDate getStart() {
+    public DateTime getStart() {
         return this.start;
     }
     @Override
@@ -115,9 +114,9 @@ public class RolledUpUsageImp implements RolledUpUsage {
     @SuppressWarnings("unchecked")
     public static class Builder<T extends RolledUpUsageImp.Builder<T>> {
 
-        protected LocalDate end;
+        protected DateTime end;
         protected List<RolledUpUnit> rolledUpUnits;
-        protected LocalDate start;
+        protected DateTime start;
         protected UUID subscriptionId;
 
         public Builder() { }
@@ -127,7 +126,7 @@ public class RolledUpUsageImp implements RolledUpUsage {
             this.start = that.start;
             this.subscriptionId = that.subscriptionId;
         }
-        public T withEnd(final LocalDate end) {
+        public T withEnd(final DateTime end) {
             this.end = end;
             return (T) this;
         }
@@ -135,7 +134,7 @@ public class RolledUpUsageImp implements RolledUpUsage {
             this.rolledUpUnits = rolledUpUnits;
             return (T) this;
         }
-        public T withStart(final LocalDate start) {
+        public T withStart(final DateTime start) {
             this.start = start;
             return (T) this;
         }

--- a/src/main/java/org/killbill/billing/usage/api/boilerplate/UsageUserApiImp.java
+++ b/src/main/java/org/killbill/billing/usage/api/boilerplate/UsageUserApiImp.java
@@ -18,17 +18,14 @@
 
 package org.killbill.billing.usage.api.boilerplate;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
-import org.joda.time.LocalDate;
+
+import org.joda.time.DateTime;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.usage.api.RolledUpUsage;
 import org.killbill.billing.usage.api.SubscriptionUsageRecord;
-import org.killbill.billing.usage.api.UsageApiException;
 import org.killbill.billing.usage.api.UsageUserApi;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
@@ -47,12 +44,12 @@ public class UsageUserApiImp implements UsageUserApi {
         throw new UnsupportedOperationException("recordRolledUpUsage(org.killbill.billing.usage.api.SubscriptionUsageRecord, org.killbill.billing.util.callcontext.CallContext) must be implemented.");
     }
     @Override
-    public List<RolledUpUsage> getAllUsageForSubscription(final UUID subscriptionId, final List<LocalDate> transitionDates, final Iterable<PluginProperty> properties, final TenantContext context) {
-        throw new UnsupportedOperationException("getAllUsageForSubscription(java.util.UUID, java.util.List<org.joda.time.LocalDate>, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    public List<RolledUpUsage> getAllUsageForSubscription(final UUID subscriptionId, final List<DateTime> transitionDates, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getAllUsageForSubscription(java.util.UUID, java.util.List<org.joda.time.DateTime>, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
-    public RolledUpUsage getUsageForSubscription(final UUID subscriptionId, final String unitType, final LocalDate startDate, final LocalDate endDate, final Iterable<PluginProperty> properties, final TenantContext context) {
-        throw new UnsupportedOperationException("getUsageForSubscription(java.util.UUID, java.lang.String, org.joda.time.LocalDate, org.joda.time.LocalDate, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
+    public RolledUpUsage getUsageForSubscription(final UUID subscriptionId, final String unitType, final DateTime startDate, final DateTime endDate, final Iterable<PluginProperty> properties, final TenantContext context) {
+        throw new UnsupportedOperationException("getUsageForSubscription(java.util.UUID, java.lang.String, org.joda.time.DateTime, org.joda.time.DateTime, java.lang.Iterable<org.killbill.billing.payment.api.PluginProperty>, org.killbill.billing.util.callcontext.TenantContext) must be implemented.");
     }
     @Override
     public boolean equals(final Object o) {


### PR DESCRIPTION
All recents [dependabot's PRs](https://github.com/killbill/killbill-oss-parent/pulls) in `killbill-oss-parent` failed. [One of them](https://github.com/killbill/killbill-oss-parent/actions/runs/3521174844/jobs/5902769316) caused by compile error in `killbill-plugin-framework-java`, and that's probably because `killbill-plugin-framework-java` use old `killbill-api` version.

This PR attempt to fix the compile error problem. This is seems easy fix, but I see that @sbrossie and @reshmabidikar have extensive work on `killbill-api` recently, so I ask review from both of you just in case I missing something, or something need to be done differently.