### PR TITLE
Base 83 make httpclientbuilder protected

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/util/http/HttpClient.java
+++ b/src/main/java/org/killbill/billing/plugin/util/http/HttpClient.java
@@ -92,7 +92,7 @@ public class HttpClient implements Closeable {
         this.url = url;
         this.username = username;
         this.password = password;
-        this.httpClient = buildHttpClient(strictSSL, DEFAULT_HTTP_CONNECT_TIMEOUT_SEC * 1000, proxyHost, proxyPort);
+        this.httpClient = httpClientBuilder(strictSSL, DEFAULT_HTTP_CONNECT_TIMEOUT_SEC * 1000, proxyHost, proxyPort).build();
         this.mapper = createObjectMapper();
     }
 
@@ -106,7 +106,7 @@ public class HttpClient implements Closeable {
         this.url = url;
         this.username = username;
         this.password = password;
-        this.httpClient = buildHttpClient(strictSSL, connectTimeoutMs, proxyHost, proxyPort);
+        this.httpClient = httpClientBuilder(strictSSL, connectTimeoutMs, proxyHost, proxyPort).build();
         this.mapper = createObjectMapper();
     }
 
@@ -121,15 +121,15 @@ public class HttpClient implements Closeable {
         this.url = url;
         this.username = username;
         this.password = password;
-        this.httpClient = buildHttpClient(strictSSL, connectTimeoutMs, proxyHost, proxyPort);
+        this.httpClient = httpClientBuilder(strictSSL, connectTimeoutMs, proxyHost, proxyPort).build();
         this.mapper = createObjectMapper();
         this.httpTimeoutSec = requestTimeoutMs;
     }
 
-    private java.net.http.HttpClient buildHttpClient(final boolean strictSSL,
-                                                     final int connectTimeoutMs,
-                                                     @Nullable final String proxyHost,
-                                                     @Nullable final Integer proxyPort) throws GeneralSecurityException {
+    protected java.net.http.HttpClient.Builder httpClientBuilder(final boolean strictSSL,
+                                                                 final int connectTimeoutMs,
+                                                                 @Nullable final String proxyHost,
+                                                                 @Nullable final Integer proxyPort) throws GeneralSecurityException {
         final java.net.http.HttpClient.Builder builder = java.net.http.HttpClient.newBuilder()
                                                                                  .sslContext(SslUtils.getInstance().getSSLContext(!strictSSL))
                                                                                  .connectTimeout(Duration.of(connectTimeoutMs, ChronoUnit.MILLIS));
@@ -138,7 +138,7 @@ public class HttpClient implements Closeable {
             builder.proxy(ProxySelector.of(new InetSocketAddress(proxyHost, proxyPort)));
         }
 
-        return builder.build();
+        return builder;
     }
 
     @Override


### PR DESCRIPTION
See https://github.com/killbill/killbill-plugin-framework-java/issues/83

- As this is mainly affected killbill-platform's kpm-plugin `KPMClient`, I tested directly against it. It passed.
- However, I [create test](https://github.com/xsalefter/killbill-plugin-framework-java/blob/f87c9fe82ec99f0f9831b9867bd4affa3e2f8569/src/test/java/org/killbill/billing/plugin/util/http/TestHttpClient.java#L170) for this, but it never passed, with error `Caused by: java.io.UncheckedIOException: java.io.IOException: Invalid redirection`. I think the way I'm [setting the HttpServer](https://github.com/xsalefter/killbill-plugin-framework-java/blob/f87c9fe82ec99f0f9831b9867bd4affa3e2f8569/src/test/java/org/killbill/billing/plugin/util/http/TestHttpClient.java#L79) is already correct, but maybe I miss something? 