### PR TITLE
Update to latest api and plugin api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
     <properties>
         <check.fail-spotbugs>true</check.fail-spotbugs>
         <check.spotbugs-exclude-filter-file>spotbugs-exclude.xml</check.spotbugs-exclude-filter-file>
-        <killbill-api.version>0.54.0-19db89f-SNAPSHOT</killbill-api.version>
+        <killbill-api.version>0.54.0-663b841-SNAPSHOT</killbill-api.version>
+        <killbill-plugin-api.version>0.27.0-df83159-SNAPSHOT</killbill-plugin-api.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoiceGroupingResult.java
+++ b/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoiceGroupingResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020-2022 Equinix, Inc
+ * Copyright 2014-2022 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.api.invoice;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.killbill.billing.invoice.plugin.api.InvoiceGroup;
+import org.killbill.billing.invoice.plugin.api.InvoiceGroupingResult;
+import org.killbill.billing.payment.api.PluginProperty;
+
+public class PluginInvoiceGroupingResult extends PluginInvoiceResult implements InvoiceGroupingResult {
+
+    private final List<InvoiceGroup> invoiceGroups;
+
+    public PluginInvoiceGroupingResult() {
+        this(Collections.emptyList(), null);
+    }
+
+    public PluginInvoiceGroupingResult(final List<InvoiceGroup> invoiceGroups, final Iterable<PluginProperty> adjustedPluginProperties) {
+        super(adjustedPluginProperties);
+        this.invoiceGroups = List.copyOf(invoiceGroups);
+    }
+
+    @Override
+    public List<InvoiceGroup> getInvoiceGroups() {
+        return List.copyOf(invoiceGroups);
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoicePluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/api/invoice/PluginInvoicePluginApi.java
@@ -30,7 +30,6 @@ import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.plugin.api.PluginApi;
-import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.clock.Clock;
 
 public class PluginInvoicePluginApi extends PluginApi implements InvoicePluginApi {
@@ -45,13 +44,13 @@ public class PluginInvoicePluginApi extends PluginApi implements InvoicePluginAp
     }
 
     @Override
-    public AdditionalItemsResult getAdditionalInvoiceItems(final Invoice invoice, final boolean dryRun, final Iterable<PluginProperty> properties, final CallContext context) {
+    public AdditionalItemsResult getAdditionalInvoiceItems(final Invoice invoice, final boolean dryRun, final Iterable<PluginProperty> properties, final InvoiceContext context) {
         return new PluginAdditionalItemsResult();
     }
 
     @Override
-    public InvoiceGroupingResult getInvoiceGrouping(final Invoice invoice, final boolean dryRun, final Iterable<PluginProperty> properties, final CallContext context) {
-        return null;
+    public InvoiceGroupingResult getInvoiceGrouping(final Invoice invoice, final boolean dryRun, final Iterable<PluginProperty> properties, final InvoiceContext context) {
+        return new PluginInvoiceGroupingResult();
     }
 
     @Override


### PR DESCRIPTION
Another attempt to fix various `killbill-oss-parent` failed build. Seems like I need to update [killbill-plugin-api](https://github.com/killbill/killbill-oss-parent/actions/runs/3599598077/jobs/6069948898#step:12:6587) as well. Commit messages quite self-explanatory about what's changes.